### PR TITLE
UILD-589: Regression fix - add complex lookup id when creating record for selected dropdown options

### DIFF
--- a/src/common/services/recordGenerator/processors/profileSchema/lookupProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/lookupProcessor.ts
@@ -24,29 +24,40 @@ export class LookupProcessor implements IProfileSchemaProcessor {
       return [];
     }
 
-    return values.map(({ meta, label }) => {
+    return values.map(({ id, meta, label }) => {
       const result: GeneratedValue = {};
 
       Object.keys(recordSchemaEntry.properties || {}).forEach(key => {
-        this.mapEntryValue(result, key, meta, label);
+        this.mapEntryValue({ result, key, meta, label, id });
       });
 
       return result;
     });
   }
 
-  private mapEntryValue(
-    result: GeneratedValue,
-    key: string,
-    meta: UserValueContents['meta'] | undefined,
-    label?: string,
-  ) {
+  private mapEntryValue({
+    result,
+    key,
+    meta,
+    label,
+    id,
+  }: {
+    result: GeneratedValue;
+    key: string;
+    meta?: UserValueContents['meta'];
+    label?: string;
+    id?: string;
+  }) {
     if (meta?.uri && key.includes('link')) {
       result[key] = [meta.uri];
     } else if (meta?.basicLabel && (key.includes('term') || key.includes('label') || key.includes('name'))) {
       result[key] = [meta.basicLabel];
     } else if (key.includes('code')) {
       result[key] = [meta?.uri?.split('/').pop() ?? label ?? ''];
+    } else if (key.includes('srsId')) {
+      const selectedKey = meta?.srsId ? 'srsId' : 'id';
+
+      result[selectedKey] = meta?.srsId ?? id;
     } else {
       result[key] = label ? [label] : [];
     }

--- a/src/common/services/recordGenerator/schemas/common/propertyDefinitions.ts
+++ b/src/common/services/recordGenerator/schemas/common/propertyDefinitions.ts
@@ -85,3 +85,11 @@ export const contributorProperties = {
     },
   },
 };
+
+export const assigningSourceProperty = {
+  type: RecordSchemaEntryType.array,
+  value: RecordSchemaEntryType.object,
+  properties: {
+    srsId: stringArrayProperty,
+  },
+};

--- a/src/common/services/recordGenerator/schemas/profiles/monograph/work.schema.ts
+++ b/src/common/services/recordGenerator/schemas/profiles/monograph/work.schema.ts
@@ -10,6 +10,7 @@ import {
   codeTermLinkProperties,
   contributorProperties,
   nameAndLinkProperties,
+  assigningSourceProperty,
 } from '../../common/propertyDefinitions';
 import {
   createObjectProperty,
@@ -68,14 +69,14 @@ export const monographWorkRecordSchema: RecordSchema = {
             [BFLITE_URIS.CODE]: stringArrayProperty,
             [BFLITE_URIS.ITEM_NUMBER]: stringArrayProperty,
             [BFLITE_URIS.MARC_STATUS]: createStatusProperty(statusProperties),
-            _assigningSourceReference: stringArrayProperty,
+            _assigningSourceReference: assigningSourceProperty,
           }),
           ddc: createObjectProperty({
             [BFLITE_URIS.CODE]: stringArrayProperty,
             [BFLITE_URIS.ITEM_NUMBER]: stringArrayProperty,
             [BFLITE_URIS.EDITION]: stringArrayProperty,
             [BFLITE_URIS.EDITION_NUMBER]: stringArrayProperty,
-            _assigningSourceReference: stringArrayProperty,
+            _assigningSourceReference: assigningSourceProperty,
           }),
         },
         {

--- a/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/lookupProcessor.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/lookupProcessor.test.ts
@@ -319,6 +319,72 @@ describe('LookupProcessor', () => {
       ]);
     });
 
+    it('processes values with srsId property correctly when meta.srsId is present', () => {
+      const recordSchemaEntry = {
+        type: RecordSchemaEntryType.array,
+        value: RecordSchemaEntryType.object,
+        properties: {
+          srsId: { type: RecordSchemaEntryType.string },
+        },
+      } as RecordSchemaEntry;
+      const profileSchemaEntry = {
+        uuid: 'test-uuid',
+        type: AdvancedFieldType.complex,
+      } as SchemaEntry;
+      const userValues = {
+        'test-uuid': {
+          contents: [
+            {
+              id: 'record-id-123',
+              label: 'test value',
+              meta: { srsId: 'srs-123' },
+            },
+          ],
+        },
+      } as unknown as UserValues;
+
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
+
+      expect(result).toEqual([
+        {
+          srsId: 'srs-123',
+        },
+      ]);
+    });
+
+    it('processes values with srsId property correctly when meta.srsId is not present', () => {
+      const recordSchemaEntry = {
+        type: RecordSchemaEntryType.array,
+        value: RecordSchemaEntryType.object,
+        properties: {
+          srsId: { type: RecordSchemaEntryType.string },
+        },
+      } as RecordSchemaEntry;
+      const profileSchemaEntry = {
+        uuid: 'test-uuid',
+        type: AdvancedFieldType.complex,
+      } as SchemaEntry;
+      const userValues = {
+        'test-uuid': {
+          contents: [
+            {
+              id: 'record-id-123',
+              label: 'test value',
+              meta: { uri: 'http://example.com/resource/123' },
+            },
+          ],
+        },
+      } as unknown as UserValues;
+
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
+
+      expect(result).toEqual([
+        {
+          id: 'record-id-123',
+        },
+      ]);
+    });
+
     it('processes multiple user value contents correctly', () => {
       const recordSchemaEntry = {
         type: RecordSchemaEntryType.array,


### PR DESCRIPTION
[https://folio-org.atlassian.net/browse/UILD-589](https://folio-org.atlassian.net/browse/UILD-589)

**Technical details:**
**Case:** “Assigning agency” of “Classification numbers” field does not show value when it was imported (050 ind1=0, ind2=0), opened in LDE and then Work updated and saved, e.g. “Additional call number information” updated:
![image](https://github.com/user-attachments/assets/ace42fca-1563-4b7e-bbbd-9120e0563a1d)
**Fix:** Enhanced LookupProcessor to handle "srsId" property correctly and "assigningSourceProperty" to schema definitions. This allows you to add an "srsId" or "id" value to the generated record.