### PR TITLE
UILD-534: display External Preview controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Search query shows slashes when entered value has quotation marks. Fixes [UILD-535].
 * Fix double title shown when importing after marc preview is opened. Fixes [UILD-534].
 * Add safe formatting to the console error message. Fixes [UILD-526].
+* Clear MARC preview state to display controls on the External Preview pane. Fixes [UILD-534].
 
 [UILD-533]: https://folio-org.atlassian.net/browse/UILD-533
 [UILD-543]:https://folio-org.atlassian.net/browse/UILD-543

--- a/src/views/ExternalResource/ExternalResourcePreview.tsx
+++ b/src/views/ExternalResource/ExternalResourcePreview.tsx
@@ -6,27 +6,27 @@ import { ExternalResourceIdType } from '@common/constants/api.constants';
 import { Preview } from '@components/Preview';
 import { EDIT_ALT_DISPLAY_LABELS } from '@common/constants/uiElements.constants';
 import { ModalDuplicateImportedResource } from '@components/ModalDuplicateImportedResource';
+import { useInputsState, useMarcPreviewState } from '@src/store';
 import './ExternalResourcePreview.scss';
-import { useInputsState } from '@src/store';
 
 export const ExternalResourcePreview = () => {
   const { record } = useInputsState();
   const { fetchExternalRecordForPreview } = useRecordControls();
+  const { resetBasicValue } = useMarcPreviewState();
   const { externalId } = useParams();
 
   useEffect(() => {
     // TODO: UILD-443 - if applicable in future, pass in resource type from query params
     fetchExternalRecordForPreview(externalId, ExternalResourceIdType.Inventory);
+
+    // TODO: UILD-552 - temporary solution. Reset the whole state on application unload.
+    resetBasicValue();
   }, [externalId]);
 
   return (
     <div className="external-resource-preview">
       {record ? (
-        <Preview
-          altDisplayNames={EDIT_ALT_DISPLAY_LABELS}
-          forceRenderAllTopLevelEntities
-          entityRowDisplay
-        />
+        <Preview altDisplayNames={EDIT_ALT_DISPLAY_LABELS} forceRenderAllTopLevelEntities entityRowDisplay />
       ) : (
         <ExternalResourceLoader />
       )}


### PR DESCRIPTION
Fix for External Preview: clear MARC preview state to display controls on the External Preview pane.

[https://folio-org.atlassian.net/browse/UILD-534](https://folio-org.atlassian.net/browse/UILD-534)

