### PR TITLE
UILD-508: Error messages to display on LDE

### DIFF
--- a/src/common/constants/api.constants.ts
+++ b/src/common/constants/api.constants.ts
@@ -18,6 +18,14 @@ export const DEFAULT_PAGES_METADATA = {
 
 export enum ApiErrorCodes {
   AlreadyExists = 'already_exists_error',
+  RequiredPrimaryMainTitle = 'required_primary_main_title',
+  LccnDoesNotMatchPattern = 'lccn_does_not_match_pattern',
+  LccnNotUnique = 'lccn_not_unique',
+  FailedDependency = 'failed_dependency',
+  NotFound = 'not_found',
+  Mapping = 'mapping',
+  GenericBadRequest = 'generic_bad_request',
+  Server = 'server',
 }
 
 export enum ExternalResourceIdType {

--- a/src/common/helpers/api.helper.ts
+++ b/src/common/helpers/api.helper.ts
@@ -31,3 +31,12 @@ const fetchSimpleLookup = async (url: string): Promise<any> => {
 
 export const checkHasErrorOfCodeType = (err: ApiError, codeType: ApiErrorCodes) =>
   err?.errors.find(e => e.code === codeType);
+
+export const getFriendlyErrorMessage = (err: unknown) => {
+  const apiError = err as Partial<{ errors: { code: string }[] }>;
+
+  if (!apiError.errors?.length) return 'ld.cantSaveRd';
+  const errorCode = apiError.errors[0].code as keyof typeof ApiErrorCodes;
+
+  return `ld.${ApiErrorCodes[errorCode] ?? errorCode}`;
+}

--- a/src/common/hooks/useRecordControls.ts
+++ b/src/common/hooks/useRecordControls.ts
@@ -18,7 +18,7 @@ import { BLOCKS_BFLITE } from '@common/constants/bibframeMapping.constants';
 import { RecordStatus, ResourceType } from '@common/constants/record.constants';
 import { generateEditResourceUrl } from '@common/helpers/navigation.helper';
 import { ApiErrorCodes, ExternalResourceIdType } from '@common/constants/api.constants';
-import { checkHasErrorOfCodeType } from '@common/helpers/api.helper';
+import { checkHasErrorOfCodeType, getFriendlyErrorMessage } from '@common/helpers/api.helper';
 import { useLoadingState, useStatusState, useProfileState, useInputsState, useUIState } from '@src/store';
 import { useRecordGeneration } from './useRecordGeneration';
 import { useBackToSearchUri } from './useBackToSearchUri';
@@ -160,7 +160,8 @@ export const useRecordControls = () => {
     } catch (error) {
       console.error('Cannot save the resource description', error);
 
-      addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, 'ld.cantSaveRd'));
+      addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, getFriendlyErrorMessage(error)));
+
     } finally {
       setIsLoading(false);
     }

--- a/translations/ui-linked-data/en.json
+++ b/translations/ui-linked-data/en.json
@@ -226,5 +226,14 @@
   "ld.errorAssigningAuthority.no_lccn": "Only Library of Congress authorities can be assigned for now. This is temporary until additional source types are supported.",
   "ld.errorAssigningAuthority.unsupported_marc": "The selected authority isn't mapped to Linked Data, and can't be assigned yet. This is temporary, since MARC mapping is in progress.",
   "ld.modal.uncontrolledAuthoritiesWarning.title": "Uncontrolled authorities warning",
-  "ld.modal.uncontrolledAuthoritiesWarning.body": "This description includes one or more uncontrolled authorities.\n Do you want to save changes?"
+  "ld.modal.uncontrolledAuthoritiesWarning.body": "This description includes one or more uncontrolled authorities.\n Do you want to save changes?",
+
+  "ld.required_primary_main_title": "Please add the main title in order to save.",
+  "ld.lccn_does_not_match_pattern": "LCCN Pattern validation enabled: Please provide an LCCN that complies with standard structure.",
+  "ld.lccn_not_unique": "LCCN uniqueness enabled: The LCCN you provided already exists. Please provide a different LCCN.",
+  "ld.failed_dependency": "Unable to verify if LCCN is duplicated.",
+  "ld.not_found": "The resource ID has been changed by another user while you had this resource open. Please refresh your browser’s window.",
+  "ld.mapping": "There’s been a mapping issue. Please report this to your support team, with screenshots and a detailed account of what happened.",
+  "ld.generic_bad_request": "There’s been a UI issue. Please report this to your support team, with screenshots and a detailed account of what happened.",
+  "ld.server": "There’s been a server issue. Please report this to your support team, with screenshots and a detailed account of what happened."
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-508

We added error handling for `linked-data/resource` endpoint based on error codes to provide more user-friendly error toasts.