### PR TITLE
UILD-594: Add series support to editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Address general accessibility issues with focus. Refs [UILD-579].
 * Loading separate profiles for Work and Instance on the Create resource page. Refs [UILD-578].
 * Add support for administrative history, biographical data, physical description, accompanying material and award notes. Refs [UILD-569].
+* Address accessibility issues. Refs [UILD-579].
+* Add support for serials. Refs [UILD-594].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -31,6 +33,8 @@
 [UILD-579]:https://folio-org.atlassian.net/browse/UILD-579
 [UILD-578]:https://folio-org.atlassian.net/browse/UILD-578
 [UILD-569]:https://folio-org.atlassian.net/browse/UILD-569
+[UILD-579]:https://folio-org.atlassian.net/browse/UILD-579
+[UILD-594]:https://folio-org.atlassian.net/browse/UILD-594
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/common/constants/bibframeMapping.constants.ts
+++ b/src/common/constants/bibframeMapping.constants.ts
@@ -64,6 +64,9 @@ export const BFLITE_URIS = {
   ITEM_NUMBER: 'http://bibfra.me/vocab/marc/itemNumber',
   EDITION_NUMBER: 'http://bibfra.me/vocab/marc/editionNumber',
   CONTENT: 'http://bibfra.me/vocab/marc/content',
+  IS_PART_OF: 'http://bibfra.me/vocab/relation/isPartOf',
+  ISSN: 'http://bibfra.me/vocab/marc/issn',
+  VOLUME: 'http://bibfra.me/vocab/marc/volume',
 };
 
 export const NON_BF_RECORD_ELEMENTS = {

--- a/src/common/services/recordGenerator/schemas/common/propertyDefinitions.ts
+++ b/src/common/services/recordGenerator/schemas/common/propertyDefinitions.ts
@@ -72,6 +72,12 @@ export const nameAndLinkProperties = {
   [BFLITE_URIS.LINK]: stringArrayProperty,
 };
 
+export const seriesProperties = {
+  [BFLITE_URIS.NAME]: stringArrayProperty,
+  [BFLITE_URIS.ISSN]: stringArrayProperty,
+  [BFLITE_URIS.VOLUME]: stringArrayProperty,
+};
+
 export const contributorProperties = {
   _name: {
     type: RecordSchemaEntryType.string,

--- a/src/common/services/recordGenerator/schemas/profiles/monograph/work.schema.ts
+++ b/src/common/services/recordGenerator/schemas/profiles/monograph/work.schema.ts
@@ -11,6 +11,7 @@ import {
   contributorProperties,
   nameAndLinkProperties,
   assigningSourceProperty,
+  seriesProperties,
 } from '../../common/propertyDefinitions';
 import {
   createObjectProperty,
@@ -91,6 +92,8 @@ export const monographWorkRecordSchema: RecordSchema = {
       }),
 
       [BFLITE_URIS.LANGUAGE]: createArrayObjectProperty(codeTermLinkProperties),
+
+      [BFLITE_URIS.IS_PART_OF]: createArrayObjectProperty(seriesProperties),
     },
   },
 };


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-594

Updated editor UI includes new, repeatable series section:
<img width="1557" height="435" alt="Screenshot 2025-07-15 at 16 04 45" src="https://github.com/user-attachments/assets/4f030dab-f867-4d71-8c1f-357e80c40e63" />

Saving the form generates a request with this structure, as detailed in https://folio-org.atlassian.net/browse/MODLD-777:
<img width="532" height="294" alt="Screenshot 2025-07-15 at 16 05 22" src="https://github.com/user-attachments/assets/56ce148e-65cf-42f7-b4f8-ebdea7a4bc0b" />
