### PR TITLE
UILD-579: General accessibility issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Removed unused code after introducing the new profile. Remove BF2-BFLite mapping. Refs [UILD-550].
 * Extended configs to add support for Subject of Work. Refs [UILD-555].
 * Added export RDF file action. Refs [UILD-587].
+* Address general accessibility issues with focus. Refs [UILD-579].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -25,6 +26,7 @@
 [UILD-550]:https://folio-org.atlassian.net/browse/UILD-550
 [UILD-555]:https://folio-org.atlassian.net/browse/UILD-555
 [UILD-587]:https://folio-org.atlassian.net/browse/UILD-587
+[UILD-579]:https://folio-org.atlassian.net/browse/UILD-579
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/App.scss
+++ b/src/App.scss
@@ -200,4 +200,25 @@ h6 {
     height: 1px;
     overflow: hidden;
   }
+
+  a {
+    color: $blue-2f;
+    text-decoration: 1px underline solid $gray-200;
+
+    &:hover {
+      color: $blue-850;
+      text-decoration-color: $blue-850;
+    }
+
+    &:active {
+      color: #000;
+      text-decoration-color: $blue-850;
+    }
+
+    &:focus-visible {
+      outline: 1px solid $blue-550;
+      border-radius: 6px;
+      box-shadow: 0 0 0 3px $buttonActive;
+    }
+  }
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -218,7 +218,7 @@ h6 {
     &:focus-visible {
       outline: 1px solid $blue-550;
       border-radius: 6px;
-      box-shadow: 0 0 0 3px $buttonActive;
+      box-shadow: 0 0 0 3px $buttonFocus;
     }
   }
 }

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -4,7 +4,6 @@ $base: #fff;
 $blue-500-hover: #3465a8;
 $blue-700: #255096;
 $blue-50: #e9effa;
-$blue-700: #255096;
 $blue-600: #2d62b7;
 $blue-800: #1d3f75;
 $gray-200: #d7d8da;

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -17,7 +17,8 @@ $gray-600: #3d3f42;
 $disabled-input-bg-color: #ebebe4;
 $disabled-input-color: #777;
 $buttonHighlighted: #1960a4;
-$buttonActive: rgba(37, 118, 195, 0.2);
+$buttonHover: rgba(37, 118, 195, 0.2);
+$buttonFocus: rgba(37, 118, 195, 0.3);
 $error: #990000;
 
 $btn-hover-drop-shadow: 0px 10px 10px -6px rgba(0, 0, 0, 0.37);
@@ -31,6 +32,7 @@ $secondary-focusable-outline-box-shadow:
   0 0 0 4px $blue-100;
 
 $btn-border-radius: 12px;
