### PR TITLE
UILD-573: Initialize 'selected profile' with first profile's ID

### DIFF
--- a/src/components/ModalChooseProfile/ModalChooseProfile.tsx
+++ b/src/components/ModalChooseProfile/ModalChooseProfile.tsx
@@ -1,4 +1,4 @@
-import { FC, memo, useState } from 'react';
+import { FC, memo, useState, useEffect } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Modal } from '@components/Modal';
 import './ModalChooseProfile.scss';
@@ -13,8 +13,14 @@ interface Props {
 
 export const ModalChooseProfile: FC<Props> = memo(({ isOpen, onCancel, onSubmit, onClose, profiles }) => {
   const { formatMessage } = useIntl();
-  const [selectedValue, setSelectedValue] = useState<string>(profiles?.[0].id);
+  const [selectedValue, setSelectedValue] = useState<string>(profiles?.[0]?.id);
   const [isDefault, setIsDefault] = useState(false);
+
+  useEffect(() => {
+    if (profiles && profiles.length > 0 && !selectedValue) {
+      setSelectedValue(profiles[0].id);
+    }
+  }, [profiles, selectedValue]);
 
   const onChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectedValue(event.target.value);

--- a/src/test/__tests__/components/ModalChooseProfile.test.tsx
+++ b/src/test/__tests__/components/ModalChooseProfile.test.tsx
@@ -13,6 +13,10 @@ describe('ModalChooseProfile', () => {
   const onSubmit = jest.fn();
   const onClose = jest.fn();
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   beforeAll(() => {
     createModalContainer();
   });
@@ -161,5 +165,36 @@ describe('ModalChooseProfile', () => {
     );
 
     expect(container.firstChild).toBeNull();
+  });
+
+  test('calls onSubmit with correct profile id when form is submitted without manual selection', async () => {
+    
+    const { rerender } = render(
+      <ModalChooseProfile
+        isOpen={true}
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+        onClose={onClose}
+        profiles={[]}
+      />,
+    );
+    
+    rerender(
+      <ModalChooseProfile
+        isOpen={true}
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+        onClose={onClose}
+        profiles={mockProfiles}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('modal-button-submit'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith('profile_1');
+      expect(onSubmit).not.toHaveBeenCalledWith('0');
+      expect(onSubmit).not.toHaveBeenCalledWith(undefined);
+    });
   });
 });


### PR DESCRIPTION
[This PR](https://github.com/folio-org/ui-linked-data/pull/189) that we merged yesterday caused a problem. See the attached screen recording.

https://github.com/user-attachments/assets/15bf9edc-b408-4607-be9f-99ece4373d8b


This PR solves the problem.
Summary the change: Set the first profiles's ID as the `selectedValue` in `ModalChooseProfile` component.