### PR TITLE
Fix: Update package.json and vite.config.ts to remove UMD format support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/linked-data.es.js",
-      "require": "./dist/linked-data.umd.js"
+      "import": "./dist/linked-data.es.js"
     }
   },
-  "main": "./dist/linked-data.umd.js",
+  "main": "./dist/linked-data.es.js",
   "module": "./dist/linked-data.es.js",
   "scripts": {
     "dev": "vite",
@@ -28,7 +27,6 @@
     "preview": "vite preview",
     "prettier:format:all": "prettier --write ./src/**/*.{ts,tsx,json,scss}",
     "test": "npm run test:unit:coverage",
-    "test:unit": "jest",
     "test:unit:watch": "jest --watch",
     "test:unit:coverage": "jest --ci --coverage"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig(() => {
           lib: {
             entry: path.resolve(__dirname, 'src/embed.tsx'),
             name: 'linked-data',
-            formats: ['es', 'umd'],
+            formats: ['es'],
             fileName: format => `linked-data.${format}.js`,
           },
         },


### PR DESCRIPTION
The goal of this PR is to remove redundant file format to reduce the final package size.
A deprecated script has also been removed.