### PR TITLE
UILD-526: Fix formatting of console error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 * Added "selectedEntries" property to compared resources to properly render dropdown options. Fixes [UILD-533]
 * Update blocker logic in Prompt component and add fetchableId check in Edit component. Fixes [UILD-543]
 * Search query shows slashes when entered value has quotation marks. Fixes [UILD-535].
-* Fix double title shown when importing after marc preview is opened. Fixex [UILD-534].
+* Fix double title shown when importing after marc preview is opened. Fixes [UILD-534].
+* Add safe formatting to the console error message. Fixes [UILD-526].
 
 [UILD-533]: https://folio-org.atlassian.net/browse/UILD-533
 [UILD-543]:https://folio-org.atlassian.net/browse/UILD-543
 [UILD-535]: https://folio-org.atlassian.net/browse/UILD-535
 [UILD-534]: https://folio-org.atlassian.net/browse/UILD-534
+[UILD-526]: https://folio-org.atlassian.net/browse/UILD-526
 
 
 ## 1.0.3 (2025-04-08)

--- a/src/common/services/userValues/userValues.service.ts
+++ b/src/common/services/userValues/userValues.service.ts
@@ -77,7 +77,9 @@ export class UserValuesService implements IUserValues {
       this.generatedValue = await this.userValueFactory?.generate({ ...typedValue, uuid: this.key, type: this.type });
     } catch (error) {
       console.error(
-        `Error occurred generating value for ${this.value?.fieldUri} field of the ${this.value?.groupUri} record entry`,
+        `Error occurred generating value for %s field of the %s record entry`,
+        this.value?.groupUri,
+        this.value?.fieldUri,
         error,
       );
     }


### PR DESCRIPTION
Fix formatting of console error message in `UserValuesService` to make it safe.

[https://folio-org.atlassian.net/browse/UILD-526](https://folio-org.atlassian.net/browse/UILD-526)