### PR TITLE
UILD-534: Fix double title shown when importing after marc preview is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 ## 1.0.4 (IN PROGRESS)
 * Added "selectedEntries" property to compared resources to properly render dropdown options. Fixes [UILD-533]
 
-[UILD-533]:https://folio-org.atlassian.net/browse/UILD-533
-
 * Search query shows slashes when entered value has quotation marks. Fixes [UILD-535].
+* Fix double title shown when importing after marc preview is opened. Fixex [UILD-534].
 
 [UILD-535]: https://folio-org.atlassian.net/browse/UILD-535
+[UILD-533]: https://folio-org.atlassian.net/browse/UILD-533
+[UILD-534]: https://folio-org.atlassian.net/browse/UILD-534
 
 ## 1.0.3 (2025-04-08)
 * Empty header cell in table changed from `<th>` to `<td>`. Fixes [UILD-485]

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -18,7 +18,7 @@ export const Nav = () => {
     isVisible && (
       <div data-testid="nav" className={DOM_ELEMENTS.classNames.nav}>
         {isEditSectionOpen && !marcPreviewData && <EditControlPane />}
-        {marcPreviewData && <ViewMarcControlPane />}
+        {marcPreviewData && !isExternalResourceSectionOpen && <ViewMarcControlPane />}
         {isExternalResourceSectionOpen && <PreviewExternalResourcePane />}
       </div>
     )

--- a/src/components/SearchControls/SearchControls.tsx
+++ b/src/components/SearchControls/SearchControls.tsx
@@ -54,8 +54,8 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
   const [searchParams, setSearchParams] = useSearchParams();
   const [announcementMessage, setAnnouncementMessage] = useState('');
   const searchQueryParam = searchParams.get(SearchQueryParams.Query);
-  const isDisabledResetButton = !query && !searchQueryParam;
   const [searchValue, setSearchValue] = useState(query);
+  const isDisabledResetButton = !query && !searchQueryParam && !searchValue;
   const selectOptions =
     searchByControlOptions && navigationSegment?.value
       ? (searchByControlOptions as ComplexLookupSearchBy)[navigationSegment.value]
@@ -78,6 +78,7 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
     resetPreviewContent();
     resetFullDisplayComponentType();
     resetSelectedInstances();
+    setSearchValue('');
     hasSearchParams && setSearchParams({});
     hasSearchParams && setNavigationState({});
     setAnnouncementMessage(formatMessage({ id: 'ld.aria.filters.reset.announce' }));


### PR DESCRIPTION
[UILD-534](https://folio-org.atlassian.net/browse/UILD-534)

Fixed the problem with the double pane for `external/marc ` resources. 

<img width="1509" alt="Screenshot 2025-04-16 at 10 58 46" src="https://github.com/user-attachments/assets/a4bfe4a9-237d-464e-918e-ddcc5d601dea" />
