### PR TITLE
UILD-475: Comparison Mode Refinement - Numbered icons

### DIFF
--- a/src/components/Comparison/Comparison.scss
+++ b/src/components/Comparison/Comparison.scss
@@ -32,6 +32,23 @@
     }
   }
 
+  h3{
+    display: flex;
+    align-items: center;
+  }
+
+  .comparison-index {
+    width: 1.125rem;
+    height: 1.125rem;
+    text-align: center;
+    background-color: #9fc7ea;
+    border-radius: 0.125rem;
+    line-height: 1.1rem;
+    font-size: 0.875rem;
+    display: inline-block;
+    margin-right: 0.625rem;
+  }
+
   &-contents {
     display: flex;
     flex-grow: 1;

--- a/src/components/Comparison/Comparison.tsx
+++ b/src/components/Comparison/Comparison.tsx
@@ -19,7 +19,7 @@ const COMPARED_ELEMENTS_COUNT = 2;
 export const Comparison = () => {
   const { formatMessage } = useIntl();
   const { previewContent, setPreviewContent, resetPreviewContent } = useInputsState();
-  const { setSelectedInstances, resetSelectedInstances } = useSearchState();
+  const { setSelectedInstances, resetSelectedInstances, selectedInstances } = useSearchState();
   const { resetFullDisplayComponentType } = useUIState();
   const { navigateToEditPage } = useNavigateToEditPage();
   const [currentPage, setCurrentPage] = useState(0);
@@ -53,6 +53,7 @@ export const Comparison = () => {
 
   const handleNavigateToOwnEditPage = (id: string) => navigateToEditPage(generateEditResourceUrl(id));
   const totalPages = (previewContent.length > 1 ? previewContent.length : 2) - 1;
+  const comparisonIndex = previewContent.findIndex(({ id }) => id);
 
   return (
     <section className="comparison">
@@ -91,8 +92,9 @@ export const Comparison = () => {
       </header>
       <div className="comparison-contents">
         {previewContent
+          .sort((a, b) => selectedInstances.indexOf(a.id) - selectedInstances.indexOf(b.id))
           .slice(currentPage, currentPage + 2)
-          .map(({ initKey, base, userValues, id, title, referenceIds }) => (
+          .map(({ initKey, base, userValues, id, title, referenceIds }, index) => (
             <section key={id} className="entry">
               <div className="entry-header">
                 <div className="entry-header-controls">
@@ -112,7 +114,10 @@ export const Comparison = () => {
                     handleNavigateToEditPage={() => handleNavigateToOwnEditPage(id)}
                   />
                 </div>
-                <h3>{title}</h3>
+                <h3>
+                  <span className="comparison-index">{comparisonIndex + currentPage + index + 1}</span>
+                  {title}
+                </h3>
               </div>
               <Preview
                 altInitKey={initKey}

--- a/src/components/SearchResultEntry/SearchResultEntry.tsx
+++ b/src/components/SearchResultEntry/SearchResultEntry.tsx
@@ -97,7 +97,7 @@ export const SearchResultEntry: FC<SearchResultEntry> = ({ instances, ...restOfW
 
   const applyActionItems = (rows: Row[]): Row[] =>
     rows.map(row => {
-      const comparisonIndex = previewContent.findIndex(({ id }) => id === row.__meta.id);
+      const comparisonIndex = selectedInstances.findIndex(id => id === row.__meta.id);
 
       return {
         ...row,


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-475

We added numbered icons inside the panes for comparison mode. Also, in the scope of that ticket were fixed bugs with reversed order of comparison indexes. https://folio-org.atlassian.net/browse/UILD-473


https://github.com/user-attachments/assets/47a5c36e-48d4-4198-81d1-92bd20d7cfcf

