### PR TITLE
UILD-561 update

### DIFF
--- a/src/common/constants/import.constants.ts
+++ b/src/common/constants/import.constants.ts
@@ -3,7 +3,7 @@ export const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024 * 1024;
 
 export const HOLD_LOADING_SCREEN_MS = 2.5 * 1000;
 
-export const LOADING_TIMEOUT_MS = 20 * 1000;
+export const LOADING_TIMEOUT_MS = 60 * 1000;
 
 export const LD_JSON_MIME_TYPE = 'application/ld+json';
 

--- a/src/common/constants/import.constants.ts
+++ b/src/common/constants/import.constants.ts
@@ -3,6 +3,8 @@ export const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024 * 1024;
 
 export const HOLD_LOADING_SCREEN_MS = 2.5 * 1000;
 
+export const LOADING_TIMEOUT_MS = 20 * 1000;
+
 export const LD_JSON_MIME_TYPE = 'application/ld+json';
 
 export enum ImportModes {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -20,6 +20,7 @@ interface Props {
   submitButtonLabel?: string;
   cancelButtonLabel?: string;
   shouldCloseOnEsc?: boolean;
+  shouldCloseOnExternalClick? : boolean;
   onSubmit?: () => void;
   onCancel?: () => void;
   onClose: () => void;
@@ -40,6 +41,7 @@ const Modal: FC<Props> = ({
   submitButtonLabel,
   cancelButtonLabel,
   shouldCloseOnEsc = true,
+  shouldCloseOnExternalClick = true,
   onSubmit,
   onCancel,
   onClose,
@@ -69,12 +71,18 @@ const Modal: FC<Props> = ({
     window.addEventListener('keydown', handleEscape);
 
     return () => window.removeEventListener('keydown', handleEscape);
-  }, []);
+  }, [shouldCloseOnEsc]);
+
+  const onExternalClickClose = () => {
+    if (shouldCloseOnExternalClick) {
+      onClose();
+    }
+  };
 
   return isOpen && portalElement
     ? createPortal(
         <>
-          <div className="overlay" onClick={onClose} role="presentation" data-testid="modal-overlay" />
+          <div className="overlay" onClick={onExternalClickClose} role="presentation" data-testid="modal-overlay" />
           <div className={classNames(['modal', className])} role="dialog" data-testid="modal">
             <div className={classNames(['modal-header', classNameHeader])}>
               {showCloseIconButton && (

--- a/src/components/ModalImport/ModalImport.tsx
+++ b/src/components/ModalImport/ModalImport.tsx
@@ -55,19 +55,24 @@ export const ModalImport = memo(() => {
         try {
           // Wait at least long enough to read the loading message for success.
           const started = Date.now();
-          // Reject (throw) if importFile is taking too long since we've removed
+          // Reject if importFile is taking too long since we've removed
           // the ability to alter the modal state during load.
-          await new Promise(async (resolve, reject) => {
-            const timeout = setTimeout(() => reject(), LOADING_TIMEOUT_MS);
-            try {
-              const result = await importFile(filesToUpload);
-              resolve(result);
-            } catch {
-              reject();
-            } finally {
-              clearTimeout(timeout);
-            }
-          })
+          await new Promise((resolve, reject) => {
+            const timeout = setTimeout(
+              () => reject(new Error(formatMessage({ id: 'ld.importTimedOut' }))),
+              LOADING_TIMEOUT_MS,
+            );
+            importFile(filesToUpload)
+              .then(result => {
+                resolve(result);
+              })
+              .catch(e => {
+                reject(e);
+              })
+              .finally(() => {
+                clearTimeout(timeout);
+              });
+          });
           const elapsed = Date.now() - started;
           const delta = HOLD_LOADING_SCREEN_MS - elapsed;
           if (delta > 0) {

--- a/src/components/ModalImport/ModalImport.tsx
+++ b/src/components/ModalImport/ModalImport.tsx
@@ -67,7 +67,7 @@ export const ModalImport = memo(() => {
                 resolve(result);
               })
               .catch(e => {
-                reject(e);
+                reject(new Error(e));
               })
               .finally(() => {
                 clearTimeout(timeout);

--- a/src/components/ModalImport/ModalImport.tsx
+++ b/src/components/ModalImport/ModalImport.tsx
@@ -132,6 +132,8 @@ export const ModalImport = memo(() => {
       spreadModalControls
       cancelButtonDisabled={isImportSubmitted}
       showCloseIconButton={!isImportSubmitted}
+      shouldCloseOnEsc={!isImportSubmitted}
+      shouldCloseOnExternalClick={!isImportSubmitted}
       cancelButtonHidden={isImportSuccessful}
       cancelButtonLabel={formatMessage({ id: 'ld.cancel' })}
       onCancel={reset}

--- a/src/test/__tests__/components/ModalImport.test.tsx
+++ b/src/test/__tests__/components/ModalImport.test.tsx
@@ -55,6 +55,7 @@ describe('ModalImport', () => {
     expect(importFileMock).toHaveBeenCalled();
     expect(screen.getByTestId('modal-import-waiting')).toBeInTheDocument();
     expect(screen.getByTestId('modal-button-submit')).toBeDisabled();
+    expect(screen.getByTestId('modal-button-cancel')).toBeDisabled();
   });
 
   test('successful import shows done button which closes modal', async () => {
@@ -70,6 +71,21 @@ describe('ModalImport', () => {
     await user.click(screen.getByTestId('modal-button-submit'));
     expect(screen.queryByTestId('modal-import')).not.toBeInTheDocument();
   });
+
+  test('import timeout progresses to failed load state', async () => {
+    jest.useFakeTimers({ advanceTimers: true });
+    importFileMock = (jest.spyOn(importApi, 'importFile') as any).mockImplementation(() => {
+      setTimeout(() => {
+        Promise.resolve(null);
+      }, 30 * 1000);
+    });
+    const input = screen.getByTestId('dropzone-file-input');
+    await user.upload(input, file);
+    await user.click(screen.getByTestId('modal-button-submit'));
+    await jest.advanceTimersToNextTimerAsync();
+    expect(screen.getByTestId('modal-import-completed')).toBeInTheDocument();
+  });
+
 
   test('failed import shows try again button which resets modal state', async () => {
     importFileMock.mockRejectedValueOnce(null);

--- a/src/test/__tests__/components/ModalImport.test.tsx
+++ b/src/test/__tests__/components/ModalImport.test.tsx
@@ -86,7 +86,6 @@ describe('ModalImport', () => {
     expect(screen.getByTestId('modal-import-completed')).toBeInTheDocument();
   });
 
-
   test('failed import shows try again button which resets modal state', async () => {
     importFileMock.mockRejectedValueOnce(null);
     const input = screen.getByTestId('dropzone-file-input');

--- a/translations/ui-linked-data/en.json
+++ b/translations/ui-linked-data/en.json
@@ -257,5 +257,6 @@
   "ld.importFileFailure": "Your file was unable to be imported. Please check the import log downloaded to your browser for more details.",
   "ld.importFailed": "Import failed",
   "ld.importDone": "Done",
-  "ld.importTryAgain": "Try again"
+  "ld.importTryAgain": "Try again",
+  "ld.importTimedout": "Import failed to complete in time"
 }


### PR DESCRIPTION
Update modal to disable close actions during active import. Add a timeout mechanism to avoid trapping the user permanently on this screen, progress to failure view after timeout expires.