### PR TITLE
UILD-578: use separate profiles for Work and Instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Removed unused code after introducing the new profile. Remove BF2-BFLite mapping. Refs [UILD-550].
 * Extended configs to add support for Subject of Work. Refs [UILD-555].
 * Added export RDF file action. Refs [UILD-587].
+* Loading separate profiles for Work and Instance on the Create resource page. Refs [UILD-578].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -25,6 +26,7 @@
 [UILD-550]:https://folio-org.atlassian.net/browse/UILD-550
 [UILD-555]:https://folio-org.atlassian.net/browse/UILD-555
 [UILD-587]:https://folio-org.atlassian.net/browse/UILD-587
+[UILD-578]:https://folio-org.atlassian.net/browse/UILD-578
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/common/helpers/profile.helper.ts
+++ b/src/common/helpers/profile.helper.ts
@@ -1,0 +1,19 @@
+import { ResourceType } from '@common/constants/record.constants';
+import { PROFILES_CONFIG } from '@src/configs';
+
+export const getProfileConfig = (profileId: keyof typeof PROFILES_CONFIG, pageType: ResourceType) => {
+  if (!PROFILES_CONFIG[profileId]) {
+    throw new Error(`Profile with ID ${profileId} does not exist in the configuration.`);
+  }
+
+  const { api, rootEntry } = PROFILES_CONFIG[profileId];
+  let ids: number[] = [];
+
+  if (pageType === ResourceType.work) {
+    ids = [api.work];
+  } else if (pageType === ResourceType.instance) {
+    ids = [api.work, api.instance];
+  }
+
+  return { ids, rootEntry: rootEntry as ProfileNode };
+};

--- a/src/common/helpers/profile.helper.ts
+++ b/src/common/helpers/profile.helper.ts
@@ -1,7 +1,7 @@
 import { ResourceType } from '@common/constants/record.constants';
 import { PROFILES_CONFIG } from '@src/configs';
 
