### PR TITLE
UILD-610: Add support for supplementary content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Added Profile selection when the user creates a new Instance. Refs[UILD-573].
 * Add support for dates of publication note (MARC 362). Refs [UILD-606].
 * Add support for book format. Refs [UILD-607].
-* Add support for supplementary content. Refs [UILD-610].
+* Add support for supplementary content. Refs [UILD-611].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -44,7 +44,7 @@
 [UILD-573]:https://folio-org.atlassian.net/browse/UILD-573
 [UILD-606]:https://folio-org.atlassian.net/browse/UILD-606
 [UILD-607]:https://folio-org.atlassian.net/browse/UILD-607
-[UILD-610]:https://folio-org.atlassian.net/browse/UILD-610
+[UILD-611]:https://folio-org.atlassian.net/browse/UILD-611
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Added Profile selection when the user creates a new Instance. Refs[UILD-573].
 * Add support for dates of publication note (MARC 362). Refs [UILD-606].
 * Add support for book format. Refs [UILD-607].
+* Add support for supplementary content. Refs [UILD-610].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -43,6 +44,7 @@
 [UILD-573]:https://folio-org.atlassian.net/browse/UILD-573
 [UILD-606]:https://folio-org.atlassian.net/browse/UILD-606
 [UILD-607]:https://folio-org.atlassian.net/browse/UILD-607
+[UILD-610]:https://folio-org.atlassian.net/browse/UILD-610
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/common/constants/bibframeMapping.constants.ts
+++ b/src/common/constants/bibframeMapping.constants.ts
@@ -67,6 +67,7 @@ export const BFLITE_URIS = {
   ISSN: 'http://bibfra.me/vocab/marc/issn',
   VOLUME: 'http://bibfra.me/vocab/marc/volume',
   BOOK_FORMAT: 'http://bibfra.me/vocab/marc/bookFormat',
+  SUPPLEMENTARY_CONTENT: 'http://bibfra.me/vocab/marc/supplementaryContent',
 };
 
 export const NON_BF_RECORD_ELEMENTS = {

--- a/src/common/services/recordGenerator/schemas/profiles/monograph/work.schema.ts
+++ b/src/common/services/recordGenerator/schemas/profiles/monograph/work.schema.ts
@@ -42,6 +42,8 @@ export const monographWorkRecordSchema: RecordSchema = {
 
       [BFLITE_URIS.GOVERNMENT_PUBLICATION]: createArrayObjectProperty(linkAndTermProperties),
 
+      [BFLITE_URIS.SUPPLEMENTARY_CONTENT]: createArrayObjectProperty(linkAndTermProperties),
+
       [BFLITE_URIS.DATE_START]: stringArrayProperty,
 
       [BFLITE_URIS.ORIGIN_PLACE]: createArrayObjectProperty(nameAndLinkProperties),


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-611

This screen recording walks through the following steps:
* create a new work with four supplementary content values
* save, reviewing the POST request body that was sent and the GET response body after saving
* create an instance in order to review the MARC
* note the correct MARC output with `bk` and `1` in `008`

![output](https://github.com/user-attachments/assets/0ae1b808-365f-4f0e-8ba4-701a3e9a5a04)
