### PR TITLE
UILD-449: Fix - Read-only Instance screen: 'Cancel' and X do not return user back to Inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Change history for ui-linked-data
 
 ## 1.0.2 (IN PROGRESS)
-* Several modals shown at once/Wrong app background colour when Advanced search modal is opened. Fixes [UILD-506](https://folio-org.atlassian.net/browse/UILD-506). 
+* Several modals shown at once/Wrong app background colour when Advanced search modal is opened. Fixes [UILD-506]. 
 * Comparison Mode Refinement - Numbered icons. Refs [UILD-475].
+* Read-only Instance screen: 'Cancel' and X do not return user back to Inventory. Fixes [UILD-449].
 
+[UILD-506]:https://folio-org.atlassian.net/browse/UILD-506
 [UILD-475]:https://folio-org.atlassian.net/browse/UILD-475
+[UILD-449]:https://folio-org.atlassian.net/browse/UILD-449
 
 ## 1.0.1 (2025-03-12)
 * Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.2 (IN PROGRESS)
 * Several modals shown at once/Wrong app background colour when Advanced search modal is opened. Fixes [UILD-506]. 
 * Comparison Mode Refinement - Numbered icons. Refs [UILD-475].
-* Read-only Instance screen: 'Cancel' and X do not return user back to Inventory. Fixes [UILD-449].
+* Read-only Instance screen: Correctly redirect after clicking 'Cancel' and 'X' buttons. Fixes [UILD-449].
 
 [UILD-506]:https://folio-org.atlassian.net/browse/UILD-506
 [UILD-475]:https://folio-org.atlassian.net/browse/UILD-475

--- a/src/common/hooks/useContainerEvents.ts
+++ b/src/common/hooks/useContainerEvents.ts
@@ -47,7 +47,7 @@ export const useContainerEvents = ({ onTriggerModal, watchEditedState = false }:
   const dispatchProceedNavigationEvent = () => dispatchEventWrapper(PROCEED_NAVIGATION);
 
   const dispatchNavigateToOriginEventWithFallback = (fallbackUri?: string) => {
-    if (hasNavigationOrigin && !location.state?.origin) {
+    if (hasNavigationOrigin && !location.state?.isNavigatedFromLDE) {
       dispatchEventWrapper(NAVIGATE_TO_ORIGIN);
     } else {
       navigate(fallbackUri ?? ROUTES.SEARCH.uri);

--- a/src/common/hooks/useContainerEvents.ts
+++ b/src/common/hooks/useContainerEvents.ts
@@ -47,9 +47,11 @@ export const useContainerEvents = ({ onTriggerModal, watchEditedState = false }:
   const dispatchProceedNavigationEvent = () => dispatchEventWrapper(PROCEED_NAVIGATION);
 
   const dispatchNavigateToOriginEventWithFallback = (fallbackUri?: string) => {
-    hasNavigationOrigin && location.state.isNavigatedFromExternal
-      ? dispatchEventWrapper(NAVIGATE_TO_ORIGIN)
-      : navigate(fallbackUri ?? ROUTES.SEARCH.uri);
+    if (hasNavigationOrigin && !location.state?.origin) {
+      dispatchEventWrapper(NAVIGATE_TO_ORIGIN);
+    } else {
+      navigate(fallbackUri ?? ROUTES.SEARCH.uri);
+    }
   };
 
   const dispatchDropNavigateToOriginEvent = () => dispatchEventWrapper(DROP_NAVIGATE_TO_ORIGIN);

--- a/src/common/hooks/useNavigateToEditPage.ts
+++ b/src/common/hooks/useNavigateToEditPage.ts
@@ -1,9 +1,10 @@
 import { ROUTES, QueryParams } from '@common/constants/routes.constants';
 import { useSearchState } from '@src/store';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export const useNavigateToEditPage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { navigationState } = useSearchState();
 
   const navigateAsDuplicate = (duplicateId: string) => {
@@ -11,7 +12,8 @@ export const useNavigateToEditPage = () => {
   };
 
   return {
-    navigateToEditPage: (uri: string, { ...options } = {}) => navigate(uri, { state: navigationState, ...options }),
+    navigateToEditPage: (uri: string, { ...options } = {}) =>
+      navigate(uri, { state: { ...navigationState, origin: location.pathname }, ...options }),
     navigateAsDuplicate,
   };
 };

--- a/src/common/hooks/useNavigateToEditPage.ts
+++ b/src/common/hooks/useNavigateToEditPage.ts
@@ -1,10 +1,9 @@
 import { ROUTES, QueryParams } from '@common/constants/routes.constants';
 import { useSearchState } from '@src/store';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 export const useNavigateToEditPage = () => {
   const navigate = useNavigate();
-  const location = useLocation();
   const { navigationState } = useSearchState();
 
   const navigateAsDuplicate = (duplicateId: string) => {
@@ -13,7 +12,7 @@ export const useNavigateToEditPage = () => {
 
   return {
     navigateToEditPage: (uri: string, { ...options } = {}) =>
-      navigate(uri, { state: { ...navigationState, origin: location.pathname }, ...options }),
+      navigate(uri, { state: { ...navigationState, isNavigatedFromLDE: true }, ...options }),
     navigateAsDuplicate,
   };
 };

--- a/src/common/hooks/useRecordControls.ts
+++ b/src/common/hooks/useRecordControls.ts
@@ -161,7 +161,6 @@ export const useRecordControls = () => {
       console.error('Cannot save the resource description', error);
 
       addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, getFriendlyErrorMessage(error)));
-
     } finally {
       setIsLoading(false);
     }
@@ -279,7 +278,7 @@ export const useRecordControls = () => {
 
       const { id } = await getGraphIdByExternalId({ recordId });
 
-      id && navigate(generateEditResourceUrl(id), { state: { isNavigatedFromExternal: true }, replace: true });
+      id && navigate(generateEditResourceUrl(id), { replace: true });
     } catch (err: unknown) {
       if (checkHasErrorOfCodeType(err as ApiError, ApiErrorCodes.AlreadyExists)) {
         setIsDuplicateImportedResourceModalOpen(true);

--- a/src/components/ModalDuplicateImportedResource/ModalDuplicateImportedResource.tsx
+++ b/src/components/ModalDuplicateImportedResource/ModalDuplicateImportedResource.tsx
@@ -20,7 +20,7 @@ export const ModalDuplicateImportedResource = memo(() => {
       alignTitleCenter
       cancelButtonLabel={formatMessage({ id: 'ld.backToInventory' })}
       onClose={() => setIsDuplicateImportedResourceModalOpen(false)}
-      onCancel={dispatchNavigateToOriginEventWithFallback}
+      onCancel={() => dispatchNavigateToOriginEventWithFallback()}
     >
       <div className="duplicate-imported-resource-contents" data-testid="modal-duplicate-imported-resource">
         <FormattedMessage id="ld.rdPropertiesMatchContinue" />

--- a/src/components/PreviewExternalResourceControls/PreviewExternalResourceControls.tsx
+++ b/src/components/PreviewExternalResourceControls/PreviewExternalResourceControls.tsx
@@ -15,7 +15,7 @@ export const PreviewExternalResourceControls = () => {
       <Button
         data-testid="close-external-preview-button"
         type={ButtonType.Primary}
-        onClick={dispatchNavigateToOriginEventWithFallback}
+        onClick={() => dispatchNavigateToOriginEventWithFallback()}
       >
         <FormattedMessage id="ld.cancel" />
       </Button>

--- a/src/components/PreviewExternalResourcePane/PreviewExternalResourcePane.tsx
+++ b/src/components/PreviewExternalResourcePane/PreviewExternalResourcePane.tsx
@@ -16,7 +16,7 @@ export const PreviewExternalResourcePane = () => {
         <Button
           data-testid="nav-close-button"
           type={ButtonType.Icon}
-          onClick={dispatchNavigateToOriginEventWithFallback}
+          onClick={() => dispatchNavigateToOriginEventWithFallback()}
           className="nav-close"
           ariaLabel={formatMessage({ id: 'ld.aria.externalResourcePreview.close' })}
         >

--- a/src/test/__tests__/common/hooks/useContainerEvents.test.ts
+++ b/src/test/__tests__/common/hooks/useContainerEvents.test.ts
@@ -1,13 +1,20 @@
 import { renderHook } from '@testing-library/react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { dispatchEventWrapper } from '@common/helpers/dom.helper';
 import { useContainerEvents } from '@common/hooks/useContainerEvents';
 import * as domHelper from '@common/helpers/dom.helper';
 import { useConfigStore, useStatusStore } from '@src/store';
 import { setInitialGlobalState } from '@src/test/__mocks__/store';
+import { ROUTES } from '@common/constants/routes.constants';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: jest.fn(),
   useLocation: jest.fn(),
+}));
+
+jest.mock('@common/helpers/dom.helper', () => ({
+  dispatchEventWrapper: jest.fn(),
 }));
 
 const mockDispatchEventWrapper = jest.fn();
@@ -45,5 +52,81 @@ describe('useContainerEvents', () => {
     renderUseContainerEventsHook(false);
 
     expect(mockDispatchEventWrapper).toHaveBeenCalledWith(mockEvents.UNBLOCK_NAVIGATION);
+  });
+
+  describe('dispatchNavigateToOriginEventWithFallback', () => {
+    const mockNavigate = jest.fn();
+    const mockDispatchEvent = jest.fn();
+    const fallbackUri = '/test-fallback';
+
+    beforeEach(() => {
+      (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+      (dispatchEventWrapper as jest.Mock).mockImplementation(mockDispatchEvent);
+      jest.clearAllMocks();
+    });
+
+    const setupTest = (hasNavigationOrigin: boolean, isNavigatedFromLDE = false) => {
+      (useLocation as jest.Mock).mockReturnValue({
+        state: isNavigatedFromLDE ? { isNavigatedFromLDE: true } : {},
+      });
+
+      const mockCustomEvents = {
+        NAVIGATE_TO_ORIGIN: 'navigate-to-origin',
+      };
+
+      setInitialGlobalState([
+        {
+          store: useConfigStore,
+          state: { hasNavigationOrigin, customEvents: mockCustomEvents },
+        },
+      ]);
+
+      return renderHook(() => useContainerEvents());
+    };
+
+    it('dispatches NAVIGATE_TO_ORIGIN event when hasNavigationOrigin is true and not navigated from LDE', () => {
+      const { result } = setupTest(true, false);
+
+      result.current.dispatchNavigateToOriginEventWithFallback(fallbackUri);
+
+      expect(mockDispatchEvent).toHaveBeenCalledWith('navigate-to-origin');
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('navigates to fallbackUri when hasNavigationOrigin is false', () => {
+      const { result } = setupTest(false);
+
+      result.current.dispatchNavigateToOriginEventWithFallback(fallbackUri);
+
+      expect(mockNavigate).toHaveBeenCalledWith(fallbackUri);
+      expect(mockDispatchEvent).not.toHaveBeenCalled();
+    });
+
+    it('navigates to search route when no fallbackUri is provided', () => {
+      const { result } = setupTest(false);
+
+      result.current.dispatchNavigateToOriginEventWithFallback();
+
+      expect(mockNavigate).toHaveBeenCalledWith(ROUTES.SEARCH.uri);
+      expect(mockDispatchEvent).not.toHaveBeenCalled();
+    });
+
+    it('navigates to fallbackUri when navigated from LDE, even if hasNavigationOrigin is true', () => {
+      const { result } = setupTest(true, true);
+
+      result.current.dispatchNavigateToOriginEventWithFallback(fallbackUri);
+
+      expect(mockNavigate).toHaveBeenCalledWith(fallbackUri);
+      expect(mockDispatchEvent).not.toHaveBeenCalled();
+    });
+
+    it('navigates to search route when navigated from LDE and no fallbackUri provided', () => {
+      const { result } = setupTest(true, true);
+
+      result.current.dispatchNavigateToOriginEventWithFallback();
+
+      expect(mockNavigate).toHaveBeenCalledWith(ROUTES.SEARCH.uri);
+      expect(mockDispatchEvent).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/test/__tests__/common/hooks/useNavigateToEditPage.test.ts
+++ b/src/test/__tests__/common/hooks/useNavigateToEditPage.test.ts
@@ -1,12 +1,11 @@
 import { renderHook } from '@testing-library/react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useNavigateToEditPage } from '@common/hooks/useNavigateToEditPage';
 import { setInitialGlobalState, setUpdatedGlobalState } from '@src/test/__mocks__/store';
 import { useSearchStore } from '@src/store';
 
 jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(),
-  useLocation: jest.fn(),
 }));
 
 describe('useNavigateToEditPage', () => {
@@ -31,13 +30,12 @@ describe('useNavigateToEditPage', () => {
     ]);
 
     (useNavigate as jest.Mock).mockReturnValue(navigate);
-    (useLocation as jest.Mock).mockReturnValue({ pathname: '/search' });
 
     const { result } = renderHook(() => useNavigateToEditPage());
     const { navigateToEditPage } = result.current;
 
     navigateToEditPage(uri);
 
-    expect(navigate).toHaveBeenCalledWith(uri, { state: { ...navigationState, origin: '/search' } });
+    expect(navigate).toHaveBeenCalledWith(uri, { state: { ...navigationState, isNavigatedFromLDE: true } });
   });
 });

--- a/src/test/__tests__/common/hooks/useNavigateToEditPage.test.ts
+++ b/src/test/__tests__/common/hooks/useNavigateToEditPage.test.ts
@@ -1,11 +1,12 @@
 import { renderHook } from '@testing-library/react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useNavigateToEditPage } from '@common/hooks/useNavigateToEditPage';
 import { setInitialGlobalState, setUpdatedGlobalState } from '@src/test/__mocks__/store';
 import { useSearchStore } from '@src/store';
 
 jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(),
+  useLocation: jest.fn(),
 }));
 
 describe('useNavigateToEditPage', () => {
@@ -30,12 +31,13 @@ describe('useNavigateToEditPage', () => {
     ]);
 
     (useNavigate as jest.Mock).mockReturnValue(navigate);
+    (useLocation as jest.Mock).mockReturnValue({ pathname: '/search' });
 
     const { result } = renderHook(() => useNavigateToEditPage());
     const { navigateToEditPage } = result.current;
 
     navigateToEditPage(uri);
 
-    expect(navigate).toHaveBeenCalledWith(uri, { state: navigationState });
+    expect(navigate).toHaveBeenCalledWith(uri, { state: { ...navigationState, origin: '/search' } });
   });
 });

--- a/src/test/__tests__/components/SearchResultEntry.test.tsx
+++ b/src/test/__tests__/components/SearchResultEntry.test.tsx
@@ -45,7 +45,7 @@ describe('SearchResultEntry', () => {
     test('navigates to edit section for the relevant ID', () => {
       fireEvent.click(getByTestId('edit-button__instanceId'));
 
-      expect(mockedUsedNavigate).toHaveBeenCalledWith('/resources/instanceId/edit', { state: {} });
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/resources/instanceId/edit', { state: { origin: '/' } });
     });
   });
 

--- a/src/test/__tests__/components/SearchResultEntry.test.tsx
+++ b/src/test/__tests__/components/SearchResultEntry.test.tsx
@@ -45,7 +45,9 @@ describe('SearchResultEntry', () => {
     test('navigates to edit section for the relevant ID', () => {
       fireEvent.click(getByTestId('edit-button__instanceId'));
 
-      expect(mockedUsedNavigate).toHaveBeenCalledWith('/resources/instanceId/edit', { state: { origin: '/' } });
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/resources/instanceId/edit', {
+        state: { isNavigatedFromLDE: true },
+      });
     });
   });
 


### PR DESCRIPTION
## Description
Introduced the navigation state option `isNavigatedFromLDE`, which is set when the user navigates to the Edit page from LDE. This parameter is used to check if the user has been redirected from LDE, in order to perform the correct redirect when clicking the "Cancel" or "X" button.

## Refs 
[https://folio-org.atlassian.net/browse/UILD-449](https://folio-org.atlassian.net/browse/UILD-449)