### PR TITLE
UILD-544: fix for a record with repeatable subcomponents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 * Added "selectedEntries" property to compared resources to properly render dropdown options. Fixes [UILD-533]
 * Update blocker logic in Prompt component and add fetchableId check in Edit component. Fixes [UILD-543]
 * Search query shows slashes when entered value has quotation marks. Fixes [UILD-535].
-* Fix double title shown when importing after marc preview is opened. Fixex [UILD-534].
+* Fix double title shown when importing after marc preview is opened. Fixes [UILD-534].
+* Remove unnecessary child subcomponents when copying a whole field when the record is loaded. Fixes [UILD-544].
 
-[UILD-533]: https://folio-org.atlassian.net/browse/UILD-533
+[UILD-533]:https://folio-org.atlassian.net/browse/UILD-533
 [UILD-543]:https://folio-org.atlassian.net/browse/UILD-543
-[UILD-535]: https://folio-org.atlassian.net/browse/UILD-535
-[UILD-534]: https://folio-org.atlassian.net/browse/UILD-534
+[UILD-535]:https://folio-org.atlassian.net/browse/UILD-535
+[UILD-534]:https://folio-org.atlassian.net/browse/UILD-534
+[UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
 
 
 ## 1.0.3 (2025-04-08)

--- a/src/common/services/recordToSchemaMapping/recordToSchemaMapping.service.ts
+++ b/src/common/services/recordToSchemaMapping/recordToSchemaMapping.service.ts
@@ -108,7 +108,7 @@ export class RecordToSchemaMappingService implements IRecordToSchemaMapping {
     // generate repeatable fields
     if (Array.isArray(recordEntry) && recordEntry?.length > 1 && parseInt(recordGroupIndex) !== 0) {
       const schemaEntry = this.getSchemaEntries(containerBf2Uri, containerDataTypeUri)[parseInt(recordGroupIndex) - 1];
-      const newEntryUuid = this.repeatableFieldsService?.duplicateEntry(schemaEntry, false) ?? '';
+      const newEntryUuid = this.repeatableFieldsService?.duplicateEntry(schemaEntry, true) ?? '';
       this.updatedSchema = this.repeatableFieldsService?.get();
       this.schemaArray = Array.from(this.updatedSchema?.values() || []);
 
@@ -419,7 +419,7 @@ export class RecordToSchemaMappingService implements IRecordToSchemaMapping {
   private createDuplicateEntry(schemaUiElem: SchemaEntry): {
     newEntryUuid: string;
   } {
-    const newEntryUuid = this.repeatableFieldsService?.duplicateEntry(schemaUiElem, false) ?? '';
+    const newEntryUuid = this.repeatableFieldsService?.duplicateEntry(schemaUiElem, true) ?? '';
     this.updatedSchema = this.repeatableFieldsService?.get();
 
     this.schemaArray = Array.from(this.updatedSchema?.values() || []);

--- a/src/common/services/schema/schemaWithDuplicates.interface.ts
+++ b/src/common/services/schema/schemaWithDuplicates.interface.ts
@@ -3,7 +3,7 @@ export interface ISchemaWithDuplicates {
 
   set: (schema: Schema) => void;
 
-  duplicateEntry: (entry: SchemaEntry, isManualDuplication?: boolean) => string | undefined;
+  duplicateEntry: (entry: SchemaEntry, isAutoDuplication?: boolean) => string | undefined;
 
   deleteEntry: (entry: SchemaEntry) => string[] | undefined;
 }

--- a/src/common/services/schema/schemaWithDuplicates.service.ts
+++ b/src/common/services/schema/schemaWithDuplicates.service.ts
@@ -187,14 +187,14 @@ export class SchemaWithDuplicatesService implements ISchemaWithDuplicatesService
     if (!parentEntry) return;
 
     this.removeFromParentChildren(entry, parentEntry);
-    this.removeFromTwinChildren(entry, parentEntry);
+    this.removeFromParentTwinChildren(entry, parentEntry);
   }
 
   private removeFromParentChildren(entry: SchemaEntry, parentEntry: SchemaEntry): void {
     parentEntry.children = parentEntry.children?.filter(childId => childId !== entry.uuid) || [];
   }
 
-  private removeFromTwinChildren(entry: SchemaEntry, parentEntry: SchemaEntry): void {
+  private removeFromParentTwinChildren(entry: SchemaEntry, parentEntry: SchemaEntry): void {
     const hasTwinChildren = parentEntry.twinChildren && entry.uri && parentEntry.twinChildren[entry.uri];
 
     if (!hasTwinChildren || !parentEntry.twinChildren || !entry.uri) {

--- a/src/test/__tests__/common/services/recordToSchemaMapping/recordToSchemaMapping.service.test.ts
+++ b/src/test/__tests__/common/services/recordToSchemaMapping/recordToSchemaMapping.service.test.ts
@@ -88,7 +88,7 @@ describe('RecordToSchemaMappingService', () => {
         displayName: 'Literal label 1',
         path: ['testKey-1', 'testKey-2', 'testKey-3'],
       }),
-      false,
+      true,
     );
     expect(repeatableFieldsService.get).toHaveBeenCalled();
     expect(selectedEntriesService.addNew).toHaveBeenCalledWith(undefined, 'testKey-7');
@@ -139,7 +139,7 @@ describe('RecordToSchemaMappingService', () => {
         displayName: 'Dropdown Option 1 Item 1',
         path: ['testKey-1', 'testKey-2', 'testKey-5', 'testKey-7', 'testKey-9'],
       }),
-      false,
+      true,
     );
 
     expect(repeatableFieldsService.get).toHaveBeenCalled();


### PR DESCRIPTION
Changed a parameter for the `duplicateEntry` entry, which is used to detect if the duplication is initiated automatically during the record's loading or by the user.
Excluded record IDs from parent records to address an issue where a record contains repeatable subcomponents and this results in redundant records being created when mapping the record against the schema.

[https://folio-org.atlassian.net/browse/UILD-544](https://folio-org.atlassian.net/browse/UILD-544)