### PR TITLE
UILD-501: Fix - 'Continue without saving' is disabled on the modal shown when switching to work from duplicated instance with unsaved changes

### DIFF
--- a/src/components/ModalSwitchToNewRecord/ModalSwitchToNewRecord.tsx
+++ b/src/components/ModalSwitchToNewRecord/ModalSwitchToNewRecord.tsx
@@ -1,8 +1,6 @@
 import { FC, memo } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Modal } from '@components/Modal';
-import { useParams, useSearchParams } from 'react-router-dom';
-import { QueryParams } from '@common/constants/routes.constants';
 import './ModalSwitchToNewRecord.scss';
 
 interface Props {
@@ -14,8 +12,6 @@ interface Props {
 
 export const ModalSwitchToNewRecord: FC<Props> = memo(({ isOpen, onCancel, onSubmit, onClose }) => {
   const { formatMessage } = useIntl();
-  const { resourceId } = useParams();
-  const [queryParams] = useSearchParams();
 
   return (
     <Modal
@@ -23,7 +19,6 @@ export const ModalSwitchToNewRecord: FC<Props> = memo(({ isOpen, onCancel, onSub
       title={formatMessage({ id: 'ld.unsavedChanges' })}
       submitButtonLabel={formatMessage({ id: 'ld.saveAndContinue' })}
       cancelButtonLabel={formatMessage({ id: 'ld.continueWithoutSaving' })}
-      cancelButtonDisabled={!resourceId && !queryParams.get(QueryParams.Ref)}
       onClose={onClose}
       onSubmit={onSubmit}
       onCancel={onCancel}


### PR DESCRIPTION
[https://folio-org.atlassian.net/browse/UILD-501](https://folio-org.atlassian.net/browse/UILD-501)