### PR TITLE
UILD-569: Add support for adminhist, biogdata, physical, accmat and award notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Added export RDF file action. Refs [UILD-587].
 * Address general accessibility issues with focus. Refs [UILD-579].
 * Loading separate profiles for Work and Instance on the Create resource page. Refs [UILD-578].
+* Add support for administrative history, biographical data, physical description, accompanying material and award notes. Refs [UILD-569].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -29,6 +30,7 @@
 [UILD-587]:https://folio-org.atlassian.net/browse/UILD-587
 [UILD-579]:https://folio-org.atlassian.net/browse/UILD-579
 [UILD-578]:https://folio-org.atlassian.net/browse/UILD-578
+[UILD-569]:https://folio-org.atlassian.net/browse/UILD-569
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/common/constants/bibframeMapping.constants.ts
+++ b/src/common/constants/bibframeMapping.constants.ts
@@ -186,6 +186,26 @@ export const SIMPLE_LOOKUP_MAPPING = {
       uri: 'http://id.loc.gov/vocabulary/mnotetype/lang',
       parentBlock: { bfLiteUri: BLOCKS_BFLITE.WORK.uri },
     },
+    'http://bibfra.me/vocab/marc/adminhist': {
+      uri: 'http://id.loc.gov/vocabulary/mnotetype/adminhist',
+      parentBlock: { bfLiteUri: BLOCKS_BFLITE.INSTANCE.uri },
+    },
+    'http://bibfra.me/vocab/marc/biogdata': {
+      uri: 'http://id.loc.gov/vocabulary/mnotetype/biogdata',
+      parentBlock: { bfLiteUri: BLOCKS_BFLITE.INSTANCE.uri },
+    },
+    'http://bibfra.me/vocab/marc/physicalDescription': {
+      uri: 'http://id.loc.gov/vocabulary/mnotetype/physical',
+      parentBlock: { bfLiteUri: BLOCKS_BFLITE.INSTANCE.uri },
+    },
+    'http://bibfra.me/vocab/marc/accompanyingMaterial': {
+      uri: 'http://id.loc.gov/vocabulary/mnotetype/accmat',
+      parentBlock: { bfLiteUri: BLOCKS_BFLITE.INSTANCE.uri },
+    },
+    'http://bibfra.me/vocab/marc/awardsNote': {
+      uri: 'http://id.loc.gov/vocabulary/mnotetype/award',
+      parentBlock: { bfLiteUri: BLOCKS_BFLITE.WORK.uri },
+    },
   },
   _contributions: {
     'http://bibfra.me/vocab/relation/abridger': { uri: 'http://id.loc.gov/vocabulary/relators/abr' },


### PR DESCRIPTION
Add "award" note  in Work section
<img width="688" height="449" alt="Screenshot 2025-07-10 at 4 58 57 PM" src="https://github.com/user-attachments/assets/b52d7d51-3d40-41f5-ba58-3a60e8036a25" />

--

Add "admin history", "biographical data", "physical Description" & "accompanying material" notes in Instance section. ("physical Description" is not shown in the attached image due to alphabetical sorting)
<img width="656" height="551" alt="Screenshot 2025-07-10 at 4 59 40 PM" src="https://github.com/user-attachments/assets/d7562951-12e4-4f54-b338-275edc25d5ed" />
