### PR TITLE
UILD-589: Fix - incorrect record generation

### DIFF
--- a/src/common/constants/bibframeMapping.constants.ts
+++ b/src/common/constants/bibframeMapping.constants.ts
@@ -49,7 +49,6 @@ export const BFLITE_URIS = {
   IDENTIFIER_LCCN: 'http://library.link/identifier/LCCN',
   IDENTIFIER_ISBN: 'http://library.link/identifier/ISBN',
   MARC_STATUS: 'http://bibfra.me/vocab/marc/status',
-  MARC_LABEL: 'http://bibfra.me/vocab/marc/label',
   MARC_SUPPLEMENTARY_CONTENT: 'http://bibfra.me/vocab/marc/supplementaryContent',
   MARC_MEDIA: 'http://bibfra.me/vocab/marc/media',
   MARC_DIMENSIONS: 'http://bibfra.me/vocab/marc/dimensions',

--- a/src/common/helpers/record.helper.ts
+++ b/src/common/helpers/record.helper.ts
@@ -111,3 +111,7 @@ export const getRecordDependencies = (record?: RecordEntry | null) => {
     };
   }
 };
+
+export const hasEmptyValues = (values: UserValueContents[]) => {
+  return values.every(({ label }) => label === '' || label === null || label === undefined);
+};

--- a/src/common/helpers/record.helper.ts
+++ b/src/common/helpers/record.helper.ts
@@ -113,5 +113,5 @@ export const getRecordDependencies = (record?: RecordEntry | null) => {
 };
 
 export const hasEmptyValues = (values: UserValueContents[]) => {
-  return values.every(({ label }) => label === '' || label === null || label === undefined);
+  return values.every(({ label }) => label === '' || label === undefined);
 };

--- a/src/common/helpers/record.helper.ts
+++ b/src/common/helpers/record.helper.ts
@@ -112,6 +112,6 @@ export const getRecordDependencies = (record?: RecordEntry | null) => {
   }
 };
 
