### PR TITLE
UILD-619: Adjusting Profile prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Refactor profile handling logic to streamline schema management. Refs [UILD-613].
 * Refactor record generation logic to remove hardcoded profile references. Refs [UILD-614].
 * Add support for illustrative content. Refs [UILD-610].
+* Adjust Profile prefix. Refs [UILD-619].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -55,6 +56,7 @@
 [UILD-613]:https://folio-org.atlassian.net/browse/UILD-613
 [UILD-614]:https://folio-org.atlassian.net/browse/UILD-614
 [UILD-610]:https://folio-org.atlassian.net/browse/UILD-610
+[UILD-619]:https://folio-org.atlassian.net/browse/UILD-619
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/configs/profiles/profiles.config.ts
+++ b/src/configs/profiles/profiles.config.ts
@@ -6,9 +6,9 @@ export const PROFILE_CONFIG = {
   },
   rootEntry: {
     type: 'profile',
-    displayName: 'Monograph',
-    bfid: 'monograph',
-    children: ['Monograph:Work', 'Monograph:Instance'],
-    id: 'Monograph',
+    displayName: 'Profile',
+    bfid: 'profile',
+    children: ['Profile:Work', 'Profile:Instance'],
+    id: 'Profile',
   },
 };


### PR DESCRIPTION
Refactored Profile config to standardize profile naming and to make LDE profile agnostic.

[https://folio-org.atlassian.net/browse/UILD-619](https://folio-org.atlassian.net/browse/UILD-619)