### PR TITLE
UILD-483: Fix: Comparison modal stays opened when all the resources removed from comparison

### DIFF
--- a/src/components/Comparison/Comparison.tsx
+++ b/src/components/Comparison/Comparison.tsx
@@ -37,7 +37,15 @@ export const Comparison = () => {
       });
     }
 
-    setPreviewContent(prev => prev.filter(({ id: prevId }) => prevId !== id));
+    setPreviewContent(prev => {
+      const updatedPreviewContent = prev.filter(({ id: prevId }) => prevId !== id);
+
+      if (!updatedPreviewContent.length) {
+        resetFullDisplayComponentType();
+      }
+
+      return updatedPreviewContent;
+    });
     setSelectedInstances(prev => prev.filter(prevId => prevId !== id));
   };
 

--- a/src/components/SearchControls/SearchControls.tsx
+++ b/src/components/SearchControls/SearchControls.tsx
@@ -46,8 +46,10 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
     setNavigationState,
     resetFacets: resetControls,
     setFacetsBySegments,
+    resetSelectedInstances,
   } = useSearchState();
-  const { isSearchPaneCollapsed, setIsSearchPaneCollapsed, setIsAdvancedSearchOpen } = useUIState();
+  const { isSearchPaneCollapsed, setIsSearchPaneCollapsed, setIsAdvancedSearchOpen, resetFullDisplayComponentType } =
+    useUIState();
   const { resetPreviewContent } = useInputsState();
   const [searchParams, setSearchParams] = useSearchParams();
   const [announcementMessage, setAnnouncementMessage] = useState('');
@@ -72,6 +74,8 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
   const onResetButtonClick = () => {
     clearValuesAndResetControls();
     resetPreviewContent();
+    resetFullDisplayComponentType();
+    resetSelectedInstances();
     hasSearchParams && setSearchParams({});
     hasSearchParams && setNavigationState({});
     setAnnouncementMessage(formatMessage({ id: 'ld.aria.filters.reset.announce' }));
@@ -92,7 +96,7 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
             <FormattedMessage id={isVisibleFilters ? 'ld.searchAndFilter' : 'ld.search'} />
           </h2>
           <Button
-            className='close-ctl'
+            className="close-ctl"
             onClick={() => setIsSearchPaneCollapsed(true)}
             ariaLabel={formatMessage({ id: 'ld.aria.searchPane.close' })}
           >

--- a/src/test/__tests__/components/Comparison.test.tsx
+++ b/src/test/__tests__/components/Comparison.test.tsx
@@ -65,17 +65,24 @@ describe('Comparison', () => {
 
   test('removes an entry', () => {
     const { getByTestId } = renderWithState([
-      ...baseMockState,
+      {
+        store: useInputsStore,
+        state: { previewContent: [{ id: 'mockId', title: 'mockTitle' }] },
+      },
       {
         store: useSearchStore,
         state: { setSelectedInstances },
+      },
+      {
+        store: useUIStore,
+        state: { resetFullDisplayComponentType },
       },
     ]);
 
     fireEvent.click(getByTestId('remove-comparison-entry-mockId'));
 
-    expect(setPreviewContent).toHaveBeenCalled();
     expect(setSelectedInstances).toHaveBeenCalled();
+    expect(resetFullDisplayComponentType).toHaveBeenCalled();
   });
 
   test('updates current page when removing last item on last page', () => {


### PR DESCRIPTION
[https://folio-org.atlassian.net/browse/UILD-483](https://folio-org.atlassian.net/browse/UILD-483)