-export const hasEmptyValues = (values: UserValueContents[]) => {
+export const hasAllEmptyValues = (values: UserValueContents[]) => {
   return values.every(({ label }) => label === '' || label === undefined);
 };

--- a/src/common/services/recordGenerator/processors/profileSchema/baseDropdownProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/baseDropdownProcessor.ts
@@ -64,8 +64,9 @@ export abstract class BaseDropdownProcessor extends BaseFieldProcessor {
     }
 
     const childValues = this.userValues[childEntry.uuid]?.contents || [];
+    const hasEmptyValues = childValues.every(({ label }) => label === '' || label === null || label === undefined);
 
-    if (childValues.length === 0 || !childEntry.uriBFLite) {
+    if (childValues.length === 0 || hasEmptyValues || !childEntry.uriBFLite) {
       return null;
     }
 

--- a/src/common/services/recordGenerator/processors/profileSchema/baseDropdownProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/baseDropdownProcessor.ts
@@ -1,5 +1,5 @@
 import { AdvancedFieldType } from '@common/constants/uiControls.constants';
-import { hasEmptyValues } from '@common/helpers/record.helper';
+import { hasAllEmptyValues } from '@common/helpers/record.helper';
 import { IProfileSchemaManager } from '../../profileSchemaManager.interface';
 import { ProcessorResult, SimplePropertyResult } from '../../types/profileSchemaProcessor.types';
 import { ProcessContext } from '../../types/common.types';
@@ -66,7 +66,7 @@ export abstract class BaseDropdownProcessor extends BaseFieldProcessor {
 
     const childValues = this.userValues[childEntry.uuid]?.contents || [];
 
-    if (childValues.length === 0 || hasEmptyValues(childValues) || !childEntry.uriBFLite) {
+    if (childValues.length === 0 || hasAllEmptyValues(childValues) || !childEntry.uriBFLite) {
       return null;
     }
 

--- a/src/common/services/recordGenerator/processors/profileSchema/baseDropdownProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/baseDropdownProcessor.ts
@@ -1,4 +1,5 @@
 import { AdvancedFieldType } from '@common/constants/uiControls.constants';
+import { hasEmptyValues } from '@common/helpers/record.helper';
 import { IProfileSchemaManager } from '../../profileSchemaManager.interface';
 import { ProcessorResult, SimplePropertyResult } from '../../types/profileSchemaProcessor.types';
 import { ProcessContext } from '../../types/common.types';
@@ -64,9 +65,8 @@ export abstract class BaseDropdownProcessor extends BaseFieldProcessor {
     }
 
     const childValues = this.userValues[childEntry.uuid]?.contents || [];
-    const hasEmptyValues = childValues.every(({ label }) => label === '' || label === null || label === undefined);
 
-    if (childValues.length === 0 || hasEmptyValues || !childEntry.uriBFLite) {
+    if (childValues.length === 0 || hasEmptyValues(childValues) || !childEntry.uriBFLite) {
       return null;
     }
 

--- a/src/common/services/recordGenerator/processors/value/valueProcessor.interface.ts
+++ b/src/common/services/recordGenerator/processors/value/valueProcessor.interface.ts
@@ -15,12 +15,12 @@ export interface SchemaValue {
 }
 
 export interface IValueProcessor {
-  processSimpleValues(values: UserValueContents[]): string[];
+  processSimpleValues(values: UserValueContents[]): (string | undefined)[] | null;
   process(
     values: UserValueContents[],
     options?: ValueOptions,
   ): {
-    value: string[] | null;
+    value: (string | undefined)[] | null;
     options: ValueOptions;
   };
   processSchemaValues(

--- a/src/common/services/recordGenerator/processors/value/valueProcessor.ts
+++ b/src/common/services/recordGenerator/processors/value/valueProcessor.ts
@@ -3,7 +3,15 @@ import { IValueProcessor } from './valueProcessor.interface';
 
 export class ValueProcessor implements IValueProcessor {
   processSimpleValues(values: UserValueContents[]) {
-    return values?.map(({ label, meta }) => meta?.basicLabel || label).filter(label => label !== undefined);
+    const processedValues = values
+      ?.map(({ label, meta }) => meta?.basicLabel || label)
+      .filter(label => label !== undefined && label !== null && label !== '');
+
+    if (!processedValues || !processedValues.length) {
+      return null;
+    }
+
+    return processedValues;
   }
 
   process(values: UserValueContents[], options: ValueOptions = {}) {

--- a/src/common/services/recordGenerator/processors/value/valueProcessor.ts
+++ b/src/common/services/recordGenerator/processors/value/valueProcessor.ts
@@ -7,7 +7,7 @@ export class ValueProcessor implements IValueProcessor {
       ?.map(({ label, meta }) => meta?.basicLabel || label)
       .filter(label => label !== undefined && label !== null && label !== '');
 
-    if (!processedValues || !processedValues.length) {
+    if (!processedValues?.length) {
       return null;
     }
 

--- a/src/common/services/recordGenerator/processors/value/valueProcessor.ts
+++ b/src/common/services/recordGenerator/processors/value/valueProcessor.ts
@@ -5,7 +5,7 @@ export class ValueProcessor implements IValueProcessor {
   processSimpleValues(values: UserValueContents[]) {
     const processedValues = values
       ?.map(({ label, meta }) => meta?.basicLabel || label)
-      .filter(label => label !== undefined && label !== null && label !== '');
+      .filter(label => label !== undefined && label !== '');
 
     if (!processedValues?.length) {
       return null;

--- a/src/common/services/recordGenerator/schemas/common/propertyDefinitions.ts
+++ b/src/common/services/recordGenerator/schemas/common/propertyDefinitions.ts
@@ -52,7 +52,7 @@ export const providerProperties = {
 };
 
 export const statusProperties = {
-  [BFLITE_URIS.MARC_LABEL]: stringArrayProperty,
+  [BFLITE_URIS.LABEL]: stringArrayProperty,
   [BFLITE_URIS.LINK]: stringArrayProperty,
 };
 

--- a/src/common/services/recordGenerator/schemas/profiles/monograph/work.schema.ts
+++ b/src/common/services/recordGenerator/schemas/profiles/monograph/work.schema.ts
@@ -85,7 +85,7 @@ export const monographWorkRecordSchema: RecordSchema = {
       ),
 
       [BFLITE_URIS.CONTENT]: createArrayObjectProperty({
-        [BFLITE_URIS.CODE]: stringArrayProperty,
+        [BFLITE_URIS.TERM]: stringArrayProperty,
         [BFLITE_URIS.LINK]: stringArrayProperty,
       }),
 

--- a/src/common/services/recordGenerator/types/value.types.ts
+++ b/src/common/services/recordGenerator/types/value.types.ts
@@ -7,7 +7,7 @@ export interface ValueOptions {
   }>;
 }
 
-export type SchemaPropertyValue = string | SchemaPropertyValueArray | SchemaPropertyValueObject;
+export type SchemaPropertyValue = undefined | string | SchemaPropertyValueArray | SchemaPropertyValueObject;
 
 export type SchemaPropertyValueArray = Array<SchemaPropertyValue>;
 

--- a/src/test/__tests__/common/helpers/record.helper.test.ts
+++ b/src/test/__tests__/common/helpers/record.helper.test.ts
@@ -10,6 +10,10 @@ describe('record.helper', () => {
   const mockTypeUriConstant = getMockedImportedConstant(BibframeConstants, 'TYPE_URIS');
   mockTypeUriConstant({ INSTANCE: testInstanceUri });
 
+  interface UserValueContents {
+    label: string | undefined;
+  }
+
   describe('getEditingRecordBlocks', () => {
     test("returns an object with the record's blocks", () => {
       mockBlocksBFLiteConstant({
@@ -105,6 +109,30 @@ describe('record.helper', () => {
         keys: { key: 'workReferenceKey', uri: 'testWorkUri' },
         type: undefined,
       });
+    });
+  });
+
+  describe('hasEmptyValues', () => {
+    test('returns true when all values have empty labels', () => {
+      const values: UserValueContents[] = [{ label: '' }, { label: undefined }];
+
+      const result = RecordHelper.hasEmptyValues(values);
+
+      expect(result).toBe(true);
+    });
+
+    test('returns false when any value has a non-empty label', () => {
+      const values: UserValueContents[] = [{ label: '' }, { label: 'Some content' }, { label: undefined }];
+
+      const result = RecordHelper.hasEmptyValues(values);
+
+      expect(result).toBe(false);
+    });
+
+    test('returns true for empty array', () => {
+      const result = RecordHelper.hasEmptyValues([]);
+
+      expect(result).toBe(true);
     });
   });
 });

--- a/src/test/__tests__/common/helpers/record.helper.test.ts
+++ b/src/test/__tests__/common/helpers/record.helper.test.ts
@@ -112,11 +112,11 @@ describe('record.helper', () => {
     });
   });
 
-  describe('hasEmptyValues', () => {
+  describe('hasAllEmptyValues', () => {
     test('returns true when all values have empty labels', () => {
       const values: UserValueContents[] = [{ label: '' }, { label: undefined }];
 
-      const result = RecordHelper.hasEmptyValues(values);
+      const result = RecordHelper.hasAllEmptyValues(values);
 
       expect(result).toBe(true);
     });
@@ -124,13 +124,13 @@ describe('record.helper', () => {
     test('returns false when any value has a non-empty label', () => {
       const values: UserValueContents[] = [{ label: '' }, { label: 'Some content' }, { label: undefined }];
 
-      const result = RecordHelper.hasEmptyValues(values);
+      const result = RecordHelper.hasAllEmptyValues(values);
 
       expect(result).toBe(false);
     });
 
     test('returns true for empty array', () => {
-      const result = RecordHelper.hasEmptyValues([]);
+      const result = RecordHelper.hasAllEmptyValues([]);
 
       expect(result).toBe(true);
     });

--- a/src/test/__tests__/common/services/recordGenerator/processors/value/valueProcessor.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/processors/value/valueProcessor.test.ts
@@ -18,12 +18,12 @@ describe('ValueProcessor', () => {
       expect(result).toEqual(['Label 1', 'Label 2']);
     });
 
-    it('returns empty array for empty input', () => {
+    it('returns null for empty input', () => {
       const values: UserValueContents[] = [];
 
       const result = processor.processSimpleValues(values);
 
-      expect(result).toEqual([]);
+      expect(result).toBeNull();
     });
 
     it('prefers meta.basicLabel over label', () => {
@@ -43,6 +43,22 @@ describe('ValueProcessor', () => {
       const result = processor.processSimpleValues(values);
 
       expect(result).toEqual(['Label 1', 'Label 3']);
+    });
+
+    it('filters out empty string labels', () => {
+      const values: UserValueContents[] = [{ label: 'Label 1' }, { label: '' }, { label: 'Label 3' }];
+
+      const result = processor.processSimpleValues(values);
+
+      expect(result).toEqual(['Label 1', 'Label 3']);
+    });
+
+    it('returns null when all values are filtered out', () => {
+      const values: UserValueContents[] = [{ label: '' }, { label: undefined }];
+
+      const result = processor.processSimpleValues(values);
+
+      expect(result).toBeNull();
     });
   });
 
@@ -82,7 +98,7 @@ describe('ValueProcessor', () => {
       const result = processor.process(values, options);
 
       expect(result).toEqual({
-        value: [],
+        value: null,
         options,
       });
     });


### PR DESCRIPTION
This PR fixes a regression that occurred after the UI refactoring and the introduction of new record generation services.

**Fixes made:**
Updated record generation services to remove empty values ​​from the generated record.
Updated record schemas to set correct field names.

[https://folio-org.atlassian.net/browse/UILD-589](https://folio-org.atlassian.net/browse/UILD-589)