### PR TITLE
UILD-535: Search query shows slashes when entered value has quotation marks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.4 (IN PROGRESS)
 
+* Search query shows slashes when entered value has quotation marks. Fixes [UILD-535].
+
+[UILD-535]: https://folio-org.atlassian.net/browse/UILD-535
+
 ## 1.0.3 (2025-04-08)
 * Empty header cell in table changed from `<th>` to `<td>`. Fixes [UILD-485]
 * A11y enhanced by including resource titles in ARIA labels for buttons and checkboxes in Search results table. Fixes [UILD-486]

--- a/src/components/SearchControls/SearchControls.tsx
+++ b/src/components/SearchControls/SearchControls.tsx
@@ -55,7 +55,7 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
   const [announcementMessage, setAnnouncementMessage] = useState('');
   const searchQueryParam = searchParams.get(SearchQueryParams.Query);
   const isDisabledResetButton = !query && !searchQueryParam;
-  const [searachValue, setSearchValue] = useState(query);
+  const [searchValue, setSearchValue] = useState(query);
   const selectOptions =
     searchByControlOptions && navigationSegment?.value
       ? (searchByControlOptions as ComplexLookupSearchBy)[navigationSegment.value]
@@ -134,7 +134,7 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
               <Input
                 id="id-search-input"
                 type="text"
-                value={searachValue}
+                value={searchValue}
                 onChange={onChangeSearchInput}
                 className="text-input"
                 onPressEnter={submitSearch}

--- a/src/components/SearchControls/SearchControls.tsx
+++ b/src/components/SearchControls/SearchControls.tsx
@@ -55,7 +55,7 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
   const [announcementMessage, setAnnouncementMessage] = useState('');
   const searchQueryParam = searchParams.get(SearchQueryParams.Query);
   const isDisabledResetButton = !query && !searchQueryParam;
-  const [serachValue, setSearchValue] = useState(query);
+  const [searachValue, setSearchValue] = useState(query);
   const selectOptions =
     searchByControlOptions && navigationSegment?.value
       ? (searchByControlOptions as ComplexLookupSearchBy)[navigationSegment.value]
@@ -134,7 +134,7 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
               <Input
                 id="id-search-input"
                 type="text"
-                value={serachValue}
+                value={searachValue}
                 onChange={onChangeSearchInput}
                 className="text-input"
                 onPressEnter={submitSearch}

--- a/src/components/SearchControls/SearchControls.tsx
+++ b/src/components/SearchControls/SearchControls.tsx
@@ -55,6 +55,7 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
   const [announcementMessage, setAnnouncementMessage] = useState('');
   const searchQueryParam = searchParams.get(SearchQueryParams.Query);
   const isDisabledResetButton = !query && !searchQueryParam;
+  const [serachValue, setSearchValue] = useState(query);
   const selectOptions =
     searchByControlOptions && navigationSegment?.value
       ? (searchByControlOptions as ComplexLookupSearchBy)[navigationSegment.value]
@@ -63,6 +64,7 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
   const onChangeSearchInput = ({ target: { value } }: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setMessage('');
     setQuery(value);
+    setSearchValue(value.replace(/\\/g, ''));
   };
 
   const clearValuesAndResetControls = () => {
@@ -132,7 +134,7 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
               <Input
                 id="id-search-input"
                 type="text"
-                value={query}
+                value={serachValue}
                 onChange={onChangeSearchInput}
                 className="text-input"
                 onPressEnter={submitSearch}


### PR DESCRIPTION
[UILD-535](https://folio-org.atlassian.net/browse/UILD-535)

We separated the query value from the input state to avoid triggering the increment process within the search input.