### PR TITLE
UILD-550: Fix - generate a record including values only for the selected dropdown options

### DIFF
--- a/src/common/hooks/useRecordGeneration.ts
+++ b/src/common/hooks/useRecordGeneration.ts
@@ -13,7 +13,7 @@ const getReferenceIds = (record: RecordEntry, block: string, referenceKey: strin
 export const useRecordGeneration = () => {
   const [searchParams] = useSearchParams();
   const { recordGeneratorService } = useServicesContext();
-  const { record, userValues, selectedRecordBlocks } = useInputsState();
+  const { record, userValues, selectedEntries, selectedRecordBlocks } = useInputsState();
   const { selectedProfile, schema } = useProfileState();
 
   const updatedSelectedRecordBlocks = selectedRecordBlocks || getSelectedRecordBlocks(searchParams);
@@ -26,7 +26,7 @@ export const useRecordGeneration = () => {
 
   const generateRecord = () =>
     recordGeneratorService?.generate(
-      { schema, userValues, referenceIds },
+      { schema, userValues, selectedEntries, referenceIds },
       (selectedProfile?.[0]?.id as ProfileType) ?? 'Monograph',
       entityType,
     );

--- a/src/common/services/recordGenerator/processors/profileSchema/baseDropdownProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/baseDropdownProcessor.ts
@@ -31,7 +31,7 @@ export abstract class BaseDropdownProcessor extends BaseFieldProcessor {
     this.recordSchemaEntry = recordSchemaEntry;
   }
 
-  protected processDropdownChildren(dropdownEntry: SchemaEntry) {
+  protected processDropdownChildren(dropdownEntry: SchemaEntry, selectedEntries: string[]) {
     const results: ProcessorResult[] = [];
 
     if (!dropdownEntry.children) return results;
@@ -39,7 +39,12 @@ export abstract class BaseDropdownProcessor extends BaseFieldProcessor {
     dropdownEntry.children.forEach(optionUuid => {
       const optionEntry = this.profileSchemaManager.getSchemaEntry(optionUuid);
 
-      if (!optionEntry?.children || !this.profileSchemaManager.hasOptionValues(optionEntry, this.userValues)) return;
+      if (
+        !optionEntry?.children ||
+        !selectedEntries.includes(optionEntry.uuid) ||
+        !this.profileSchemaManager.hasOptionValues(optionEntry, this.userValues)
+      )
+        return;
 
       const result = this.processOptionEntry(optionEntry);
 

--- a/src/common/services/recordGenerator/processors/profileSchema/baseDropdownProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/baseDropdownProcessor.ts
@@ -1,10 +1,11 @@
 import { AdvancedFieldType } from '@common/constants/uiControls.constants';
+import { IProfileSchemaManager } from '../../profileSchemaManager.interface';
 import { ProcessorResult, SimplePropertyResult } from '../../types/profileSchemaProcessor.types';
+import { ProcessContext } from '../../types/common.types';
 import { IProfileSchemaProcessorManager } from './profileSchemaProcessorManager.interface';
 import { ProcessorUtils } from './utils/processorUtils';
 import { DropdownValueFormatter } from './formatters/value/dropdownValueFormatter';
 import { BaseFieldProcessor } from './baseFieldProcessor';
-import { IProfileSchemaManager } from '../../profileSchemaManager.interface';
 
 export abstract class BaseDropdownProcessor extends BaseFieldProcessor {
   constructor(
@@ -16,19 +17,17 @@ export abstract class BaseDropdownProcessor extends BaseFieldProcessor {
 
   abstract canProcess(profileSchemaEntry: SchemaEntry, recordSchemaEntry: RecordSchemaEntry): boolean;
 
-  abstract process(
-    profileSchemaEntry: SchemaEntry,
-    userValues: UserValues,
-    recordSchemaEntry: RecordSchemaEntry,
-  ): ProcessorResult[];
+  abstract process(data: ProcessContext): ProcessorResult[];
 
-  protected initializeProcessor(
-    profileSchemaEntry: SchemaEntry,
-    userValues: UserValues,
-    recordSchemaEntry: RecordSchemaEntry,
-  ) {
+  protected initializeProcessor({
+    profileSchemaEntry,
+    userValues,
+    selectedEntries,
+    recordSchemaEntry,
+  }: ProcessContext) {
     this.profileSchemaEntry = profileSchemaEntry;
     this.userValues = userValues;
+    this.selectedEntries = selectedEntries;
     this.recordSchemaEntry = recordSchemaEntry;
   }
 
@@ -70,7 +69,12 @@ export abstract class BaseDropdownProcessor extends BaseFieldProcessor {
     }
 
     if (recordSchemaEntry) {
-      return this.profileSchemaProcessorManager.process(childEntry, recordSchemaEntry, this.userValues);
+      return this.profileSchemaProcessorManager.process({
+        profileSchemaEntry: childEntry,
+        recordSchemaEntry,
+        userValues: this.userValues,
+        selectedEntries: this.selectedEntries,
+      });
     } else {
       return this.processSimpleChildValues(childValues);
     }

--- a/src/common/services/recordGenerator/processors/profileSchema/baseFieldProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/baseFieldProcessor.ts
@@ -2,11 +2,13 @@ import { AdvancedFieldType } from '@common/constants/uiControls.constants';
 import { IProfileSchemaProcessor } from './profileSchemaProcessor.interface';
 import { IProfileSchemaManager } from '../../profileSchemaManager.interface';
 import { ProcessorResult } from '../../types/profileSchemaProcessor.types';
+import { ProcessContext } from '../../types/common.types';
 import { IValueFormatter } from './formatters';
 import { ProcessorUtils } from './utils/processorUtils';
 
 export abstract class BaseFieldProcessor implements IProfileSchemaProcessor {
   protected userValues: UserValues = {};
+  protected selectedEntries: string[] = [];
   protected profileSchemaEntry: SchemaEntry | null = null;
   protected recordSchemaEntry: RecordSchemaEntry | null = null;
 
@@ -16,19 +18,17 @@ export abstract class BaseFieldProcessor implements IProfileSchemaProcessor {
   ) {}
 
   abstract canProcess(profileSchemaEntry: SchemaEntry, recordSchemaEntry: RecordSchemaEntry): boolean;
-  abstract process(
-    profileSchemaEntry: SchemaEntry,
-    userValues: UserValues,
-    recordSchemaEntry: RecordSchemaEntry,
-  ): ProcessorResult[];
+  abstract process(data: ProcessContext): ProcessorResult[];
 
-  protected initializeProcessor(
-    profileSchemaEntry: SchemaEntry,
-    userValues: UserValues,
-    recordSchemaEntry: RecordSchemaEntry,
-  ) {
+  protected initializeProcessor({
+    profileSchemaEntry,
+    userValues,
+    selectedEntries,
+    recordSchemaEntry,
+  }: ProcessContext) {
     this.profileSchemaEntry = profileSchemaEntry;
     this.userValues = userValues;
+    this.selectedEntries = selectedEntries;
     this.recordSchemaEntry = recordSchemaEntry;
   }
 

--- a/src/common/services/recordGenerator/processors/profileSchema/dropdownProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/dropdownProcessor.ts
@@ -1,4 +1,5 @@
 import { AdvancedFieldType } from '@common/constants/uiControls.constants';
+import { ProcessContext } from '../../types/common.types';
 import { BaseDropdownProcessor } from './baseDropdownProcessor';
 
 export class DropdownProcessor extends BaseDropdownProcessor {
@@ -10,10 +11,10 @@ export class DropdownProcessor extends BaseDropdownProcessor {
     );
   }
 
-  process(profileSchemaEntry: SchemaEntry, userValues: UserValues, recordSchemaEntry: RecordSchemaEntry) {
-    this.initializeProcessor(profileSchemaEntry, userValues, recordSchemaEntry);
+  process(data: ProcessContext) {
+    this.initializeProcessor(data);
 
-    return this.processDropdownChildren(profileSchemaEntry);
+    return this.processDropdownChildren(data.profileSchemaEntry);
   }
 
   protected processOptionEntry(optionEntry: SchemaEntry) {

--- a/src/common/services/recordGenerator/processors/profileSchema/dropdownProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/dropdownProcessor.ts
@@ -14,7 +14,7 @@ export class DropdownProcessor extends BaseDropdownProcessor {
   process(data: ProcessContext) {
     this.initializeProcessor(data);
 
-    return this.processDropdownChildren(data.profileSchemaEntry);
+    return this.processDropdownChildren(data.profileSchemaEntry, data.selectedEntries);
   }
 
   protected processOptionEntry(optionEntry: SchemaEntry) {

--- a/src/common/services/recordGenerator/processors/profileSchema/flattenedDropdownProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/flattenedDropdownProcessor.ts
@@ -1,6 +1,7 @@
 import { AdvancedFieldType } from '@common/constants/uiControls.constants';
 import { BFLITE_URIS } from '@common/constants/bibframeMapping.constants';
 import { ProcessorResult } from '../../types/profileSchemaProcessor.types';
+import { ProcessContext } from '../../types/common.types';
 import { BaseDropdownProcessor } from './baseDropdownProcessor';
 
 export class FlattenedDropdownProcessor extends BaseDropdownProcessor {
@@ -10,11 +11,11 @@ export class FlattenedDropdownProcessor extends BaseDropdownProcessor {
     );
   }
 
-  process(profileSchemaEntry: SchemaEntry, userValues: UserValues, recordSchemaEntry: RecordSchemaEntry) {
-    this.initializeProcessor(profileSchemaEntry, userValues, recordSchemaEntry);
+  process(data: ProcessContext) {
+    this.initializeProcessor(data);
 
-    const sourceProperty = recordSchemaEntry.options?.sourceProperty ?? BFLITE_URIS.SOURCE;
-    const dropdownResults = this.processDropdownChildren(profileSchemaEntry);
+    const sourceProperty = data.recordSchemaEntry.options?.sourceProperty ?? BFLITE_URIS.SOURCE;
+    const dropdownResults = this.processDropdownChildren(data.profileSchemaEntry);
 
     return dropdownResults.map(result => {
       // Each result is an object with a single key (the URI) and its associated value

--- a/src/common/services/recordGenerator/processors/profileSchema/flattenedDropdownProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/flattenedDropdownProcessor.ts
@@ -15,7 +15,7 @@ export class FlattenedDropdownProcessor extends BaseDropdownProcessor {
     this.initializeProcessor(data);
 
     const sourceProperty = data.recordSchemaEntry.options?.sourceProperty ?? BFLITE_URIS.SOURCE;
-    const dropdownResults = this.processDropdownChildren(data.profileSchemaEntry);
+    const dropdownResults = this.processDropdownChildren(data.profileSchemaEntry, data.selectedEntries);
 
     return dropdownResults.map(result => {
       // Each result is an object with a single key (the URI) and its associated value

--- a/src/common/services/recordGenerator/processors/profileSchema/groupProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/groupProcessor.ts
@@ -3,6 +3,7 @@ import { AdvancedFieldType } from '@common/constants/uiControls.constants';
 import { IProfileSchemaManager } from '../../profileSchemaManager.interface';
 import { ChildEntryWithValues, GeneratedValue, SchemaPropertyValue } from '../../types/value.types';
 import { ProcessorResult } from '../../types/profileSchemaProcessor.types';
+import { ProcessContext } from '../../types/common.types';
 import { BaseFieldProcessor } from './baseFieldProcessor';
 import { GroupValueFormatter } from './formatters';
 
@@ -23,8 +24,8 @@ export class GroupProcessor extends BaseFieldProcessor {
     return entry.value === RecordSchemaEntryType.object;
   }
 
-  process(profileSchemaEntry: SchemaEntry, userValues: UserValues, recordSchemaEntry: RecordSchemaEntry) {
-    this.initializeProcessor(profileSchemaEntry, userValues, recordSchemaEntry);
+  process(data: ProcessContext) {
+    this.initializeProcessor(data);
 
     return this.processGroupWithChildren();
   }

--- a/src/common/services/recordGenerator/processors/profileSchema/lookupProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/lookupProcessor.ts
@@ -1,8 +1,8 @@
 import { AdvancedFieldType } from '@common/constants/uiControls.constants';
 import { RecordSchemaEntryType } from '@common/constants/recordSchema.constants';
 import { GeneratedValue } from '../../types/value.types';
-import { IProfileSchemaProcessor } from './profileSchemaProcessor.interface';
 import { ProcessContext } from '../../types/common.types';
+import { IProfileSchemaProcessor } from './profileSchemaProcessor.interface';
 
 export class LookupProcessor implements IProfileSchemaProcessor {
   canProcess(profileSchemaEntry: SchemaEntry, recordSchemaEntry: RecordSchemaEntry) {

--- a/src/common/services/recordGenerator/processors/profileSchema/lookupProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/lookupProcessor.ts
@@ -2,6 +2,7 @@ import { AdvancedFieldType } from '@common/constants/uiControls.constants';
 import { RecordSchemaEntryType } from '@common/constants/recordSchema.constants';
 import { GeneratedValue } from '../../types/value.types';
 import { IProfileSchemaProcessor } from './profileSchemaProcessor.interface';
+import { ProcessContext } from '../../types/common.types';
 
 export class LookupProcessor implements IProfileSchemaProcessor {
   canProcess(profileSchemaEntry: SchemaEntry, recordSchemaEntry: RecordSchemaEntry) {
@@ -12,7 +13,7 @@ export class LookupProcessor implements IProfileSchemaProcessor {
     );
   }
 
-  process(profileSchemaEntry: SchemaEntry, userValues: UserValues, recordSchemaEntry: RecordSchemaEntry) {
+  process({ profileSchemaEntry, userValues, recordSchemaEntry }: ProcessContext) {
     const values = userValues[profileSchemaEntry.uuid]?.contents || [];
 
     return this.processLookupValues(recordSchemaEntry, values);

--- a/src/common/services/recordGenerator/processors/profileSchema/profileSchemaProcessor.interface.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/profileSchemaProcessor.interface.ts
@@ -1,9 +1,7 @@
+import { ProcessContext } from '../../types/common.types';
+
 export interface IProfileSchemaProcessor {
   canProcess(profileSchemaEntry: SchemaEntry, recordSchemaEntry: RecordSchemaEntry): boolean;
 
-  process(
-    profileSchemaEntry: SchemaEntry,
-    userValues: UserValues,
-    recordSchemaEntry?: RecordSchemaEntry,
-  ): Record<string, any>;
+  process(data: ProcessContext): Record<string, any>;
 }

--- a/src/common/services/recordGenerator/processors/profileSchema/profileSchemaProcessorManager.interface.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/profileSchemaProcessorManager.interface.ts
@@ -1,7 +1,5 @@
+import { ProcessContext } from '../../types/common.types';
+
 export interface IProfileSchemaProcessorManager {
-  process(
-    profileSchemaEntry: SchemaEntry,
-    recordSchemaEntry: RecordSchemaEntry,
-    userValues: UserValues,
-  ): Record<string, any> | never[];
+  process(data: ProcessContext): Record<string, any> | never[];
 }

--- a/src/common/services/recordGenerator/processors/profileSchema/profileSchemaProcessorManager.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/profileSchemaProcessorManager.ts
@@ -6,6 +6,7 @@ import { LookupProcessor } from './lookupProcessor';
 import { FlattenedDropdownProcessor } from './flattenedDropdownProcessor';
 import { IProfileSchemaProcessorManager } from './profileSchemaProcessorManager.interface';
 import { IProfileSchemaManager } from '../../profileSchemaManager.interface';
+import { ProcessContext } from '../../types/common.types';
 
 export class ProfileSchemaProcessorManager implements IProfileSchemaProcessorManager {
   private readonly processors: IProfileSchemaProcessor[];
@@ -20,10 +21,10 @@ export class ProfileSchemaProcessorManager implements IProfileSchemaProcessorMan
     ];
   }
 
-  process(profileSchemaEntry: SchemaEntry, recordSchemaEntry: RecordSchemaEntry, userValues: UserValues) {
+  process(data: ProcessContext) {
     for (const processor of this.processors) {
-      if (processor.canProcess(profileSchemaEntry, recordSchemaEntry)) {
-        return processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      if (processor.canProcess(data.profileSchemaEntry, data.recordSchemaEntry)) {
+        return processor.process(data);
       }
     }
 

--- a/src/common/services/recordGenerator/processors/profileSchema/profileSchemaProcessorManager.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/profileSchemaProcessorManager.ts
@@ -1,3 +1,5 @@
+import { IProfileSchemaManager } from '../../profileSchemaManager.interface';
+import { ProcessContext } from '../../types/common.types';
 import { IProfileSchemaProcessor } from './profileSchemaProcessor.interface';
 import { DropdownProcessor } from './dropdownProcessor';
 import { UnwrappedDropdownOptionProcessor } from './unwrappedDropdownOptionProcessor';
@@ -5,8 +7,6 @@ import { GroupProcessor } from './groupProcessor';
 import { LookupProcessor } from './lookupProcessor';
 import { FlattenedDropdownProcessor } from './flattenedDropdownProcessor';
 import { IProfileSchemaProcessorManager } from './profileSchemaProcessorManager.interface';
-import { IProfileSchemaManager } from '../../profileSchemaManager.interface';
-import { ProcessContext } from '../../types/common.types';
 
 export class ProfileSchemaProcessorManager implements IProfileSchemaProcessorManager {
   private readonly processors: IProfileSchemaProcessor[];

--- a/src/common/services/recordGenerator/processors/profileSchema/unwrappedDropdownOptionProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/unwrappedDropdownOptionProcessor.ts
@@ -1,15 +1,16 @@
 import { AdvancedFieldType } from '@common/constants/uiControls.constants';
 import { BaseDropdownProcessor } from './baseDropdownProcessor';
+import { ProcessContext } from '../../types/common.types';
 
 export class UnwrappedDropdownOptionProcessor extends BaseDropdownProcessor {
   canProcess(profileSchemaEntry: SchemaEntry, recordSchemaEntry: RecordSchemaEntry) {
     return profileSchemaEntry.type === AdvancedFieldType.dropdown && recordSchemaEntry.options?.hiddenWrapper === true;
   }
 
-  process(profileSchemaEntry: SchemaEntry, userValues: UserValues, recordSchemaEntry: RecordSchemaEntry) {
-    this.initializeProcessor(profileSchemaEntry, userValues, recordSchemaEntry);
+  process(data: ProcessContext) {
+    this.initializeProcessor(data);
 
-    return this.processDropdownChildren(profileSchemaEntry);
+    return this.processDropdownChildren(data.profileSchemaEntry);
   }
 
   protected processOptionEntry(optionEntry: SchemaEntry) {

--- a/src/common/services/recordGenerator/processors/profileSchema/unwrappedDropdownOptionProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/unwrappedDropdownOptionProcessor.ts
@@ -1,6 +1,6 @@
 import { AdvancedFieldType } from '@common/constants/uiControls.constants';
-import { BaseDropdownProcessor } from './baseDropdownProcessor';
 import { ProcessContext } from '../../types/common.types';
+import { BaseDropdownProcessor } from './baseDropdownProcessor';
 
 export class UnwrappedDropdownOptionProcessor extends BaseDropdownProcessor {
   canProcess(profileSchemaEntry: SchemaEntry, recordSchemaEntry: RecordSchemaEntry) {

--- a/src/common/services/recordGenerator/processors/profileSchema/unwrappedDropdownOptionProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/unwrappedDropdownOptionProcessor.ts
@@ -10,7 +10,7 @@ export class UnwrappedDropdownOptionProcessor extends BaseDropdownProcessor {
   process(data: ProcessContext) {
     this.initializeProcessor(data);
 
-    return this.processDropdownChildren(data.profileSchemaEntry);
+    return this.processDropdownChildren(data.profileSchemaEntry, data.selectedEntries);
   }
 
   protected processOptionEntry(optionEntry: SchemaEntry) {

--- a/src/common/services/recordGenerator/processors/recordSchema/arrayEntryProcessor.ts
+++ b/src/common/services/recordGenerator/processors/recordSchema/arrayEntryProcessor.ts
@@ -1,9 +1,9 @@
 import { RecordSchemaEntryType } from '@common/constants/recordSchema.constants';
 import { ValueOptions, ValueResult, SchemaPropertyValue } from '../../types/value.types';
+import { ProcessContext } from '../../types/common.types';
 import { IValueProcessor, SchemaValue } from '../value/valueProcessor.interface';
 import { IProfileSchemaProcessorManager } from '../profileSchema/profileSchemaProcessorManager.interface';
 import { IRecordSchemaEntryProcessor } from './recordSchemaProcessor.interface';
-import { ProcessContext } from '../../types/common.types';
 
 export class ArrayEntryProcessor implements IRecordSchemaEntryProcessor {
   constructor(

--- a/src/common/services/recordGenerator/processors/recordSchema/arrayEntryProcessor.ts
+++ b/src/common/services/recordGenerator/processors/recordSchema/arrayEntryProcessor.ts
@@ -2,7 +2,8 @@ import { RecordSchemaEntryType } from '@common/constants/recordSchema.constants'
 import { ValueOptions, ValueResult, SchemaPropertyValue } from '../../types/value.types';
 import { IValueProcessor, SchemaValue } from '../value/valueProcessor.interface';
 import { IProfileSchemaProcessorManager } from '../profileSchema/profileSchemaProcessorManager.interface';
-import { RecordSchemaEntryProcessingContext, IRecordSchemaEntryProcessor } from './recordSchemaProcessor.interface';
+import { IRecordSchemaEntryProcessor } from './recordSchemaProcessor.interface';
+import { ProcessContext } from '../../types/common.types';
 
 export class ArrayEntryProcessor implements IRecordSchemaEntryProcessor {
   constructor(
@@ -14,28 +15,24 @@ export class ArrayEntryProcessor implements IRecordSchemaEntryProcessor {
     return property.type === RecordSchemaEntryType.array;
   }
 
-  process({ recordSchemaEntry, profileSchemaEntry, userValues }: RecordSchemaEntryProcessingContext) {
-    if (!profileSchemaEntry.type) {
+  process(data: ProcessContext) {
+    if (!data.profileSchemaEntry.type) {
       return { value: null, options: {} };
     }
 
-    const processingResult = this.processArrayEntry(recordSchemaEntry, profileSchemaEntry, userValues);
+    const processingResult = this.processArrayEntry(data);
 
-    return this.applyValueContainer(processingResult, recordSchemaEntry.options?.valueContainer);
+    return this.applyValueContainer(processingResult, data.recordSchemaEntry.options?.valueContainer);
   }
 
-  private processArrayEntry(
-    recordSchemaEntry: RecordSchemaEntry,
-    profileSchemaEntry: SchemaEntry,
-    userValues: UserValues,
-  ) {
+  private processArrayEntry({ recordSchemaEntry, profileSchemaEntry, userValues, selectedEntries }: ProcessContext) {
     const options = {
       hiddenWrapper: recordSchemaEntry.options?.hiddenWrapper ?? false,
     };
 
     return recordSchemaEntry.value === RecordSchemaEntryType.string
       ? this.processStringArrayValues(profileSchemaEntry, userValues, options)
-      : this.processSchemaArrayValues(profileSchemaEntry, recordSchemaEntry, userValues, options);
+      : this.processSchemaArrayValues(profileSchemaEntry, recordSchemaEntry, userValues, selectedEntries, options);
   }
 
   private processStringArrayValues(profileSchemaEntry: SchemaEntry, userValues: UserValues, options: ValueOptions) {
@@ -48,13 +45,15 @@ export class ArrayEntryProcessor implements IRecordSchemaEntryProcessor {
     profileSchemaEntry: SchemaEntry,
     recordSchemaEntry: RecordSchemaEntry,
     userValues: UserValues,
+    selectedEntries: string[],
     options: ValueOptions,
   ): ValueResult {
-    const processedValues = this.profileSchemaProcessorManager.process(
+    const processedValues = this.profileSchemaProcessorManager.process({
       profileSchemaEntry,
       recordSchemaEntry,
       userValues,
-    );
+      selectedEntries,
+    });
 
     const result = this.valueProcessor.processSchemaValues(processedValues as Record<string, SchemaValue>, options);
 

--- a/src/common/services/recordGenerator/processors/recordSchema/objectEntryProcessor.ts
+++ b/src/common/services/recordGenerator/processors/recordSchema/objectEntryProcessor.ts
@@ -1,10 +1,10 @@
 import { RecordSchemaEntryType } from '@common/constants/recordSchema.constants';
 import { GeneratedValue, ValueOptions, ValueResult, SchemaPropertyValue } from '../../types/value.types';
+import { ProcessContext } from '../../types/common.types';
 import { IProfileSchemaManager } from '../../profileSchemaManager.interface';
 import { IValueProcessor, SchemaValue } from '../value/valueProcessor.interface';
 import { IRecordSchemaEntryManager } from './recordSchemaEntryManager.interface';
 import { IRecordSchemaEntryProcessor } from './recordSchemaProcessor.interface';
-import { ProcessContext } from '../../types/common.types';
 
 export class ObjectEntryProcessor implements IRecordSchemaEntryProcessor {
   constructor(
@@ -36,7 +36,14 @@ export class ObjectEntryProcessor implements IRecordSchemaEntryProcessor {
     const parentPath = profileSchemaEntry ? profileSchemaEntry.path : undefined;
 
     Object.entries(recordSchemaEntry.properties).forEach(([key, childProperty]) => {
-      this.processObjectProperty(key, childProperty, result, parentPath, userValues, selectedEntries);
+      this.processObjectProperty({
+        key,
+        recordSchemaEntry: childProperty,
+        result,
+        parentPath,
+        userValues,
+        selectedEntries,
+      });
     });
 
     const processedResult = this.valueProcessor.processSchemaValues(
@@ -51,14 +58,21 @@ export class ObjectEntryProcessor implements IRecordSchemaEntryProcessor {
     };
   }
 
-  private processObjectProperty(
-    key: string,
-    recordSchemaEntry: RecordSchemaEntry,
-    result: GeneratedValue,
-    parentPath: string[] | undefined,
-    userValues: UserValues,
-    selectedEntries: string[],
-  ) {
+  private processObjectProperty({
+    key,
+    recordSchemaEntry,
+    result,
+    parentPath,
+    userValues,
+    selectedEntries,
+  }: {
+    key: string;
+    recordSchemaEntry: RecordSchemaEntry;
+    result: GeneratedValue;
+    parentPath?: string[];
+    userValues: UserValues;
+    selectedEntries: string[];
+  }) {
     const localParentPath = parentPath ? [...parentPath] : undefined;
     const childEntries = this.profileSchemaManager.findSchemaEntriesByUriBFLite(key, localParentPath);
 

--- a/src/common/services/recordGenerator/processors/recordSchema/objectEntryProcessor.ts
+++ b/src/common/services/recordGenerator/processors/recordSchema/objectEntryProcessor.ts
@@ -3,7 +3,8 @@ import { GeneratedValue, ValueOptions, ValueResult, SchemaPropertyValue } from '
 import { IProfileSchemaManager } from '../../profileSchemaManager.interface';
 import { IValueProcessor, SchemaValue } from '../value/valueProcessor.interface';
 import { IRecordSchemaEntryManager } from './recordSchemaEntryManager.interface';
-import { RecordSchemaEntryProcessingContext, IRecordSchemaEntryProcessor } from './recordSchemaProcessor.interface';
+import { IRecordSchemaEntryProcessor } from './recordSchemaProcessor.interface';
+import { ProcessContext } from '../../types/common.types';
 
 export class ObjectEntryProcessor implements IRecordSchemaEntryProcessor {
   constructor(
@@ -16,7 +17,7 @@ export class ObjectEntryProcessor implements IRecordSchemaEntryProcessor {
     return recordSchemaEntry.type === RecordSchemaEntryType.object && !!recordSchemaEntry.properties;
   }
 
-  process({ recordSchemaEntry, profileSchemaEntry, userValues }: RecordSchemaEntryProcessingContext): ValueResult {
+  process({ recordSchemaEntry, profileSchemaEntry, userValues, selectedEntries }: ProcessContext): ValueResult {
     const options: ValueOptions = {
       hiddenWrapper: recordSchemaEntry.options?.hiddenWrapper ?? false,
     };
@@ -35,7 +36,7 @@ export class ObjectEntryProcessor implements IRecordSchemaEntryProcessor {
     const parentPath = profileSchemaEntry ? profileSchemaEntry.path : undefined;
 
     Object.entries(recordSchemaEntry.properties).forEach(([key, childProperty]) => {
-      this.processObjectProperty(key, childProperty, result, parentPath, userValues);
+      this.processObjectProperty(key, childProperty, result, parentPath, userValues, selectedEntries);
     });
 
     const processedResult = this.valueProcessor.processSchemaValues(
@@ -56,6 +57,7 @@ export class ObjectEntryProcessor implements IRecordSchemaEntryProcessor {
     result: GeneratedValue,
     parentPath: string[] | undefined,
     userValues: UserValues,
+    selectedEntries: string[],
   ) {
     const localParentPath = parentPath ? [...parentPath] : undefined;
     const childEntries = this.profileSchemaManager.findSchemaEntriesByUriBFLite(key, localParentPath);
@@ -65,6 +67,7 @@ export class ObjectEntryProcessor implements IRecordSchemaEntryProcessor {
         recordSchemaEntry,
         userValues,
         profileSchemaEntry: childEntry,
+        selectedEntries,
       });
 
       if (!childResult.value) return;

--- a/src/common/services/recordGenerator/processors/recordSchema/recordSchemaEntryManager.interface.ts
+++ b/src/common/services/recordGenerator/processors/recordSchema/recordSchemaEntryManager.interface.ts
@@ -1,11 +1,6 @@
+import { ProcessContext } from '../../types/common.types';
 import { ValueResult } from '../../types/value.types';
 
-export interface IProcessEntryProps {
-  recordSchemaEntry: RecordSchemaEntry;
-  profileSchemaEntry: SchemaEntry;
-  userValues: UserValues;
-}
-
 export interface IRecordSchemaEntryManager {
-  processEntry({ recordSchemaEntry, profileSchemaEntry, userValues }: IProcessEntryProps): ValueResult;
+  processEntry(data: ProcessContext): ValueResult;
 }

--- a/src/common/services/recordGenerator/processors/recordSchema/recordSchemaEntryManager.ts
+++ b/src/common/services/recordGenerator/processors/recordSchema/recordSchemaEntryManager.ts
@@ -2,10 +2,11 @@ import { IProfileSchemaManager } from '../../profileSchemaManager.interface';
 import { IProfileSchemaProcessorManager } from '../profileSchema/profileSchemaProcessorManager.interface';
 import { IValueProcessor } from '../value/valueProcessor.interface';
 import { IRecordSchemaEntryProcessor } from './recordSchemaProcessor.interface';
-import { IProcessEntryProps, IRecordSchemaEntryManager } from './recordSchemaEntryManager.interface';
+import { IRecordSchemaEntryManager } from './recordSchemaEntryManager.interface';
 import { ArrayEntryProcessor } from './arrayEntryProcessor';
 import { ObjectEntryProcessor } from './objectEntryProcessor';
 import { SimpleEntryProcessor } from './simpleEntryProcessor';
+import { ProcessContext } from '../../types/common.types';
 
 export class RecordSchemaEntryManager implements IRecordSchemaEntryManager {
   private readonly processors: IRecordSchemaEntryProcessor[] = [];
@@ -26,10 +27,10 @@ export class RecordSchemaEntryManager implements IRecordSchemaEntryManager {
     );
   }
 
-  processEntry({ recordSchemaEntry, profileSchemaEntry, userValues }: IProcessEntryProps) {
+  processEntry({ recordSchemaEntry, profileSchemaEntry, userValues, selectedEntries }: ProcessContext) {
     const processor = this.getProcessorForEntry(recordSchemaEntry);
 
-    return processor.process({ recordSchemaEntry, profileSchemaEntry, userValues });
+    return processor.process({ recordSchemaEntry, profileSchemaEntry, userValues, selectedEntries });
   }
 
   private getProcessorForEntry(recordSchemaEntry: RecordSchemaEntry) {

--- a/src/common/services/recordGenerator/processors/recordSchema/recordSchemaEntryManager.ts
+++ b/src/common/services/recordGenerator/processors/recordSchema/recordSchemaEntryManager.ts
@@ -1,4 +1,5 @@
 import { IProfileSchemaManager } from '../../profileSchemaManager.interface';
+import { ProcessContext } from '../../types/common.types';
 import { IProfileSchemaProcessorManager } from '../profileSchema/profileSchemaProcessorManager.interface';
 import { IValueProcessor } from '../value/valueProcessor.interface';
 import { IRecordSchemaEntryProcessor } from './recordSchemaProcessor.interface';
@@ -6,7 +7,6 @@ import { IRecordSchemaEntryManager } from './recordSchemaEntryManager.interface'
 import { ArrayEntryProcessor } from './arrayEntryProcessor';
 import { ObjectEntryProcessor } from './objectEntryProcessor';
 import { SimpleEntryProcessor } from './simpleEntryProcessor';
-import { ProcessContext } from '../../types/common.types';
 
 export class RecordSchemaEntryManager implements IRecordSchemaEntryManager {
   private readonly processors: IRecordSchemaEntryProcessor[] = [];
@@ -27,10 +27,10 @@ export class RecordSchemaEntryManager implements IRecordSchemaEntryManager {
     );
   }
 
-  processEntry({ recordSchemaEntry, profileSchemaEntry, userValues, selectedEntries }: ProcessContext) {
-    const processor = this.getProcessorForEntry(recordSchemaEntry);
+  processEntry(data: ProcessContext) {
+    const processor = this.getProcessorForEntry(data.recordSchemaEntry);
 
-    return processor.process({ recordSchemaEntry, profileSchemaEntry, userValues, selectedEntries });
+    return processor.process(data);
   }
 
   private getProcessorForEntry(recordSchemaEntry: RecordSchemaEntry) {

--- a/src/common/services/recordGenerator/processors/recordSchema/recordSchemaProcessor.interface.ts
+++ b/src/common/services/recordGenerator/processors/recordSchema/recordSchemaProcessor.interface.ts
@@ -1,13 +1,8 @@
+import { ProcessContext } from '../../types/common.types';
 import { ValueResult } from '../../types/value.types';
-
-export type RecordSchemaEntryProcessingContext = {
-  recordSchemaEntry: RecordSchemaEntry;
-  profileSchemaEntry: SchemaEntry;
-  userValues: UserValues;
-};
 
 export interface IRecordSchemaEntryProcessor {
   canProcess(recordSchemaEntry: RecordSchemaEntry): boolean;
 
-  process(recordSchemaEntryProcessingContext: RecordSchemaEntryProcessingContext): ValueResult;
+  process(recordSchemaEntryProcessingContext: ProcessContext): ValueResult;
 }

--- a/src/common/services/recordGenerator/processors/recordSchema/simpleEntryProcessor.ts
+++ b/src/common/services/recordGenerator/processors/recordSchema/simpleEntryProcessor.ts
@@ -1,7 +1,8 @@
 import { RecordSchemaEntryType } from '@common/constants/recordSchema.constants';
 import { ValueOptions } from '../../types/value.types';
 import { IValueProcessor } from '../value/valueProcessor.interface';
-import { RecordSchemaEntryProcessingContext, IRecordSchemaEntryProcessor } from './recordSchemaProcessor.interface';
+import { IRecordSchemaEntryProcessor } from './recordSchemaProcessor.interface';
+import { ProcessContext } from '../../types/common.types';
 
 export class SimpleEntryProcessor implements IRecordSchemaEntryProcessor {
   constructor(private readonly valueProcessor: IValueProcessor) {}
@@ -12,7 +13,7 @@ export class SimpleEntryProcessor implements IRecordSchemaEntryProcessor {
     );
   }
 
-  process({ recordSchemaEntry, profileSchemaEntry, userValues }: RecordSchemaEntryProcessingContext) {
+  process({ recordSchemaEntry, profileSchemaEntry, userValues }: ProcessContext) {
     const options: ValueOptions = {
       hiddenWrapper: recordSchemaEntry.options?.hiddenWrapper ?? false,
     };

--- a/src/common/services/recordGenerator/processors/recordSchema/simpleEntryProcessor.ts
+++ b/src/common/services/recordGenerator/processors/recordSchema/simpleEntryProcessor.ts
@@ -1,8 +1,8 @@
 import { RecordSchemaEntryType } from '@common/constants/recordSchema.constants';
 import { ValueOptions } from '../../types/value.types';
+import { ProcessContext } from '../../types/common.types';
 import { IValueProcessor } from '../value/valueProcessor.interface';
 import { IRecordSchemaEntryProcessor } from './recordSchemaProcessor.interface';
-import { ProcessContext } from '../../types/common.types';
 
 export class SimpleEntryProcessor implements IRecordSchemaEntryProcessor {
   constructor(private readonly valueProcessor: IValueProcessor) {}

--- a/src/common/services/recordGenerator/recordGenerator.interface.ts
+++ b/src/common/services/recordGenerator/recordGenerator.interface.ts
@@ -1,6 +1,7 @@
 export interface IRecordGeneratorData {
   schema: Schema;
   userValues: UserValues;
+  selectedEntries: string[];
   referenceIds?: { id: string }[];
 }
 

--- a/src/common/services/recordGenerator/recordGenerator.ts
+++ b/src/common/services/recordGenerator/recordGenerator.ts
@@ -15,6 +15,7 @@ export class RecordGenerator implements IRecordGenerator {
   private readonly recordSchemaEntryManager: IRecordSchemaEntryManager;
   private recordSchema: RecordSchema;
   private userValues: UserValues;
+  private selectedEntries: string[];
   private referenceIds?: { id: string }[];
 
   constructor() {
@@ -30,6 +31,7 @@ export class RecordGenerator implements IRecordGenerator {
 
     this.recordSchema = {};
     this.userValues = {};
+    this.selectedEntries = [];
   }
 
   generate(data: IRecordGeneratorData, profileType: ProfileType = 'Monograph', entityType: ResourceType = 'work') {
@@ -54,11 +56,13 @@ export class RecordGenerator implements IRecordGenerator {
     schema,
     recordSchema,
     userValues,
+    selectedEntries,
     referenceIds,
   }: IRecordGeneratorData & { recordSchema: RecordSchema }) {
     this.profileSchemaManager.init(schema);
     this.recordSchema = recordSchema;
     this.userValues = userValues;
+    this.selectedEntries = selectedEntries;
     this.referenceIds = referenceIds;
   }
 
@@ -90,6 +94,7 @@ export class RecordGenerator implements IRecordGenerator {
             recordSchemaEntry: rootProperty,
             profileSchemaEntry: entry,
             userValues: this.userValues,
+            selectedEntries: this.selectedEntries,
           }).value,
       )
       .filter((value): value is SchemaPropertyValue => value !== null);

--- a/src/common/services/recordGenerator/types/common.types.ts
+++ b/src/common/services/recordGenerator/types/common.types.ts
@@ -1,0 +1,6 @@
+export interface ProcessContext {
+  profileSchemaEntry: SchemaEntry;
+  userValues: UserValues;
+  selectedEntries: string[];
+  recordSchemaEntry: RecordSchemaEntry;
+}

--- a/src/test/__tests__/common/hooks/useRecordGeneration.test.ts
+++ b/src/test/__tests__/common/hooks/useRecordGeneration.test.ts
@@ -9,6 +9,7 @@ describe('useRecordGeneration', () => {
   it('generates a record using new service', () => {
     const schema = 'mockSchema';
     const userValues = 'mockUserValues';
+    const selectedEntries: string[] = [];
     const selectedProfile = { id: 'monograph' };
 
     const searchParams = new URLSearchParams('?block=testBlock&reference.key=testKey');
@@ -26,6 +27,7 @@ describe('useRecordGeneration', () => {
         store: useInputsStore,
         state: {
           userValues,
+          selectedEntries,
           record: {
             resource: {
               testBlock: {
@@ -42,7 +44,7 @@ describe('useRecordGeneration', () => {
     result.current.generateRecord();
 
     expect(recordGeneratorService.generate).toHaveBeenCalledWith(
-      { schema, userValues, referenceIds: undefined },
+      { schema, userValues, selectedEntries, referenceIds: undefined },
       'Monograph',
       'work',
     );

--- a/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/dropdownProcessor.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/dropdownProcessor.test.ts
@@ -104,12 +104,13 @@ describe('DropdownProcessor', () => {
         uuid: 'dropdown_uuid',
         children: undefined,
       } as SchemaEntry;
-      const userValues = {} as UserValues;
+      const userValues: UserValues = {};
+      const selectedEntries: string[] = [];
       const recordSchemaEntry = {
         type: RecordSchemaEntryType.object,
       };
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
     });
@@ -120,14 +121,15 @@ describe('DropdownProcessor', () => {
         uuid: 'dropdown_uuid',
         children: ['option_1_uuid', 'option_2_uuid'],
       } as SchemaEntry;
-      const userValues = {} as UserValues;
+      const userValues: UserValues = {};
+      const selectedEntries: string[] = [];
       const recordSchemaEntry = {
         type: RecordSchemaEntryType.object,
       };
 
       mockProfileSchemaManager.getSchemaEntry.mockReturnValue(undefined);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
       expect(mockProfileSchemaManager.getSchemaEntry).toHaveBeenCalledWith('option_1_uuid');
@@ -145,7 +147,8 @@ describe('DropdownProcessor', () => {
         uriBFLite: 'option_1',
         children: undefined,
       } as SchemaEntry;
-      const userValues = {} as UserValues;
+      const userValues: UserValues = {};
+      const selectedEntries: string[] = [];
       const recordSchemaEntry = {
         type: RecordSchemaEntryType.object,
       } as RecordSchemaEntry;
@@ -153,7 +156,7 @@ describe('DropdownProcessor', () => {
       mockProfileSchemaManager.getSchemaEntry.mockReturnValue(optionEntry);
       mockProfileSchemaManager.hasOptionValues.mockReturnValue(false);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
       expect(mockProfileSchemaManager.getSchemaEntry).toHaveBeenCalledWith('option_1_uuid');
@@ -170,7 +173,8 @@ describe('DropdownProcessor', () => {
         uriBFLite: undefined,
         children: ['child_1_uuid'],
       } as SchemaEntry;
-      const userValues = {} as UserValues;
+      const userValues: UserValues = {};
+      const selectedEntries = ['option_1_uuid'];
       const recordSchemaEntry = {
         type: RecordSchemaEntryType.object,
       };
@@ -178,7 +182,7 @@ describe('DropdownProcessor', () => {
       mockProfileSchemaManager.getSchemaEntry.mockReturnValue(optionEntry);
       mockProfileSchemaManager.hasOptionValues.mockReturnValue(true);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
       expect(mockProfileSchemaManager.getSchemaEntry).toHaveBeenCalledWith('option_1_uuid');
@@ -207,6 +211,7 @@ describe('DropdownProcessor', () => {
           contents: [{ label: 'child value' }],
         },
       } as unknown as UserValues;
+      const selectedEntries = ['option_1_uuid'];
       const recordSchemaEntry = {
         type: RecordSchemaEntryType.object,
         properties: {
@@ -222,7 +227,7 @@ describe('DropdownProcessor', () => {
       mockProfileSchemaManager.getSchemaEntry.mockReturnValueOnce(optionEntry).mockReturnValueOnce(childEntry);
       mockProfileSchemaManager.hasOptionValues.mockReturnValue(true);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([{ option_1: { child_1: ['child value'] } }]);
       expect(mockProfileSchemaManager.getSchemaEntry).toHaveBeenCalledWith('option_1_uuid');
@@ -257,6 +262,7 @@ describe('DropdownProcessor', () => {
           contents: [{ label: 'child value' }],
         },
       } as unknown as UserValues;
+      const selectedEntries = ['option_1_uuid', 'option_2_uuid'];
       const recordSchemaEntry = {
         type: RecordSchemaEntryType.object,
         properties: {
@@ -283,7 +289,7 @@ describe('DropdownProcessor', () => {
       });
       mockProfileSchemaManager.hasOptionValues.mockImplementation(entry => entry.uuid === 'option_1_uuid');
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([{ option_1: { child_1: ['child value'] } }]);
       expect(mockProfileSchemaManager.getSchemaEntry).toHaveBeenCalledWith('option_1_uuid');
@@ -315,6 +321,7 @@ describe('DropdownProcessor', () => {
           contents: [{ label: 'child value' }],
         },
       } as unknown as UserValues;
+      const selectedEntries = ['option_1_uuid'];
       const childRecordSchemaEntry = { type: RecordSchemaEntryType.string };
       const recordSchemaEntry = {
         type: RecordSchemaEntryType.object,
@@ -332,17 +339,18 @@ describe('DropdownProcessor', () => {
       mockProfileSchemaManager.hasOptionValues.mockReturnValue(true);
       mockProfileSchemaProcessorManager.process.mockReturnValue(['processed value']);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([{ option_1: { child_1: ['processed value'] } }]);
       expect(mockProfileSchemaManager.getSchemaEntry).toHaveBeenCalledWith('option_1_uuid');
       expect(mockProfileSchemaManager.getSchemaEntry).toHaveBeenCalledWith('child_1_uuid');
       expect(mockProfileSchemaManager.hasOptionValues).toHaveBeenCalledWith(optionEntry, userValues);
-      expect(mockProfileSchemaProcessorManager.process).toHaveBeenCalledWith(
-        childEntry,
-        childRecordSchemaEntry,
+      expect(mockProfileSchemaProcessorManager.process).toHaveBeenCalledWith({
+        profileSchemaEntry: childEntry,
+        recordSchemaEntry: childRecordSchemaEntry,
         userValues,
-      );
+        selectedEntries,
+      });
     });
   });
 });

--- a/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/flattenedDropdownProcessor.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/flattenedDropdownProcessor.test.ts
@@ -98,6 +98,7 @@ describe('FlattenedDropdownProcessor', () => {
         children: undefined,
       } as SchemaEntry;
       const userValues = {} as UserValues;
+      const selectedEntries: string[] = [];
       const recordSchemaEntry = {
         type: RecordSchemaEntryType.object,
         options: {
@@ -105,7 +106,7 @@ describe('FlattenedDropdownProcessor', () => {
         },
       };
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
     });
@@ -117,6 +118,7 @@ describe('FlattenedDropdownProcessor', () => {
         children: ['option_1_uuid', 'option_2_uuid'],
       } as SchemaEntry;
       const userValues = {} as UserValues;
+      const selectedEntries: string[] = ['option_1_uuid', 'option_2_uuid'];
       const recordSchemaEntry = {
         type: RecordSchemaEntryType.object,
         options: {
@@ -140,7 +142,7 @@ describe('FlattenedDropdownProcessor', () => {
 
       mockProfileSchemaManager.hasOptionValues.mockReturnValue(false);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
     });
@@ -156,6 +158,7 @@ describe('FlattenedDropdownProcessor', () => {
           contents: [{ label: 'test value' }],
         },
       } as unknown as UserValues;
+      const selectedEntries = ['option_1_uuid'];
       const recordSchemaEntry = {
         type: RecordSchemaEntryType.object,
         options: {
@@ -185,7 +188,7 @@ describe('FlattenedDropdownProcessor', () => {
 
       mockProfileSchemaManager.hasOptionValues.mockReturnValue(true);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([
         {
@@ -206,6 +209,7 @@ describe('FlattenedDropdownProcessor', () => {
           contents: [{ label: 'test value' }],
         },
       } as unknown as UserValues;
+      const selectedEntries = ['option_1_uuid'];
       const recordSchemaEntry = {
         type: RecordSchemaEntryType.object,
         options: {
@@ -236,7 +240,7 @@ describe('FlattenedDropdownProcessor', () => {
 
       mockProfileSchemaManager.hasOptionValues.mockReturnValue(true);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([
         {

--- a/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/groupProcessor.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/groupProcessor.test.ts
@@ -8,10 +8,12 @@ jest.mock('@common/services/recordGenerator/profileSchemaManager');
 describe('GroupProcessor', () => {
   let processor: GroupProcessor;
   let mockProfileSchemaManager: jest.Mocked<ProfileSchemaManager>;
+  let selectedEntries: string[];
 
   beforeEach(() => {
     mockProfileSchemaManager = new ProfileSchemaManager() as jest.Mocked<ProfileSchemaManager>;
     processor = new GroupProcessor(mockProfileSchemaManager);
+    selectedEntries = [];
   });
 
   describe('canProcess', () => {
@@ -91,7 +93,7 @@ describe('GroupProcessor', () => {
         },
       } as RecordSchemaEntry;
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
     });
@@ -108,7 +110,7 @@ describe('GroupProcessor', () => {
         value: RecordSchemaEntryType.object,
       } as RecordSchemaEntry;
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
     });
@@ -140,7 +142,7 @@ describe('GroupProcessor', () => {
           uriBFLite: 'uri_2',
         } as SchemaEntry);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
     });
@@ -170,7 +172,7 @@ describe('GroupProcessor', () => {
         uriBFLite: 'uri_1',
       } as SchemaEntry);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([{ uri_1: ['test value'] }]);
     });
@@ -200,7 +202,7 @@ describe('GroupProcessor', () => {
         uriBFLite: 'uri_1',
       } as SchemaEntry);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([{ uri_1: ['test_uri'] }]);
     });
@@ -230,7 +232,7 @@ describe('GroupProcessor', () => {
         uriBFLite: 'uri_1',
       } as SchemaEntry);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([{ srsId: 'test_srs_id' }]);
     });
@@ -260,7 +262,7 @@ describe('GroupProcessor', () => {
         uriBFLite: 'uri_1',
       } as SchemaEntry);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([{ id: 'test_id' }]);
     });
@@ -309,7 +311,7 @@ describe('GroupProcessor', () => {
           uriBFLite: 'uri_3',
         } as SchemaEntry);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([
         {
@@ -345,7 +347,7 @@ describe('GroupProcessor', () => {
         uriBFLite: 'uri_1',
       } as SchemaEntry);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([{ uri_1: ['value 1', 'value 2'] }]);
     });
@@ -385,7 +387,7 @@ describe('GroupProcessor', () => {
           uriBFLite: 'uri_2',
         } as SchemaEntry);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([
         {
@@ -430,7 +432,7 @@ describe('GroupProcessor', () => {
           uriBFLite: 'uri_2',
         } as SchemaEntry);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([{ uri_1: ['valid value'] }]);
     });
@@ -469,7 +471,7 @@ describe('GroupProcessor', () => {
           uriBFLite: 'uri_2',
         } as SchemaEntry);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([{ uri_1: ['value 1'] }]);
     });
@@ -499,7 +501,7 @@ describe('GroupProcessor', () => {
         uriBFLite: 'uri_1',
       } as SchemaEntry);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
     });
@@ -536,7 +538,7 @@ describe('GroupProcessor', () => {
         uriBFLite: 'uri_1',
       } as SchemaEntry);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([{ uri_1: ['mapped_key'] }]);
     });

--- a/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/lookupProcessor.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/lookupProcessor.test.ts
@@ -4,9 +4,11 @@ import { LookupProcessor } from '@common/services/recordGenerator/processors/pro
 
 describe('LookupProcessor', () => {
   let processor: LookupProcessor;
+  let selectedEntries: string[];
 
   beforeEach(() => {
     processor = new LookupProcessor();
+    selectedEntries = [];
   });
 
   describe('canProcess', () => {
@@ -95,7 +97,7 @@ describe('LookupProcessor', () => {
       } as SchemaEntry;
       const userValues = {} as UserValues;
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
     });
@@ -116,7 +118,7 @@ describe('LookupProcessor', () => {
         },
       } as unknown as UserValues;
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
     });
@@ -146,7 +148,7 @@ describe('LookupProcessor', () => {
         },
       } as unknown as UserValues;
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([
         {
@@ -181,7 +183,7 @@ describe('LookupProcessor', () => {
         },
       } as unknown as UserValues;
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([
         {
@@ -214,7 +216,7 @@ describe('LookupProcessor', () => {
         },
       } as unknown as UserValues;
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([
         {
@@ -245,7 +247,7 @@ describe('LookupProcessor', () => {
         },
       } as unknown as UserValues;
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([
         {
@@ -277,7 +279,7 @@ describe('LookupProcessor', () => {
         },
       } as unknown as UserValues;
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([
         {
@@ -308,7 +310,7 @@ describe('LookupProcessor', () => {
         },
       } as unknown as UserValues;
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([
         {
@@ -353,7 +355,7 @@ describe('LookupProcessor', () => {
         },
       } as unknown as UserValues;
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([
         {

--- a/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/profileSchemaProcessorManager.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/profileSchemaProcessorManager.test.ts
@@ -91,6 +91,7 @@ describe('ProfileSchemaProcessorManager', () => {
     let mockProfileSchemaEntry: SchemaEntry;
     let mockRecordSchemaEntry: RecordSchemaEntry;
     let mockUserValues: UserValues;
+    let mockSelectedEntries: string[];
     let expectedResult: any[];
 
     beforeEach(() => {
@@ -106,6 +107,7 @@ describe('ProfileSchemaProcessorManager', () => {
           contents: [{ label: 'test value' }],
         },
       } as unknown as UserValues;
+      mockSelectedEntries = [];
       expectedResult = [{ value: 'processed value' }];
     });
 
@@ -117,18 +119,24 @@ describe('ProfileSchemaProcessorManager', () => {
       mockUnwrappedDropdownOptionProcessor.canProcess.mockReturnValue(true);
       mockLookupProcessor.canProcess.mockReturnValue(true);
 
-      const result = manager.process(mockProfileSchemaEntry, mockRecordSchemaEntry, mockUserValues);
+      const result = manager.process({
+        profileSchemaEntry: mockProfileSchemaEntry,
+        recordSchemaEntry: mockRecordSchemaEntry,
+        userValues: mockUserValues,
+        selectedEntries: mockSelectedEntries,
+      });
 
       expect(mockGroupProcessor.canProcess).toHaveBeenCalledWith(mockProfileSchemaEntry, mockRecordSchemaEntry);
       expect(mockFlattenedDropdownProcessor.canProcess).toHaveBeenCalledWith(
         mockProfileSchemaEntry,
         mockRecordSchemaEntry,
       );
-      expect(mockFlattenedDropdownProcessor.process).toHaveBeenCalledWith(
-        mockProfileSchemaEntry,
-        mockUserValues,
-        mockRecordSchemaEntry,
-      );
+      expect(mockFlattenedDropdownProcessor.process).toHaveBeenCalledWith({
+        profileSchemaEntry: mockProfileSchemaEntry,
+        userValues: mockUserValues,
+        selectedEntries: mockSelectedEntries,
+        recordSchemaEntry: mockRecordSchemaEntry,
+      });
       expect(mockDropdownProcessor.canProcess).not.toHaveBeenCalled();
       expect(mockUnwrappedDropdownOptionProcessor.canProcess).not.toHaveBeenCalled();
       expect(mockLookupProcessor.canProcess).not.toHaveBeenCalled();
@@ -142,7 +150,12 @@ describe('ProfileSchemaProcessorManager', () => {
       mockUnwrappedDropdownOptionProcessor.canProcess.mockReturnValue(false);
       mockLookupProcessor.canProcess.mockReturnValue(false);
 
-      const result = manager.process(mockProfileSchemaEntry, mockRecordSchemaEntry, mockUserValues);
+      const result = manager.process({
+        profileSchemaEntry: mockProfileSchemaEntry,
+        recordSchemaEntry: mockRecordSchemaEntry,
+        userValues: mockUserValues,
+        selectedEntries: mockSelectedEntries,
+      });
 
       expect(mockGroupProcessor.canProcess).toHaveBeenCalledWith(mockProfileSchemaEntry, mockRecordSchemaEntry);
       expect(mockFlattenedDropdownProcessor.canProcess).toHaveBeenCalledWith(
@@ -166,7 +179,12 @@ describe('ProfileSchemaProcessorManager', () => {
       mockLookupProcessor.canProcess.mockReturnValue(true);
       mockLookupProcessor.process.mockReturnValue(expectedResult);
 
-      const result = manager.process(mockProfileSchemaEntry, mockRecordSchemaEntry, mockUserValues);
+      const result = manager.process({
+        profileSchemaEntry: mockProfileSchemaEntry,
+        recordSchemaEntry: mockRecordSchemaEntry,
+        userValues: mockUserValues,
+        selectedEntries: mockSelectedEntries,
+      });
 
       expect(mockGroupProcessor.canProcess).toHaveBeenCalledWith(mockProfileSchemaEntry, mockRecordSchemaEntry);
       expect(mockFlattenedDropdownProcessor.canProcess).toHaveBeenCalledWith(
@@ -179,11 +197,12 @@ describe('ProfileSchemaProcessorManager', () => {
         mockRecordSchemaEntry,
       );
       expect(mockLookupProcessor.canProcess).toHaveBeenCalledWith(mockProfileSchemaEntry, mockRecordSchemaEntry);
-      expect(mockLookupProcessor.process).toHaveBeenCalledWith(
-        mockProfileSchemaEntry,
-        mockUserValues,
-        mockRecordSchemaEntry,
-      );
+      expect(mockLookupProcessor.process).toHaveBeenCalledWith({
+        profileSchemaEntry: mockProfileSchemaEntry,
+        userValues: mockUserValues,
+        selectedEntries: mockSelectedEntries,
+        recordSchemaEntry: mockRecordSchemaEntry,
+      });
       expect(result).toEqual(expectedResult);
     });
   });

--- a/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/unwrappedDropdownOptionProcessor.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/unwrappedDropdownOptionProcessor.test.ts
@@ -11,6 +11,7 @@ describe('UnwrappedDropdownOptionProcessor', () => {
   let processor: UnwrappedDropdownOptionProcessor;
   let mockProfileSchemaManager: jest.Mocked<ProfileSchemaManager>;
   let mockProfileSchemaProcessorManager: jest.Mocked<ProfileSchemaProcessorManager>;
+  let selectedEntries: string[];
 
   beforeEach(() => {
     mockProfileSchemaManager = new ProfileSchemaManager() as jest.Mocked<ProfileSchemaManager>;
@@ -18,6 +19,7 @@ describe('UnwrappedDropdownOptionProcessor', () => {
       mockProfileSchemaManager,
     ) as jest.Mocked<ProfileSchemaProcessorManager>;
     processor = new UnwrappedDropdownOptionProcessor(mockProfileSchemaManager, mockProfileSchemaProcessorManager);
+    selectedEntries = [];
   });
 
   describe('canProcess', () => {
@@ -97,7 +99,7 @@ describe('UnwrappedDropdownOptionProcessor', () => {
       };
       const userValues = {};
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
     });
@@ -118,7 +120,7 @@ describe('UnwrappedDropdownOptionProcessor', () => {
       mockProfileSchemaManager.getSchemaEntry.mockReturnValue(undefined);
       mockProfileSchemaManager.hasOptionValues.mockReturnValue(false);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
       expect(mockProfileSchemaManager.getSchemaEntry).toHaveBeenCalledWith('option_1');
@@ -150,13 +152,14 @@ describe('UnwrappedDropdownOptionProcessor', () => {
         },
       };
       const userValues = {};
+      selectedEntries = ['option_1'];
 
       mockProfileSchemaManager.getSchemaEntry
         .mockReturnValueOnce(optionEntry)
         .mockReturnValueOnce({ uuid: 'child_1', uriBFLite: 'child_uri' } as SchemaEntry);
       mockProfileSchemaManager.hasOptionValues.mockReturnValue(true);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
       expect(mockProfileSchemaManager.getSchemaEntry).toHaveBeenCalledWith('option_1');
@@ -190,11 +193,12 @@ describe('UnwrappedDropdownOptionProcessor', () => {
         },
       };
       const userValues = {};
+      selectedEntries = ['option_1'];
 
       mockProfileSchemaManager.getSchemaEntry.mockReturnValueOnce(optionEntry).mockReturnValueOnce(childEntry);
       mockProfileSchemaManager.hasOptionValues.mockReturnValue(true);
 
-      const result = processor.process(profileSchemaEntry, userValues, recordSchemaEntry);
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
 
       expect(result).toEqual([]);
     });

--- a/src/test/__tests__/common/services/recordGenerator/processors/recordSchema/arrayEntryProcessor.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/processors/recordSchema/arrayEntryProcessor.test.ts
@@ -14,6 +14,7 @@ describe('ArrayEntryProcessor', () => {
   let mockValueProcessor: jest.Mocked<ValueProcessor>;
   let mockProfileSchemaManager: jest.Mocked<ProfileSchemaManager>;
   let mockProfileSchemaProcessorManager: jest.Mocked<ProfileSchemaProcessorManager>;
+  let selectedEntries: string[];
 
   beforeEach(() => {
     mockValueProcessor = new ValueProcessor() as jest.Mocked<ValueProcessor>;
@@ -22,6 +23,7 @@ describe('ArrayEntryProcessor', () => {
       mockProfileSchemaManager,
     ) as jest.Mocked<ProfileSchemaProcessorManager>;
     processor = new ArrayEntryProcessor(mockValueProcessor, mockProfileSchemaProcessorManager);
+    selectedEntries = [];
   });
 
   describe('canProcess', () => {
@@ -71,6 +73,7 @@ describe('ArrayEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(result).toEqual({
@@ -110,6 +113,7 @@ describe('ArrayEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockValueProcessor.process).toHaveBeenCalledWith(
@@ -148,13 +152,15 @@ describe('ArrayEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
-      expect(mockProfileSchemaProcessorManager.process).toHaveBeenCalledWith(
+      expect(mockProfileSchemaProcessorManager.process).toHaveBeenCalledWith({
         profileSchemaEntry,
         recordSchemaEntry,
         userValues,
-      );
+        selectedEntries,
+      });
       expect(mockValueProcessor.processSchemaValues).toHaveBeenCalledWith(processedValues, expectedOptions);
       expect(result).toEqual(expectedResult);
     });
@@ -197,6 +203,7 @@ describe('ArrayEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockValueProcessor.process).toHaveBeenCalledWith([{ label: 'value 1' }, { label: 'value 2' }], {
@@ -243,6 +250,7 @@ describe('ArrayEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockValueProcessor.process).toHaveBeenCalledWith([{ label: 'value 1' }, { label: 'value 2' }], {
@@ -287,13 +295,15 @@ describe('ArrayEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
-      expect(mockProfileSchemaProcessorManager.process).toHaveBeenCalledWith(
+      expect(mockProfileSchemaProcessorManager.process).toHaveBeenCalledWith({
         profileSchemaEntry,
         recordSchemaEntry,
         userValues,
-      );
+        selectedEntries,
+      });
       expect(mockValueProcessor.processSchemaValues).toHaveBeenCalledWith(processedValues, { hiddenWrapper: false });
       expect(result).toEqual(expectedResult);
     });
@@ -327,6 +337,7 @@ describe('ArrayEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockValueProcessor.process).toHaveBeenCalledWith([{ label: 'value 1' }], { hiddenWrapper: true });
@@ -363,6 +374,7 @@ describe('ArrayEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockValueProcessor.process).toHaveBeenCalledWith(undefined, { hiddenWrapper: true });

--- a/src/test/__tests__/common/services/recordGenerator/processors/recordSchema/objectEntryProcessor.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/processors/recordSchema/objectEntryProcessor.test.ts
@@ -14,6 +14,8 @@ describe('ObjectEntryProcessor', () => {
   let mockValueProcessor: jest.Mocked<ValueProcessor>;
   let mockProfileSchemaManager: jest.Mocked<ProfileSchemaManager>;
   let mockRecordSchemaEntryManager: jest.Mocked<RecordSchemaEntryManager>;
+  let userValues: Record<string, any>;
+  let selectedEntries: string[];
 
   beforeEach(() => {
     mockValueProcessor = new ValueProcessor() as jest.Mocked<ValueProcessor>;
@@ -22,6 +24,8 @@ describe('ObjectEntryProcessor', () => {
       processEntry: jest.fn(),
     } as unknown as jest.Mocked<RecordSchemaEntryManager>;
     processor = new ObjectEntryProcessor(mockValueProcessor, mockProfileSchemaManager, mockRecordSchemaEntryManager);
+    userValues = {};
+    selectedEntries = [];
   });
 
   describe('canProcess', () => {
@@ -72,7 +76,6 @@ describe('ObjectEntryProcessor', () => {
       const profileSchemaEntry = {
         uuid: 'test-uuid',
       } as SchemaEntry;
-      const userValues = {} as UserValues;
       const expectedOptions = {
         hiddenWrapper: true,
       };
@@ -87,6 +90,7 @@ describe('ObjectEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockValueProcessor.processSchemaValues).toHaveBeenCalledWith({}, expectedOptions);
@@ -108,7 +112,6 @@ describe('ObjectEntryProcessor', () => {
         uuid: 'test-uuid',
         path: ['parent_1', 'child_1'],
       } as SchemaEntry;
-      const userValues = {} as UserValues;
       const childEntry_1 = { uuid: 'child_uuid_1' } as SchemaEntry;
       const childEntry_2 = { uuid: 'child_uuid_2' } as SchemaEntry;
       const childResult_1 = {
@@ -140,6 +143,7 @@ describe('ObjectEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockProfileSchemaManager.findSchemaEntriesByUriBFLite).toHaveBeenCalledWith('property_uri_1', [
@@ -153,11 +157,13 @@ describe('ObjectEntryProcessor', () => {
       expect(mockRecordSchemaEntryManager.processEntry).toHaveBeenCalledWith({
         recordSchemaEntry: { type: RecordSchemaEntryType.string },
         userValues,
+        selectedEntries,
         profileSchemaEntry: childEntry_1,
       });
       expect(mockRecordSchemaEntryManager.processEntry).toHaveBeenCalledWith({
         recordSchemaEntry: { type: RecordSchemaEntryType.string },
         userValues,
+        selectedEntries,
         profileSchemaEntry: childEntry_2,
       });
       expect(mockValueProcessor.processSchemaValues).toHaveBeenCalledWith(
@@ -184,7 +190,6 @@ describe('ObjectEntryProcessor', () => {
         uuid: 'test-uuid',
         path: ['parent_1', 'child_1'],
       } as SchemaEntry;
-      const userValues = {} as UserValues;
 
       const expectedOptions = {
         hiddenWrapper: false,
@@ -201,6 +206,7 @@ describe('ObjectEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockProfileSchemaManager.findSchemaEntriesByUriBFLite).toHaveBeenCalledWith('property_uri_1', [
@@ -226,7 +232,6 @@ describe('ObjectEntryProcessor', () => {
         uuid: 'test-uuid',
         path: ['parent_1', 'child_1'],
       } as SchemaEntry;
-      const userValues = {} as UserValues;
       const childEntry_1 = { uuid: 'child_uuid_1' } as SchemaEntry;
       const childResult_1 = {
         value: null,
@@ -248,6 +253,7 @@ describe('ObjectEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockProfileSchemaManager.findSchemaEntriesByUriBFLite).toHaveBeenCalledWith('property_uri_1', [
@@ -257,6 +263,7 @@ describe('ObjectEntryProcessor', () => {
       expect(mockRecordSchemaEntryManager.processEntry).toHaveBeenCalledWith({
         recordSchemaEntry: { type: RecordSchemaEntryType.string },
         userValues,
+        selectedEntries,
         profileSchemaEntry: childEntry_1,
       });
       expect(mockValueProcessor.processSchemaValues).toHaveBeenCalledWith({}, expectedOptions);
@@ -280,7 +287,6 @@ describe('ObjectEntryProcessor', () => {
         uuid: 'test-uuid',
         path: ['parent_1', 'child_1'],
       } as SchemaEntry;
-      const userValues = {} as UserValues;
       const childEntry_1 = { uuid: 'child_uuid_1' } as SchemaEntry;
       const childResult_1: ValueResult = {
         value: [{ nested_property: 'nested value' }],
@@ -306,6 +312,7 @@ describe('ObjectEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockProfileSchemaManager.findSchemaEntriesByUriBFLite).toHaveBeenCalledWith('property_uri_1', [
@@ -318,6 +325,7 @@ describe('ObjectEntryProcessor', () => {
           value: RecordSchemaEntryType.object,
         },
         userValues,
+        selectedEntries,
         profileSchemaEntry: childEntry_1,
       });
       expect(mockValueProcessor.processSchemaValues).toHaveBeenCalledWith(
@@ -346,7 +354,6 @@ describe('ObjectEntryProcessor', () => {
         uuid: 'test-uuid',
         path: ['parent_1', 'child_1'],
       } as SchemaEntry;
-      const userValues = {} as UserValues;
       const childEntry_1 = { uuid: 'child_uuid_1' } as SchemaEntry;
       const childResult_1: ValueResult = {
         value: ['value_1', 'value_2'],
@@ -372,6 +379,7 @@ describe('ObjectEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
       expect(mockProfileSchemaManager.findSchemaEntriesByUriBFLite).toHaveBeenCalledWith('property_uri_1', [
         'parent_1',
@@ -383,6 +391,7 @@ describe('ObjectEntryProcessor', () => {
           value: RecordSchemaEntryType.string,
         },
         userValues,
+        selectedEntries,
         profileSchemaEntry: childEntry_1,
       });
       expect(mockValueProcessor.processSchemaValues).toHaveBeenCalledWith(
@@ -411,7 +420,6 @@ describe('ObjectEntryProcessor', () => {
         uuid: 'test-uuid',
         path: ['parent_1', 'child_1'],
       } as SchemaEntry;
-      const userValues = {} as UserValues;
       const childEntry_1 = { uuid: 'child_uuid_1' } as SchemaEntry;
       const childEntry_2 = { uuid: 'child_uuid_2' } as SchemaEntry;
       const childResult_1: ValueResult = {
@@ -446,6 +454,7 @@ describe('ObjectEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockProfileSchemaManager.findSchemaEntriesByUriBFLite).toHaveBeenCalledWith('property_uri_1', [
@@ -479,7 +488,6 @@ describe('ObjectEntryProcessor', () => {
         uuid: 'test-uuid',
         path: ['parent_1', 'child_1'],
       } as SchemaEntry;
-      const userValues = {} as UserValues;
       const childEntry_1 = { uuid: 'child_uuid_1' } as SchemaEntry;
       const childResult_1: ValueResult = {
         value: 'not an array',
@@ -505,6 +513,7 @@ describe('ObjectEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockValueProcessor.processSchemaValues).toHaveBeenCalledWith(
@@ -533,7 +542,6 @@ describe('ObjectEntryProcessor', () => {
         uuid: 'test-uuid',
         path: ['parent_1', 'child_1'],
       } as SchemaEntry;
-      const userValues = {} as UserValues;
       const childEntry_1 = { uuid: 'child_uuid_1' } as SchemaEntry;
       const childResult_1: ValueResult = {
         value: ['simple string'],
@@ -557,6 +565,7 @@ describe('ObjectEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockValueProcessor.processSchemaValues).toHaveBeenCalledWith({}, expectedOptions);
@@ -580,7 +589,6 @@ describe('ObjectEntryProcessor', () => {
         uuid: 'test-uuid',
         path: ['parent_1', 'child_1'],
       } as SchemaEntry;
-      const userValues = {} as UserValues;
       const childEntry_1 = { uuid: 'child_uuid_1' } as SchemaEntry;
       const childEntry_2 = { uuid: 'child_uuid_2' } as SchemaEntry;
       const childResult_1: ValueResult = {
@@ -615,6 +623,7 @@ describe('ObjectEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockProfileSchemaManager.findSchemaEntriesByUriBFLite).toHaveBeenCalledWith('property_uri_1', [

--- a/src/test/__tests__/common/services/recordGenerator/processors/recordSchema/recordSchemaEntryManager.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/processors/recordSchema/recordSchemaEntryManager.test.ts
@@ -23,8 +23,12 @@ describe('RecordSchemaEntryManager', () => {
   let mockArrayEntryProcessor: jest.Mocked<ArrayEntryProcessor>;
   let mockObjectEntryProcessor: jest.Mocked<ObjectEntryProcessor>;
   let mockSimpleEntryProcessor: jest.Mocked<SimpleEntryProcessor>;
+  let userValues: Record<string, any>;
+  let selectedEntries: string[];
 
   beforeEach(() => {
+    userValues = {};
+    selectedEntries = [];
     mockValueProcessor = new ValueProcessor() as jest.Mocked<ValueProcessor>;
     mockProfileSchemaManager = new ProfileSchemaManager() as jest.Mocked<ProfileSchemaManager>;
     mockProfileSchemaProcessorManager = new ProfileSchemaProcessorManager(
@@ -70,7 +74,6 @@ describe('RecordSchemaEntryManager', () => {
       const profileSchemaEntry = {
         uuid: 'test-uuid',
       } as SchemaEntry;
-      const userValues = {} as UserValues;
       const expectedOptions: ValueOptions = {
         hiddenWrapper: false,
       };
@@ -88,6 +91,7 @@ describe('RecordSchemaEntryManager', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockSimpleEntryProcessor.canProcess).toHaveBeenCalledWith(recordSchemaEntry);
@@ -95,6 +99,7 @@ describe('RecordSchemaEntryManager', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
       expect(result).toEqual(expectedResult);
     });
@@ -106,7 +111,6 @@ describe('RecordSchemaEntryManager', () => {
       const profileSchemaEntry = {
         uuid: 'test-uuid',
       } as SchemaEntry;
-      const userValues = {} as UserValues;
       const expectedOptions: ValueOptions = {
         hiddenWrapper: false,
       };
@@ -124,6 +128,7 @@ describe('RecordSchemaEntryManager', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockArrayEntryProcessor.canProcess).toHaveBeenCalledWith(recordSchemaEntry);
@@ -131,6 +136,7 @@ describe('RecordSchemaEntryManager', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
       expect(result).toEqual(expectedResult);
     });
@@ -145,7 +151,6 @@ describe('RecordSchemaEntryManager', () => {
       const profileSchemaEntry = {
         uuid: 'test-uuid',
       } as SchemaEntry;
-      const userValues = {} as UserValues;
       const expectedOptions: ValueOptions = {
         hiddenWrapper: false,
       };
@@ -163,6 +168,7 @@ describe('RecordSchemaEntryManager', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockObjectEntryProcessor.canProcess).toHaveBeenCalledWith(recordSchemaEntry);
@@ -170,6 +176,7 @@ describe('RecordSchemaEntryManager', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
       expect(result).toEqual(expectedResult);
     });
@@ -181,7 +188,6 @@ describe('RecordSchemaEntryManager', () => {
       const profileSchemaEntry = {
         uuid: 'test-uuid',
       } as SchemaEntry;
-      const userValues = {} as UserValues;
 
       mockSimpleEntryProcessor.canProcess.mockReturnValue(false);
       mockArrayEntryProcessor.canProcess.mockReturnValue(false);
@@ -192,6 +198,7 @@ describe('RecordSchemaEntryManager', () => {
           recordSchemaEntry,
           profileSchemaEntry,
           userValues,
+          selectedEntries,
         });
       }).toThrow(`No processor found for entry type: unknown-type`);
     });
@@ -205,7 +212,6 @@ describe('RecordSchemaEntryManager', () => {
       const profileSchemaEntry = {
         uuid: 'test-uuid',
       } as SchemaEntry;
-      const userValues = {} as UserValues;
 
       mockArrayEntryProcessor.canProcess.mockReturnValue(true);
       mockObjectEntryProcessor.canProcess.mockReturnValue(true);
@@ -219,6 +225,7 @@ describe('RecordSchemaEntryManager', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockArrayEntryProcessor.process).toHaveBeenCalled();

--- a/src/test/__tests__/common/services/recordGenerator/processors/recordSchema/simpleEntryProcessor.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/processors/recordSchema/simpleEntryProcessor.test.ts
@@ -8,10 +8,14 @@ jest.mock('@common/services/recordGenerator/processors/value/valueProcessor');
 describe('SimpleEntryProcessor', () => {
   let processor: SimpleEntryProcessor;
   let mockValueProcessor: jest.Mocked<ValueProcessor>;
+  let userValues: Record<string, any>;
+  let selectedEntries: string[];
 
   beforeEach(() => {
     mockValueProcessor = new ValueProcessor() as jest.Mocked<ValueProcessor>;
     processor = new SimpleEntryProcessor(mockValueProcessor);
+    userValues = {};
+    selectedEntries = [];
   });
 
   describe('canProcess', () => {
@@ -73,6 +77,7 @@ describe('SimpleEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockValueProcessor.process).toHaveBeenCalledWith([{ label: 'test value' }], expectedOptions);
@@ -108,6 +113,7 @@ describe('SimpleEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockValueProcessor.process).toHaveBeenCalledWith([{ label: 'test value' }], expectedOptions);
@@ -122,7 +128,6 @@ describe('SimpleEntryProcessor', () => {
         uuid: 'test-uuid',
       } as SchemaEntry;
 
-      const userValues = {} as UserValues;
       const expectedOptions: ValueOptions = {
         hiddenWrapper: false,
       };
@@ -137,6 +142,7 @@ describe('SimpleEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockValueProcessor.process).toHaveBeenCalledWith([], expectedOptions);
@@ -169,6 +175,7 @@ describe('SimpleEntryProcessor', () => {
         recordSchemaEntry,
         profileSchemaEntry,
         userValues,
+        selectedEntries,
       });
 
       expect(mockValueProcessor.process).toHaveBeenCalledWith([], expectedOptions);

--- a/src/test/__tests__/common/services/recordGenerator/recordGenerator.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/recordGenerator.test.ts
@@ -8,6 +8,7 @@ describe('RecordGenerator', () => {
   let generator: RecordGenerator;
   let mockSchema: Schema;
   let mockUserValues: UserValues;
+  let mockSelectedEntries: string[];
   let mockReferenceIds: { id: string }[];
   let mockRecordSchema: RecordSchema;
 
@@ -15,6 +16,7 @@ describe('RecordGenerator', () => {
     generator = new RecordGenerator();
     mockSchema = new Map();
     mockUserValues = {};
+    mockSelectedEntries = [];
     mockReferenceIds = [{ id: 'test-reference-id' }];
     mockRecordSchema = {
       root: {
@@ -41,6 +43,7 @@ describe('RecordGenerator', () => {
         generator.generate({
           schema: mockSchema,
           userValues: mockUserValues,
+          selectedEntries: mockSelectedEntries,
           referenceIds: mockReferenceIds,
         });
       }).toThrow('Record schema not found for profile type: Monograph, entity type: work');
@@ -59,6 +62,7 @@ describe('RecordGenerator', () => {
       const result = generator.generate({
         schema: mockSchema,
         userValues: mockUserValues,
+        selectedEntries: mockSelectedEntries,
         referenceIds: mockReferenceIds,
       });
 
@@ -93,6 +97,7 @@ describe('RecordGenerator', () => {
         {
           schema: mockSchema,
           userValues: mockUserValues,
+          selectedEntries: mockSelectedEntries,
           referenceIds: mockReferenceIds,
         },
         profileType,
@@ -117,6 +122,7 @@ describe('RecordGenerator', () => {
       const result = generator.generate({
         schema: mockSchema,
         userValues: mockUserValues,
+        selectedEntries: mockSelectedEntries,
       });
 
       expect(result).toEqual({
@@ -137,6 +143,7 @@ describe('RecordGenerator', () => {
       const result = generator.generate({
         schema: mockSchema,
         userValues: mockUserValues,
+        selectedEntries: mockSelectedEntries,
         referenceIds: mockReferenceIds,
       });
 
@@ -157,6 +164,7 @@ describe('RecordGenerator', () => {
       const result = generator.generate({
         schema: mockSchema,
         userValues: mockUserValues,
+        selectedEntries: mockSelectedEntries,
         referenceIds: mockReferenceIds,
       });
 
@@ -182,6 +190,7 @@ describe('RecordGenerator', () => {
       const result = generator.generate({
         schema: mockSchema,
         userValues: mockUserValues,
+        selectedEntries: mockSelectedEntries,
         referenceIds: mockReferenceIds,
       });
 


### PR DESCRIPTION
The code has also been reworked in terms of using the passed values.

[https://folio-org.atlassian.net/browse/UILD-550](https://folio-org.atlassian.net/browse/UILD-550)

Before the fix: record is saved including values from the non-active dropdown options.
![before_fix](https://github.com/user-attachments/assets/8887db59-9064-488c-b176-0c80b57823b6)

After the fix: record is saved including only values of the selected "Title information" dropdown option.
![after_fix](https://github.com/user-attachments/assets/0d6742c0-f403-4ef1-971c-ff83fc5266fa)
