### PR TITLE
UILD-554: Fix - Browser Back button navigates to Edit without duplicated title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change history for ui-linked-data
 
 ## 1.0.5 (IN PROGRESS)
+* Browser Back button navigates to Edit without duplicated title when navigated from Duplicate screen. Fixes [UILD-554].
+
+[UILD-554]:https://folio-org.atlassian.net/browse/UILD-554
 
 ## 1.0.4 (2025-04-24)
 * Added "selectedEntries" property to compared resources to properly render dropdown options. Fixes [UILD-533]

--- a/src/views/Edit/Edit.tsx
+++ b/src/views/Edit/Edit.tsx
@@ -32,7 +32,7 @@ export const Edit = () => {
   const typeParam = queryParams.get(QueryParams.Type);
   const refParam = queryParams.get(QueryParams.Ref);
 
-  const prevResourceId = useRef<string | null>(null);
+  const prevResourceId = useRef<string | null | undefined>(null);
   const prevCloneOf = useRef<string | null>(null);
 
   function setEntitesBFIds() {
@@ -89,7 +89,7 @@ export const Edit = () => {
       const fetchableId = resourceId ?? cloneOfParam;
 
       if (
-        (!cloneOfParam && fetchableId && prevResourceId.current === fetchableId) ||
+        (!cloneOfParam && resourceId && prevResourceId.current === resourceId) ||
         (cloneOfParam && prevCloneOf.current === cloneOfParam) ||
         (!fetchableId && !refParam)
       ) {
@@ -104,7 +104,7 @@ export const Edit = () => {
             prevCloneOf.current = cloneOfParam;
           }
 
-          prevResourceId.current = fetchableId;
+          prevResourceId.current = resourceId;
           await fetchRecord(fetchableId);
 
           return;


### PR DESCRIPTION
Update `prevResourceId` handling to support undefined values and improve fetch logic

[https://folio-org.atlassian.net/browse/UILD-554](https://folio-org.atlassian.net/browse/UILD-554)

