### PR TITLE
UILD-557: Add support for updated extent handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Address general accessibility issues with focus. Refs [UILD-579].
 * Loading separate profiles for Work and Instance on the Create resource page. Refs [UILD-578].
 * Add support for administrative history, biographical data, physical description, accompanying material and award notes. Refs [UILD-569].
+* Add support for updated extent handling. Rfs [UILD-557].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -31,6 +32,7 @@
 [UILD-579]:https://folio-org.atlassian.net/browse/UILD-579
 [UILD-578]:https://folio-org.atlassian.net/browse/UILD-578
 [UILD-569]:https://folio-org.atlassian.net/browse/UILD-569
+[UILD-557]:https://folio-org.atlassian.net/browse/UILD-557
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/common/constants/bibframeMapping.constants.ts
+++ b/src/common/constants/bibframeMapping.constants.ts
@@ -14,9 +14,8 @@ export const BFLITE_URIS = {
   TABLE_OF_CONTENTS: 'http://bibfra.me/vocab/marc/tableOfContents',
   SUMMARY: 'http://bibfra.me/vocab/marc/summary',
   INSTANTIATES: 'http://bibfra.me/vocab/lite/instantiates',
-  EXTENT_TEMP: 'BFLITE_URI_TEMP_EXTENT', // TODO: set the value when the API contract for Extent field is updated
   EXTENT: 'http://bibfra.me/vocab/lite/extent',
-  APPLIES_TO_TEMP: 'APPLIES_TO_TEMP',
+  APPLIES_TO: 'http://bibfra.me/vocab/marc/materialsSpecified',
   NOTE: 'http://bibfra.me/vocab/lite/note',
   CREATOR: 'http://bibfra.me/vocab/lite/creator',
   CONTRIBUTOR: 'http://bibfra.me/vocab/lite/contributor',

--- a/src/common/services/recordGenerator/schemas/profiles/monograph/instance.schema.ts
+++ b/src/common/services/recordGenerator/schemas/profiles/monograph/instance.schema.ts
@@ -72,7 +72,11 @@ export const monographInstanceRecordSchema: RecordSchema = {
       
       [BFLITE_URIS.MARC_MEDIA]: createArrayObjectProperty(codeTermLinkProperties),
       
-      [BFLITE_URIS.EXTENT]: stringArrayProperty,
+      [BFLITE_URIS.EXTENT]: createArrayObjectProperty({
+        [BFLITE_URIS.LABEL]: stringArrayProperty,
+        [BFLITE_URIS.APPLIES_TO]: stringArrayProperty,
+      }),
+
       [BFLITE_URIS.MARC_DIMENSIONS]: stringArrayProperty,
       
       [BFLITE_URIS.MARC_CARRIER]: createArrayObjectProperty(linkAndTermProperties),


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-557

Requires profiles changes in https://github.com/folio-org/mod-linked-data/pull/257

`extent` is now treated as an object instead of a literal, adjust the UI accordingly.

Add extent values to an instance:
<img width="1080" height="388" alt="Screenshot 2025-07-16 at 17 08 17" src="https://github.com/user-attachments/assets/c3a4bf56-6923-4fc1-8b16-ae0167825f5f" />

Which generates the following request structure:
<img width="532" height="294" alt="Screenshot 2025-07-16 at 17 07 58" src="https://github.com/user-attachments/assets/e87b8996-1e15-4c92-9aba-421890865875" />

An instance with the former extent-as-literal generates the following response:
<img width="1082" height="391" alt="Screenshot 2025-07-16 at 17 46 08" src="https://github.com/user-attachments/assets/997bb40e-5072-4b2a-80b2-731fca0b617f" />

Which can then be modified in the UI:
<img width="532" height="283" alt="Screenshot 2025-07-16 at 17 45 49" src="https://github.com/user-attachments/assets/47ab2e03-125b-4e21-b24e-61b4008cb210" />
