### PR TITLE
UILD-606: Add support for DATES_OF_PUBLICATION_NOTE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Add support for serials. Refs [UILD-594].
 * Add support for updated extent handling. Rfs [UILD-557].
 * Added Profile selection when the user creates a new Instance. Refs[UILD-573].
+* Add support for dates of publication note (MARC 362). Refs [UILD-606].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -39,6 +40,7 @@
 [UILD-594]:https://folio-org.atlassian.net/browse/UILD-594
 [UILD-557]:https://folio-org.atlassian.net/browse/UILD-557
 [UILD-573]:https://folio-org.atlassian.net/browse/UILD-573
+[UILD-606]:https://folio-org.atlassian.net/browse/UILD-606
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/common/constants/bibframeMapping.constants.ts
+++ b/src/common/constants/bibframeMapping.constants.ts
@@ -208,6 +208,10 @@ export const SIMPLE_LOOKUP_MAPPING = {
       uri: 'http://id.loc.gov/vocabulary/mnotetype/award',
       parentBlock: { bfLiteUri: BLOCKS_BFLITE.WORK.uri },
     },
+    'http://bibfra.me/vocab/marc/datesOfPublicationNote': {
+      uri: 'http://id.loc.gov/vocabulary/mnotetype/number',
+      parentBlock: { bfLiteUri: BLOCKS_BFLITE.INSTANCE.uri }
+    }
   },
   _contributions: {
     'http://bibfra.me/vocab/relation/abridger': { uri: 'http://id.loc.gov/vocabulary/relators/abr' },


### PR DESCRIPTION
Purpose
---
Add support for Dates of Publication note (MARC 362) in Linked Data Editor.

The "Dates of Publication note"  is equivalent to "numbering" note in Bibframe. Hence, this note will be labelled as "numbering" in the UI

<img width="858" height="359" alt="Screenshot 2025-07-25 at 9 12 56 AM" src="https://github.com/user-attachments/assets/5f38c976-7b2b-45f2-b323-4cdc542813cd" />
