### PR TITLE
UILD-543: navigation blocking logic update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change history for ui-linked-data
 
 ## 1.0.4 (IN PROGRESS)
+* Update blocker logic in Prompt component and add fetchableId check in Edit component. Fixes [UILD-543]
+
+[UILD-543]:https://folio-org.atlassian.net/browse/UILD-543
 
 ## 1.0.3 (2025-04-08)
 * Empty header cell in table changed from `<th>` to `<td>`. Fixes [UILD-485]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/linked-data",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"

--- a/src/components/Prompt/Prompt.tsx
+++ b/src/components/Prompt/Prompt.tsx
@@ -44,12 +44,9 @@ export const Prompt: FC<Props> = ({ when: shouldPrompt }) => {
     setIsSwitchToNewRecordModalOpen(false);
   };
 
-  const blocker = useBlocker(({ currentLocation, nextLocation: { pathname, search }, historyAction }) => {
+  const blocker = useBlocker(({ currentLocation, nextLocation: { pathname, search } }) => {
     // TODO: investigate what's the case for this behavior
     if (currentLocation?.pathname === pathname) return false;
-
-    // Don't block if using browser back button
-    if (historyAction === 'POP') return false;
 
     // ATM that means we're switching to a new record which will
     // use the current one as a reference. Meaning, we'll have to

--- a/src/components/Prompt/Prompt.tsx
+++ b/src/components/Prompt/Prompt.tsx
@@ -74,10 +74,10 @@ export const Prompt: FC<Props> = ({ when: shouldPrompt }) => {
   };
 
   const proceedNavigation = () => {
+    blocker.proceed?.();
+    setIsEdited(false);
     dispatchProceedNavigationEvent();
     closeAllModals();
-    setIsEdited(false);
-    blocker.proceed?.();
     setRecordStatus({ type: RecordStatus.open });
   };
 
@@ -95,11 +95,9 @@ export const Prompt: FC<Props> = ({ when: shouldPrompt }) => {
         navigateToEditPage(forceNavigateTo.pathname, { replace: true });
       } else {
         const newSearchParams = new URLSearchParams(forceNavigateTo?.search);
+        const paramKey = forceNavigateTo.to === ForceNavigateToDest.CreatePage ? QueryParams.Ref : QueryParams.CloneOf;
 
-        forceNavigateTo.to === ForceNavigateToDest.CreatePage
-          ? newSearchParams.set(QueryParams.Ref, recordId)
-          : newSearchParams.set(QueryParams.CloneOf, recordId);
-
+        newSearchParams.set(paramKey, recordId);
         navigateToEditPage(`${forceNavigateTo.pathname}?${newSearchParams}`, { replace: true });
       }
     }

--- a/src/test/__tests__/components/EditSection.test.tsx
+++ b/src/test/__tests__/components/EditSection.test.tsx
@@ -170,7 +170,7 @@ const monograph = {
   configType: 'profile',
   json: {
     Profile: {
-      resourceTemplates: [],
+      resourceTemplates: ['lc:RT:bf2:Monograph:Work', 'lc:RT:bf2:Monograph:Instance'],
       author: 'author',
       date: 'date',
       description: 'description',
@@ -200,7 +200,7 @@ describe('EditSection', () => {
       },
       {
         store: useUIStore,
-        state: { currentlyEditedEntityBfid: new Set(['uuid2Bfid']) },
+        state: { currentlyEditedEntityBfid: new Set(['lc:RT:bf2:Monograph:Instance']) },
       },
     ]);
 

--- a/src/test/__tests__/views/Edit.test.tsx
+++ b/src/test/__tests__/views/Edit.test.tsx
@@ -76,11 +76,9 @@ describe('Edit', () => {
 
     await renderComponent(null);
 
-    expect(getProfiles).toHaveBeenCalledWith({
-      record: null,
-    });
+    expect(getProfiles).not.toHaveBeenCalled();
     expect(fetchRecord).not.toHaveBeenCalled();
-    expect(clearRecordState).toHaveBeenCalled();
+    expect(clearRecordState).not.toHaveBeenCalled();
   });
 
   test('calls fetchRecord with correct parameters when cloneOfParam search param is provided', async () => {

--- a/src/views/Edit/Edit.tsx
+++ b/src/views/Edit/Edit.tsx
@@ -61,6 +61,7 @@ export const Edit = () => {
       const fetchableId = resourceId ?? cloneOfParam;
 
       if (
+        !fetchableId ||
         (!cloneOfParam && fetchableId && prevResourceId.current === fetchableId) ||
         (cloneOfParam && prevCloneOf.current === cloneOfParam)
       ) {


### PR DESCRIPTION
Updated blocker logic and refactored navigation handling in `Prompt` component to streamline `proceedNavigation` logic and simplified query parameter setting for Edit page navigation.
Added `fetchableId` check in `Edit` component.

This fixes a broken Edit screen and a blocking modal window being displayed when the user presses the browser back button.

[https://folio-org.atlassian.net/browse/UILD-543](https://folio-org.atlassian.net/browse/UILD-543)