### PR TITLE
UILD-517: use "searchParams" when making API calls after clicking pagination button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 * Empty header cell in table changed from `<th>` to `<td>`. Fixes [UILD-485]
 * A11y enhanced by including resource titles in ARIA labels for buttons and checkboxes in Search results table. Fixes [UILD-486]
 * Implement updateTwinChildrenEntry method to synchronize UUIDs in twin children on entry updates. Fixes [UILD-492]
+* Refactor `useSearch` hook to use `searchParams` when making API calls after clicking pagination button. Fixes [UILD-517]
 
 [UILD-485]:https://folio-org.atlassian.net/browse/UILD-485
 [UILD-486]:https://folio-org.atlassian.net/browse/UILD-486
 [UILD-492]: https://folio-org.atlassian.net/browse/UILD-492
+[UILD-517]: https://folio-org.atlassian.net/browse/UILD-517
 
 ## 1.0.2 (2025-03-27)
 * Several modals shown at once/Wrong app background colour when Advanced search modal is opened. Fixes [UILD-506]. 

--- a/src/common/hooks/useSearch.ts
+++ b/src/common/hooks/useSearch.ts
@@ -112,8 +112,8 @@ export const useSearch = () => {
     }
 
     const typeSearchBy = updatedSearchBy as SearchIdentifiers;
-    const selectedQuery = savedFacetsData.query || '';
-    const selectedFacets = savedFacetsData.facets || {};
+    const selectedQuery = savedFacetsData.query ?? '';
+    const selectedFacets = savedFacetsData.facets ?? {};
 
     setSearchBy(typeSearchBy);
     setQuery(selectedQuery);
@@ -228,5 +228,6 @@ export const useSearch = () => {
     data,
     fetchData,
     onChangeSegment,
+    handlePageChange
   };
 };

--- a/src/common/hooks/useSearch.ts
+++ b/src/common/hooks/useSearch.ts
@@ -9,6 +9,7 @@ import { useSearchContext } from '@common/hooks/useSearchContext';
 import { useFetchSearchData } from '@common/hooks/useFetchSearchData';
 import { useInputsState, useLoadingState, useSearchState, useUIState } from '@src/store';
 import { FullDisplayType } from '@common/constants/uiElements.constants';
+import { SearchQueryParams } from '@common/constants/routes.constants';
 
 export const useSearch = () => {
   const {
@@ -49,7 +50,7 @@ export const useSearch = () => {
     onNextPageClick: onNextPageClickBase,
   } = usePagination(hasSearchParams, 0, hasCustomPagination);
   const currentPageNumber = getCurrentPageNumber();
-  const setSearchParams = useSearchParams()?.[1];
+  const [searchParams, setSearchParams] = useSearchParams();
   const selectedNavigationSegment = navigationSegment?.value;
   const isBrowseSearch = selectedNavigationSegment === SearchSegment.Browse;
 
@@ -179,9 +180,11 @@ export const useSearch = () => {
         pageMetadataSelectorType: metadataSelector,
       });
     } else {
+      const queryValue = searchParams.get(SearchQueryParams.Query) ?? '';
+
       await fetchData({
-        query,
-        searchBy,
+        query: queryValue,
+        searchBy: searchParams.get(SearchQueryParams.SearchBy),
         offset: pageNumber * SEARCH_RESULTS_LIMIT,
       });
     }


### PR DESCRIPTION
Refactor `useSearch` hook to utilize `searchParams` for `query` and `searchBy` values

[https://folio-org.atlassian.net/browse/UILD-517](https://folio-org.atlassian.net/browse/UILD-517)