### PR TITLE
UILD-589: Regression fix - generating a record with a default value

### DIFF
--- a/src/common/services/recordGenerator/schemas/common/schemaBuilders.ts
+++ b/src/common/services/recordGenerator/schemas/common/schemaBuilders.ts
@@ -1,4 +1,6 @@
+import { BFLITE_URIS } from '@common/constants/bibframeMapping.constants';
 import { RecordSchemaEntryType } from '@common/constants/recordSchema.constants';
+import { link } from 'fs';
 
 export function createObjectProperty(properties: Record<string, RecordSchemaEntry>, options = {}) {
   return {
@@ -35,6 +37,8 @@ export function createNotesProperty(mappingReference: Record<string, { uri?: str
         value: RecordSchemaEntryType.string,
         options: {
           mappedValues: mappingReference,
+          defaultValue: BFLITE_URIS.NOTE,
+          linkedProperty: 'value'
         },
       },
       value: {

--- a/src/common/services/recordGenerator/schemas/common/schemaBuilders.ts
+++ b/src/common/services/recordGenerator/schemas/common/schemaBuilders.ts
@@ -1,6 +1,5 @@
 import { BFLITE_URIS } from '@common/constants/bibframeMapping.constants';
 import { RecordSchemaEntryType } from '@common/constants/recordSchema.constants';
-import { link } from 'fs';
 
 export function createObjectProperty(properties: Record<string, RecordSchemaEntry>, options = {}) {
   return {
@@ -38,7 +37,7 @@ export function createNotesProperty(mappingReference: Record<string, { uri?: str
         options: {
           mappedValues: mappingReference,
           defaultValue: BFLITE_URIS.NOTE,
-          linkedProperty: 'value'
+          linkedProperty: 'value',
         },
       },
       value: {

--- a/src/common/services/recordToSchemaMapping/recordToSchemaMapping.service.ts
+++ b/src/common/services/recordToSchemaMapping/recordToSchemaMapping.service.ts
@@ -302,6 +302,9 @@ export class RecordToSchemaMappingService implements IRecordToSchemaMapping {
 
     if (type === AdvancedFieldTypeEnum.dropdown) {
       this.handleDropdownOptions(schemaUiElem, recordEntryValue as string);
+
+      // no need to set the value if the dropdown option is selected
+      return;
     }
 
     if (type === AdvancedFieldTypeEnum.literal && constraints?.repeatable) {

--- a/src/test/__tests__/common/services/recordGenerator/schemas/common/schemaBuilders.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/schemas/common/schemaBuilders.test.ts
@@ -1,3 +1,4 @@
+import { BFLITE_URIS } from '@common/constants/bibframeMapping.constants';
 import { RecordSchemaEntryType } from '@common/constants/recordSchema.constants';
 import {
   createObjectProperty,
@@ -105,6 +106,8 @@ describe('SchemaBuilders', () => {
             value: RecordSchemaEntryType.string,
             options: {
               mappedValues: mappingReference,
+              defaultValue: BFLITE_URIS.NOTE,
+              linkedProperty: 'value',
             },
           },
           value: {

--- a/src/types/recordModel.d.ts
+++ b/src/types/recordModel.d.ts
@@ -13,6 +13,8 @@ interface RecordSchemaEntry {
     sourceProperty?: string;
     valueContainer?: ValueContainerOption;
     mappedValues?: Record<string, { uri?: string }>;
+    defaultValue?: string;
+    linkedProperty?: string; // Used for linking to a specific property in the valueContainer
   };
 }
 


### PR DESCRIPTION
Fixes for regression after implementing a new profile and adding a new record generation algorithm.
[https://folio-org.atlassian.net/browse/UILD-589](https://folio-org.atlassian.net/browse/UILD-589)

**Technical details:**
**Case 1:** "Creator"/"Contributor" type shows a link instead of a label on Read-only screens.
<img width="543" alt="8728f271-d697-4e15-b16d-dde25e35b238" src="https://github.com/user-attachments/assets/f38b0d7e-2912-48af-8462-b806ae1f69ed" />

**Fix:** Stopped setting the value for the profile schema entry with the type "dropdown".

**Case 2:** "Notes about the Work"/"Notes about the Instance" fields: when type is not set and only "Note" value is set and saved, it is not shown when re-opening the resource.
![Screenshot 2025-07-08 173024](https://github.com/user-attachments/assets/c24f3c46-5806-48a6-8052-1d9f60865048)

**Fix:** Extended the record schema for "Notes" with the required options and extended the record generation algorithm to apply these options. This is necessary to add a default note type when the Notes value is set.
