### PR TITLE
UILD-550: Fix - Show empty selected option by default when duplicating Creator/Contributor of Work

### DIFF
--- a/src/common/services/schema/schemaGenerator.service.ts
+++ b/src/common/services/schema/schemaGenerator.service.ts
@@ -103,6 +103,17 @@ export class SchemaGeneratorService implements ISchemaGenerator {
     const emptyOptionUuid = generateEmptyValueUuid(node.uuid);
     const children = node.children ? [emptyOptionUuid, ...node.children] : [emptyOptionUuid];
 
+    this.schema.set(emptyOptionUuid, {
+      uuid: emptyOptionUuid,
+      type: AdvancedFieldType.dropdownOption,
+      path: [...node.path, emptyOptionUuid],
+      displayName: '',
+      bfid: '',
+      uri: '',
+      uriBFLite: '',
+      children: [],
+    });
+
     return {
       ...node,
       emptyOptionUuid,

--- a/src/test/__tests__/common/services/schema/schemaGenerator.service.test.ts
+++ b/src/test/__tests__/common/services/schema/schemaGenerator.service.test.ts
@@ -75,7 +75,7 @@ describe('SchemaGeneratorService', () => {
 
       const schema = service.get();
 
-      expect(schema.size).toBe(2);
+      expect(schema.size).toBe(3);
       expect(schema.has('init-key')).toBeTruthy();
       expect(schema.has('generated-uuid')).toBeTruthy();
     });


### PR DESCRIPTION
This PR fixes the bug: When duplicating “Creator/Contributor of Work”, second occurrence shows “Person” type by default.
An empty option should be shown.

[https://folio-org.atlassian.net/browse/UILD-550](https://folio-org.atlassian.net/browse/UILD-550)



