### PR TITLE
UILD-607: Book format support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add support for updated extent handling. Rfs [UILD-557].
 * Added Profile selection when the user creates a new Instance. Refs[UILD-573].
 * Add support for dates of publication note (MARC 362). Refs [UILD-606].
+* Add support for book format. Refs [UILD-607].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -41,6 +42,7 @@
 [UILD-557]:https://folio-org.atlassian.net/browse/UILD-557
 [UILD-573]:https://folio-org.atlassian.net/browse/UILD-573
 [UILD-606]:https://folio-org.atlassian.net/browse/UILD-606
+[UILD-607]:https://folio-org.atlassian.net/browse/UILD-607
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/common/constants/bibframeMapping.constants.ts
+++ b/src/common/constants/bibframeMapping.constants.ts
@@ -66,6 +66,7 @@ export const BFLITE_URIS = {
   IS_PART_OF: 'http://bibfra.me/vocab/relation/isPartOf',
   ISSN: 'http://bibfra.me/vocab/marc/issn',
   VOLUME: 'http://bibfra.me/vocab/marc/volume',
+  BOOK_FORMAT: 'http://bibfra.me/vocab/marc/bookFormat',
 };
 
 export const NON_BF_RECORD_ELEMENTS = {

--- a/src/common/constants/lookup.constants.ts
+++ b/src/common/constants/lookup.constants.ts
@@ -430,6 +430,11 @@ export const lookupConfig: Record<string, any> = {
     type: 'complex',
     modes: [],
   },
+  'http://id.loc.gov/vocabulary/bookformat': {
+    name: 'bookFormat',
+    type: 'simple',
+    modes: [],
+  },
   'http://id.loc.gov/vocabulary/carriers': {
     name: 'carriers',
     type: 'simple',

--- a/src/common/services/recordGenerator/schemas/profiles/monograph/instance.schema.ts
+++ b/src/common/services/recordGenerator/schemas/profiles/monograph/instance.schema.ts
@@ -85,6 +85,8 @@ export const monographInstanceRecordSchema: RecordSchema = {
         [BFLITE_URIS.LINK]: stringArrayProperty,
         [BFLITE_URIS.NOTE]: stringArrayProperty,
       }),
+
+      [BFLITE_URIS.BOOK_FORMAT]: createArrayObjectProperty(linkAndTermProperties),
     },
   },
 };


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-607

Adds the new book format property to the instance editor.

New property with available values derived from the LOC API:

<img width="1556" height="475" alt="Screenshot 2025-07-25 at 18 13 44" src="https://github.com/user-attachments/assets/0712882c-2a84-4b21-a891-43ab51e4bce3" />

Related section of the resulting generated DTO sent to the backend:

<img width="536" height="237" alt="Screenshot 2025-07-25 at 18 14 28" src="https://github.com/user-attachments/assets/c53dc0e1-76c2-4a80-b370-7bc3ab746509" />
