### PR TITLE
UILD-535: Fix - remove backslashes from a search query before displaying it in the search query input

### DIFF
--- a/src/common/helpers/search.helper.ts
+++ b/src/common/helpers/search.helper.ts
@@ -102,3 +102,12 @@ export const generateSearchParamsState = (query: string | null, searchBy?: Searc
 export const normalizeQuery = (query?: string | null) => {
   return query?.replaceAll(/['"/\\]/g, '\\$&');
 };
+
+export const removeBackslashes = (query?: string | null) => {
+  if (!query) return '';
+
+  return query
+    .replace(/\\"/g, '"') // replace escaped double quotes with double quotes
+    .replace(/\\\\/g, '\\') // replace double backslashes with single
+    .replace(/([^\\])\\(?!\\)/g, '$1'); // remove single backslashes;
+};

--- a/src/common/hooks/useLoadSearchResults.ts
+++ b/src/common/hooks/useLoadSearchResults.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { SearchQueryParams } from '@common/constants/routes.constants';
 import { SEARCH_RESULTS_LIMIT, SearchIdentifiers } from '@common/constants/search.constants';
+import { removeBackslashes } from '@common/helpers/search.helper';
 import { useLoadingState, useSearchState } from '@src/store';
 import { useSearchContext } from './useSearchContext';
 
@@ -41,7 +42,7 @@ export const useLoadSearchResults = (
 
       // Sets query's value for Basic search
       if (searchByParam && prevQuery !== queryParam) {
-        setQuery(queryParam);
+        setQuery(removeBackslashes(queryParam));
       }
 
       setForceRefresh(false);
@@ -69,7 +70,7 @@ export const useLoadSearchResults = (
       }
 
       if (searchByParam && queryParam) {
-        setQuery(queryParam);
+        setQuery(removeBackslashes(queryParam));
       }
 
       if (query) {

--- a/src/components/SearchControls/SearchControls.tsx
+++ b/src/components/SearchControls/SearchControls.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { DEFAULT_FACET_BY_SEGMENT, SearchIdentifiers } from '@common/constants/search.constants';
 import { SearchQueryParams } from '@common/constants/routes.constants';
 import { useSearchContext } from '@common/hooks/useSearchContext';
+import { removeBackslashes } from '@common/helpers/search.helper';
 import { Button, ButtonType } from '@components/Button';
 import { Input } from '@components/Input';
 import { Select } from '@components/Select';
@@ -54,8 +55,7 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
   const [searchParams, setSearchParams] = useSearchParams();
   const [announcementMessage, setAnnouncementMessage] = useState('');
   const searchQueryParam = searchParams.get(SearchQueryParams.Query);
-  const [searchValue, setSearchValue] = useState(query);
-  const isDisabledResetButton = !query && !searchQueryParam && !searchValue;
+  const isDisabledResetButton = !query && !searchQueryParam;
   const selectOptions =
     searchByControlOptions && navigationSegment?.value
       ? (searchByControlOptions as ComplexLookupSearchBy)[navigationSegment.value]
@@ -64,7 +64,6 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
   const onChangeSearchInput = ({ target: { value } }: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setMessage('');
     setQuery(value);
-    setSearchValue(value.replace(/\\/g, ''));
   };
 
   const clearValuesAndResetControls = () => {
@@ -78,7 +77,6 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
     resetPreviewContent();
     resetFullDisplayComponentType();
     resetSelectedInstances();
-    setSearchValue('');
     hasSearchParams && setSearchParams({});
     hasSearchParams && setNavigationState({});
     setAnnouncementMessage(formatMessage({ id: 'ld.aria.filters.reset.announce' }));
@@ -135,7 +133,7 @@ export const SearchControls: FC<Props> = ({ submitSearch, changeSegment, clearVa
               <Input
                 id="id-search-input"
                 type="text"
-                value={searchValue}
+                value={query}
                 onChange={onChangeSearchInput}
                 className="text-input"
                 onPressEnter={submitSearch}

--- a/src/test/__tests__/common/helpers/search.helper.test.ts
+++ b/src/test/__tests__/common/helpers/search.helper.test.ts
@@ -1,0 +1,68 @@
+import { removeBackslashes } from '@common/helpers/search.helper';
+
+describe('search.helper', () => {
+  describe('removeBackslashes', () => {
+    it('removes all backslashes from a string', () => {
+      const query = 'hello\\world\\test';
+      const testResult = 'helloworldtest';
+
+      expect(removeBackslashes(query)).toBe(testResult);
+    });
+
+    it('handles string with no backslashes', () => {
+      const query = 'hello world test';
+
+      expect(removeBackslashes(query)).toBe(query);
+    });
+
+    it('handles empty string', () => {
+      expect(removeBackslashes('')).toBe('');
+    });
+
+    it('handles null query', () => {
+      expect(removeBackslashes(null)).toBe('');
+    });
+
+    it('handles multiple consecutive backslashes', () => {
+      const query = 'hello\\\\world';
+      const testResult = 'helloworld';
+
+      expect(removeBackslashes(query)).toBe(testResult);
+    });
+
+    it('preserves other special characters', () => {
+      const query = 'hello\\world!@#$%^&*()';
+      const testResult = 'helloworld!@#$%^&*()';
+
+      expect(removeBackslashes(query)).toBe(testResult);
+    });
+
+    it('handles escaped quotes', () => {
+      const query = 'hello\\"world\\"';
+      const testResult = 'hello"world"';
+
+      expect(removeBackslashes(query)).toBe(testResult);
+    });
+
+    it('handles escaped single quotes', () => {
+      const query = "hello\\'world\\'";
+      const testResult = "hello'world'";
+
+      expect(removeBackslashes(query)).toBe(testResult);
+    });
+
+    it('handles escaped forward slashes', () => {
+      const query = 'hello\\/world\\/test';
+      const testResult = 'hello/world/test';
+
+      expect(removeBackslashes(query)).toBe(testResult);
+    });
+
+    it('handles multiple escaped quotes in sequence', () => {
+      const query = '\\"\\"\\"hello\\"\\"\\"';
+      const testResult = '"""hello"""';
+
+      expect(removeBackslashes(query)).toBe(testResult);
+    });
+  });
+});


### PR DESCRIPTION
Use the normalized search query value from the global state in `SearchControls`.

[https://folio-org.atlassian.net/browse/UILD-535](https://folio-org.atlassian.net/browse/UILD-535)