+$btn-icon-border-radius: 6px;
 $btn-height: 24px;
 
 @mixin focused-outline-primary {

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -1,21 +1,23 @@
-$blue-500: #3e75cf;
 $base: #fff;
-// TODO: naming
-$blue-500-hover: #3465a8;
-$blue-700: #255096;
 $blue-50: #e9effa;
-$blue-600: #2d62b7;
-$blue-800: #1d3f75;
-$gray-200: #d7d8da;
-$gray-400: #727272;
-$gray-600: #3d3f42;
 $blue-100: #d8e3f5;
 $blue-400: #6591d9;
+$blue-500: #3e75cf;
+// TODO: naming
+$blue-500-hover: #3465a8;
+$blue-550: #3b5f9a;
+$blue-600: #2d62b7;
+$blue-700: #255096;
+$blue-800: #1d3f75;
+$blue-850: #23385a;
 $blue-2f: #2f609f;
+$gray-200: #d7dfeb;
+$gray-400: #727272;
+$gray-600: #3d3f42;
 $disabled-input-bg-color: #ebebe4;
 $disabled-input-color: #777;
 $buttonHighlighted: #1960a4;
-$buttonActive: rgba(37, 118, 195, 0.3);
+$buttonActive: rgba(37, 118, 195, 0.2);
 $error: #990000;
 
 $btn-hover-drop-shadow: 0px 10px 10px -6px rgba(0, 0, 0, 0.37);

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -90,6 +90,7 @@
   }
 
   &-link {
+    border-radius: $btn-icon-border-radius;
     color: $blue-2f;
     text-decoration: 1px underline solid $gray-200;
     height: 24px;
@@ -101,8 +102,7 @@
 
     &:focus-visible {
       outline: 1px solid $blue-550;
-      border-radius: 6px;
-      box-shadow: 0 0 0 3px $buttonActive;
+      box-shadow: 0 0 0 3px $buttonFocus;
     }
 
     &:active:not(:disabled) {
@@ -159,25 +159,27 @@
   }
 
   &-icon {
-    border-radius: 8px;
+    border-radius: $btn-icon-border-radius;
     padding: 0.188rem;
     height: fit-content;
     background-color: transparent;
     border: 1px solid transparent;
 
     &:hover {
-      background-color: rgba(37, 118, 195, 0.2);
+      background-color: $buttonHover;
     }
 
     &:focus,
-    &:focus-visible,
-    &:active {
-      border: 1px solid rgba(0, 0, 0, 0.2);
-      box-shadow: 0 0 0 3px rgba(37, 118, 195, 0.3);
+    &:focus-visible {
+      border: 1px solid rgba(0, 0, 0, 0.5);
+      background-color: $buttonFocus;
+      box-shadow: 0 0 0 3px $buttonFocus;
     }
 
     &:active {
-      background-color: #1960a4;
+      border: 1px solid rgba(0, 0, 0, 0.5);
+      background-color: $buttonHighlighted;
+      box-shadow: 0 0 0 3px $buttonFocus;
       color: #fff;
 
       > svg,

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -15,10 +15,6 @@
   font-family: inherit;
   cursor: pointer;
 
-  &:focus-visible {
-    outline: none;
-  }
-
   &:disabled,
   &:disabled:hover,
   &:disabled:active {
@@ -94,18 +90,23 @@
   }
 
   &-link {
-    color: $blue-600;
+    color: $blue-2f;
+    text-decoration: 1px underline solid $gray-200;
     height: 24px;
 
-    &:hover,
+    &:hover {
+      color: $blue-850;
+      text-decoration-color: $blue-850;
+    }
+
     &:focus-visible {
-      text-decoration: underline;
-      color: $blue-700;
-      box-shadow: none;
+      outline: 1px solid $blue-550;
+      border-radius: 6px;
+      box-shadow: 0 0 0 3px $buttonActive;
     }
 
     &:active:not(:disabled) {
-      color: $blue-800;
+      color: #000;
       text-decoration: underline;
     }
   }

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -88,7 +88,7 @@
       }
 
       &:hover {
-        background-color: $buttonActive;
+        background-color: $buttonHover;
 
         &:disabled {
           background-color: transparent;
@@ -97,8 +97,8 @@
 
       &:focus {
         border-color: rgba(0, 0, 0, 0.2);
-        background-color: $buttonActive;
-        box-shadow: 0 0 0 3px $buttonActive;
+        background-color: $buttonFocus;
+        box-shadow: 0 0 0 3px $buttonFocus;
       }
 
       &:active {

--- a/src/components/Preview/preview.types.ts
+++ b/src/components/Preview/preview.types.ts
@@ -4,7 +4,7 @@ export type FieldProps = {
   uuid: string;
   base: Schema;
   paths: Array<string>;
-  level: number;
+  level?: number;
   altSchema?: Schema;
   altUserValues?: UserValues;
   altSelectedEntries?: Array<string>;

--- a/src/components/Preview/preview.types.ts
+++ b/src/components/Preview/preview.types.ts
@@ -4,7 +4,7 @@ export type FieldProps = {
   uuid: string;
   base: Schema;
   paths: Array<string>;
-  level?: number;
+  level: number;
   altSchema?: Schema;
   altUserValues?: UserValues;
   altSelectedEntries?: Array<string>;

--- a/src/components/WorkDetailsCard/WorkDetailsCard.scss
+++ b/src/components/WorkDetailsCard/WorkDetailsCard.scss
@@ -15,10 +15,6 @@
     width: 100%;
     gap: 1rem;
 
-    .button-ghost {
-      background-color: transparent;
-    }
-
     .toggle-icon {
       cursor: pointer;
       height: 1.2rem;

--- a/src/components/WorkDetailsCard/WorkDetailsCard.scss
+++ b/src/components/WorkDetailsCard/WorkDetailsCard.scss
@@ -17,13 +17,6 @@
 
     .button-ghost {
       background-color: transparent;
-
-      &:active,
-      &:focus,
-      &:focus-visible {
-        outline: none;
-        box-shadow: none;
-      }
     }
 
     .toggle-icon {

--- a/src/components/WorkDetailsCard/WorkDetailsCard.scss
+++ b/src/components/WorkDetailsCard/WorkDetailsCard.scss
@@ -51,6 +51,23 @@
       font-weight: 700;
       text-align: left;
       color: $blue-2f;
+      border-radius: 3px;
+      padding: 3px 8px;
+
+      &:hover {
+        color: #23385a;
+        background-color: $buttonHover;
+      }
+
+      &:focus-visible {
+        color: #23385a;
+        outline-color: $blue-2f;
+      }
+
+      &:active {
+        color: #fff;
+        background-color: rgba(0, 0, 0, 0.62);
+      }
     }
 
     &-item {

--- a/src/components/WorkDetailsCard/WorkDetailsCard.tsx
+++ b/src/components/WorkDetailsCard/WorkDetailsCard.tsx
@@ -41,7 +41,7 @@ export const WorkDetailsCard: FC<WorkDetailsCard> = ({
     <div className="work-details-card">
       <div className="heading">
         <Button
-          type={ButtonType.Ghost}
+          type={ButtonType.Icon}
           onClick={toggleIsOpen}
           data-testid="work-details-card-toggle"
           ariaLabel={formatMessage({ id: isOpen ? 'ld.aria.listEntry.close' : 'ld.aria.listEntry.open' })}
@@ -65,7 +65,7 @@ export const WorkDetailsCard: FC<WorkDetailsCard> = ({
       </div>
       <div className="details">
         <Button
-          type={ButtonType.Ghost}
+          type={ButtonType.Link}
           onClick={() => handleOpenPreview?.(id)}
           className="title"
           data-testid={`preview-button__${id}`}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-579

This PR removes rules that disabled focus-visible indicators, updates button types to be more consistent, and aligns anchor and some button types' appearance across interaction states with Stripes. Aside from accessibility, it also updates Work titles in search results to align with UX designs.

Screenshots of tab-focused areas of concern fixed for this story, which would have had no visible indicators prior to these changes:

<img width="1555" alt="Screenshot 2025-07-02 at 08 27 02" src="https://github.com/user-attachments/assets/8cd3a76d-7571-4c4f-bc8d-7c2e4b2e2928" />
<img width="1555" alt="Screenshot 2025-07-02 at 08 27 08" src="https://github.com/user-attachments/assets/3f3d71dd-b92d-48c3-a5dc-b1f49178be22" />
<img width="1555" alt="Screenshot 2025-07-02 at 08 27 13" src="https://github.com/user-attachments/assets/b89625f0-f169-4a5b-8a7f-e95ffc25f922" />
