### PR TITLE
UILD-497: Update UI to use 'validAssignment' property from authority-assignment-check API response

### DIFF
--- a/src/common/hooks/useComplexLookup.ts
+++ b/src/common/hooks/useComplexLookup.ts
@@ -141,9 +141,9 @@ export const useComplexLookup = ({
       }
     }
 
-    const isValid = await validateMarcRecord(marcData);
+    const { validAssignment } = await validateMarcRecord(marcData);
 
-    if (isValid) {
+    if (validAssignment) {
       assignMarcRecord({ id, title, srsId, linkedFieldValue });
       clearFailedEntryIds();
       reset();

--- a/src/test/__tests__/common/hooks/useComplexLookup.test.ts
+++ b/src/test/__tests__/common/hooks/useComplexLookup.test.ts
@@ -162,7 +162,7 @@ describe('useComplexLookup', () => {
       (getLinkedField as jest.Mock).mockReturnValue(mockLinkedField);
       (updateLinkedFieldValue as jest.Mock).mockReturnValue({ uuid: 'newLinkedFieldId' });
       (getUpdatedSelectedEntries as jest.Mock).mockReturnValue(['newId']);
-      mockMakeRequest.mockResolvedValue(true);
+      mockMakeRequest.mockResolvedValue({ validAssignment: true });
 
       result = getRenderedHook()?.result;
 
@@ -184,7 +184,7 @@ describe('useComplexLookup', () => {
     });
 
     test('updates state correctly and does not call "setSelectedEntries"', async () => {
-      mockMakeRequest.mockResolvedValue(true);
+      mockMakeRequest.mockResolvedValue({ validAssignment: true });
 
       result = getRenderedHook({
         ...mockEntry,


### PR DESCRIPTION
Earlier, POST /linked-data/authoritty-assignment-check API was returning a boolean (true/false) value.
As part of MODLD-646, the response structure of the API is changed as follows

{
   "validAssignment": false,
   "invalidAssignmentReason": "NOT_VALID_FOR_TARGET"
}
Purpose of this change is to update UI accordingly.

Should be merged along with https://github.com/folio-org/mod-linked-data/pull/104