-export const getProfileConfig = (profileId: keyof typeof PROFILES_CONFIG, pageType: ResourceType) => {
+export const getProfileConfig = (profileId: keyof typeof PROFILES_CONFIG, pageType?: ResourceType) => {
   if (!PROFILES_CONFIG[profileId]) {
     throw new Error(`Profile with ID ${profileId} does not exist in the configuration.`);
   }

--- a/src/common/helpers/profile.helper.ts
+++ b/src/common/helpers/profile.helper.ts
@@ -13,6 +13,8 @@ export const getProfileConfig = (profileId: keyof typeof PROFILES_CONFIG, pageTy
     ids = [api.work];
   } else if (pageType === ResourceType.instance) {
     ids = [api.work, api.instance];
+  } else {
+    ids = [api.profile];
   }
 
   return { ids, rootEntry: rootEntry as ProfileNode };

--- a/src/common/hooks/useLoadProfile.ts
+++ b/src/common/hooks/useLoadProfile.ts
@@ -1,0 +1,21 @@
+import { fetchProfile } from '@common/api/profiles.api';
+import { useProfileState } from '@src/store';
+
+export const useLoadProfile = () => {
+  const { profiles, setProfiles } = useProfileState();
+
+  const loadProfile = async (profileId: number) => {
+    if (profiles[profileId]) {
+      return profiles[profileId];
+    }
+
+    const profile = await fetchProfile(profileId);
+    setProfiles(prev => ({ ...prev, [profileId]: profile }));
+
+    return profile;
+  };
+
+  return {
+    loadProfile,
+  };
+};

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,1 +1,2 @@
 export * from './complexLookup';
+export * from './profiles';

--- a/src/configs/profiles/index.ts
+++ b/src/configs/profiles/index.ts
@@ -1,0 +1,1 @@
+export * from './profiles.config';

--- a/src/configs/profiles/profiles.config.ts
+++ b/src/configs/profiles/profiles.config.ts
@@ -1,0 +1,16 @@
+export const PROFILES_CONFIG = {
+  Monograph: {
+    api: {
+      profile: '1',
+      work: '2',
+      instance: '3',
+    },
+    rootEntry: {
+      type: 'profile',
+      displayName: 'Monograph',
+      bfid: 'monograph',
+      children: ['Monograph:Work', 'Monograph:Instance'],
+      id: 'Monograph',
+    },
+  },
+};

--- a/src/configs/profiles/profiles.config.ts
+++ b/src/configs/profiles/profiles.config.ts
@@ -1,9 +1,10 @@
 export const PROFILES_CONFIG = {
   Monograph: {
+    // TODO: UILD-575 - delete this when the profile API is fully integrated
     api: {
-      profile: '1',
-      work: '2',
-      instance: '3',
+      profile: 1,
+      work: 2,
+      instance: 3,
     },
     rootEntry: {
       type: 'profile',

--- a/src/store/stores/profile.ts
+++ b/src/store/stores/profile.ts
@@ -4,7 +4,7 @@ import { type SliceState } from '../utils/slice';
 type SelectedProfileType = Profile | null;
 type InitialSchemaKeyType = string | null;
 
-export type ProfileState = SliceState<'profiles', ProfileEntry[]> &
+export type ProfileState = SliceState<'profiles', Record<string, Profile>> &
   SliceState<'selectedProfile', SelectedProfileType> &
   SliceState<'initialSchemaKey', InitialSchemaKeyType> &
   SliceState<'schema', Map<string, SchemaEntry>>;
@@ -13,7 +13,7 @@ const STORE_NAME = 'Profile';
 
 const sliceConfigs: SliceConfigs = {
   profiles: {
-    initialValue: [],
+    initialValue: {},
   },
   selectedProfile: {
     initialValue: null,

--- a/src/test/__tests__/common/helpers/profile.helper.test.ts
+++ b/src/test/__tests__/common/helpers/profile.helper.test.ts
@@ -1,0 +1,64 @@
+import { ResourceType } from '@common/constants/record.constants';
+import { getProfileConfig } from '@common/helpers/profile.helper';
+
+jest.mock('@src/configs', () => ({
+  PROFILES_CONFIG: {
+    Monograph: {
+      api: {
+        work: 1,
+        instance: 2,
+        profile: 3,
+      },
+      rootEntry: {
+        id: 'root',
+        type: 'root',
+      },
+    },
+  },
+}));
+
+describe('profile.helper', () => {
+  describe('getProfileConfig', () => {
+    test('returns work profile configuration when ResourceType is work', () => {
+      const result = getProfileConfig('Monograph', ResourceType.work);
+
+      expect(result).toEqual({
+        ids: [1],
+        rootEntry: {
+          id: 'root',
+          type: 'root',
+        },
+      });
+    });
+
+    test('returns work and instance profile configuration when ResourceType is instance', () => {
+      const result = getProfileConfig('Monograph', ResourceType.instance);
+
+      expect(result).toEqual({
+        ids: [1, 2],
+        rootEntry: {
+          id: 'root',
+          type: 'root',
+        },
+      });
+    });
+
+    test('returns profile configuration when ResourceType is not work or instance', () => {
+      const result = getProfileConfig('Monograph');
+
+      expect(result).toEqual({
+        ids: [3],
+        rootEntry: {
+          id: 'root',
+          type: 'root',
+        },
+      });
+    });
+
+    test('throws error when profile does not exist in configuration', () => {
+      expect(() => {
+        getProfileConfig('non-existent-profile' as any, ResourceType.work);
+      }).toThrow('Profile with ID non-existent-profile does not exist in the configuration.');
+    });
+  });
+});

--- a/src/test/__tests__/common/hooks/useLoadProfile.hook.test.ts
+++ b/src/test/__tests__/common/hooks/useLoadProfile.hook.test.ts
@@ -1,0 +1,76 @@
+import '@src/test/__mocks__/common/hooks/useServicesContext.mock';
+import { setInitialGlobalState } from '@src/test/__mocks__/store';
+import { renderHook } from '@testing-library/react';
+import { useLoadProfile } from '@common/hooks/useLoadProfile';
+import { fetchProfile } from '@common/api/profiles.api';
+import { useProfileStore } from '@src/store';
+
+jest.mock('@common/api/profiles.api', () => ({
+  fetchProfile: jest.fn(),
+}));
+
+describe('useLoadProfile', () => {
+  const setProfiles = jest.fn();
+
+  beforeEach(() => {
+    setInitialGlobalState([
+      {
+        store: useProfileStore,
+        state: {
+          profiles: {},
+          setProfiles,
+        },
+      },
+    ]);
+  });
+
+  describe('loadProfile', () => {
+    test('returns cached profile when it exists', async () => {
+      const cachedProfile = { id: 'cached-profile' };
+      setInitialGlobalState([
+        {
+          store: useProfileStore,
+          state: {
+            profiles: { 1: cachedProfile },
+            setProfiles,
+          },
+        },
+      ]);
+
+      const { result } = renderHook(useLoadProfile);
+      const profile = await result.current.loadProfile(1);
+
+      expect(profile).toBe(cachedProfile);
+      expect(fetchProfile).not.toHaveBeenCalled();
+      expect(setProfiles).not.toHaveBeenCalled();
+    });
+
+    test('fetches and caches profile when it does not exist', async () => {
+      const newProfile = { id: 'new-profile' };
+      (fetchProfile as jest.Mock).mockResolvedValue(newProfile);
+
+      const { result } = renderHook(useLoadProfile);
+      const profile = await result.current.loadProfile(1);
+
+      expect(profile).toBe(newProfile);
+      expect(fetchProfile).toHaveBeenCalledWith(1);
+      expect(setProfiles).toHaveBeenCalledWith(expect.any(Function));
+
+      // Verify the profiles are updated correctly
+      const setProfilesCallback = setProfiles.mock.calls[0][0];
+      const newState = setProfilesCallback({});
+      expect(newState).toEqual({ 1: newProfile });
+    });
+
+    test('handles error from fetchProfile', async () => {
+      const error = new Error('Failed to fetch profile');
+      (fetchProfile as jest.Mock).mockRejectedValue(error);
+
+      const { result } = renderHook(useLoadProfile);
+      
+      await expect(result.current.loadProfile(1)).rejects.toThrow('Failed to fetch profile');
+      expect(fetchProfile).toHaveBeenCalledWith(1);
+      expect(setProfiles).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/views/Edit/Edit.tsx
+++ b/src/views/Edit/Edit.tsx
@@ -129,10 +129,13 @@ export const Edit = () => {
         }
 
         const typedRecord = record as unknown as RecordEntry;
-
-        await getProfiles({
+        const getProfilesParams = {
+          // TODO: UILD-575 - remove the hardcoded value once the profile metadata is set in the store
+          profile: getProfileConfig('Monograph', typeParam as ResourceType),
           record: typedRecord,
-        });
+        };
+
+        await getProfiles(getProfilesParams);
       } catch {
         addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, 'ld.errorLoadingResource'));
       } finally {

--- a/src/views/Edit/Edit.tsx
+++ b/src/views/Edit/Edit.tsx
@@ -3,6 +3,7 @@ import { EditSection } from '@components/EditSection';
 import { BibframeEntities, PROFILE_BFIDS } from '@common/constants/bibframe.constants';
 import { scrollEntity } from '@common/helpers/pageScrolling.helper';
 import { getResourceIdFromUri } from '@common/helpers/navigation.helper';
+import { getProfileConfig } from '@common/helpers/profile.helper';
 import { useConfig } from '@common/hooks/useConfig.hook';
 import { useRecordControls } from '@common/hooks/useRecordControls';
 import { useResetRecordStatus } from '@common/hooks/useResetRecordStatus';
@@ -59,7 +60,12 @@ export const Edit = () => {
 
       try {
         setIsLoading(true);
-        await getProfiles({});
+        const params = {
+          // TODO: UILD-575 - remove the hardcoded value once the profile metadata is set in the store
+          profile: getProfileConfig('Monograph', typeParam as ResourceType),
+        };
+
+        await getProfiles(params);
         setEntitesBFIds();
       } catch {
         addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, 'ld.errorFetching'));


### PR DESCRIPTION
Loading separate profiles for Work and Instance on the Create resource page
[https://folio-org.atlassian.net/browse/UILD-578](https://folio-org.atlassian.net/browse/UILD-578)

**Technical details:**
The Create Work page now makes a request for the Work profile. The Create Instance page makes two requests: one for the Instance profile to render the work form and another for the Work profile to render the preview section with the linked Work data.

To implement this, a new hook has been introduced to load profiles, along with a new configuration to determine the root entry of the Monograph profile. Additionally, the general logic has been updated to apply the configuration and load the required profiles.
