### PR TITLE
UILD-635: Fix - use selected profile in profile selection modal

### DIFF
--- a/src/components/ProfileSelectionManager/ProfileSelectionManager.tsx
+++ b/src/components/ProfileSelectionManager/ProfileSelectionManager.tsx
@@ -18,6 +18,7 @@ export const ProfileSelectionManager = () => {
 
   const onClose = () => {
     setIsProfileSelectionModalOpen(false);
+    setSelectedProfileId(null);
   };
 
   const onSubmit = async (profileId: string | number) => {
@@ -34,11 +35,13 @@ export const ProfileSelectionManager = () => {
   };
 
   useEffect(() => {
+    if (!isProfileSelectionModalOpen) return;
+
     const updatedSelectedProfileId = profileSelectionType.action === 'change' ? getRecordProfileId(record) : null;
     setSelectedProfileId(updatedSelectedProfileId);
-  }, [profileSelectionType.action]);
+  }, [isProfileSelectionModalOpen, profileSelectionType.action]);
 
-  return (
+  return isProfileSelectionModalOpen ? (
     <ModalChooseProfile
       isOpen={isProfileSelectionModalOpen}
       profileSelectionType={profileSelectionType}
@@ -48,5 +51,5 @@ export const ProfileSelectionManager = () => {
       profiles={availableProfiles?.[profileSelectionType?.resourceType]}
       selectedProfileId={selectedProfileId}
     />
-  );
+  ) : null;
 };

--- a/src/components/ProfileSelectionManager/ProfileSelectionManager.tsx
+++ b/src/components/ProfileSelectionManager/ProfileSelectionManager.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { ROUTES } from '@common/constants/routes.constants';
 import { generatePageURL } from '@common/helpers/navigation.helper';
 import { getRecordProfileId } from '@common/helpers/record.helper';
@@ -13,6 +14,7 @@ export const ProfileSelectionManager = () => {
   const { queryParams } = useNavigationState();
   const { navigateToEditPage } = useNavigateToEditPage();
   const { changeRecordProfile } = useRecordControls();
+  const [selectedProfileId, setSelectedProfileId] = useState<string | number | null | undefined>();
 
   const onClose = () => {
     setIsProfileSelectionModalOpen(false);
@@ -31,7 +33,10 @@ export const ProfileSelectionManager = () => {
     }
   };
 
-  const selectedProfileId = getRecordProfileId(record);
+  useEffect(() => {
+    const updatedSelectedProfileId = profileSelectionType.action === 'change' ? getRecordProfileId(record) : null;
+    setSelectedProfileId(updatedSelectedProfileId);
+  }, [profileSelectionType.action]);
 
   return (
     <ModalChooseProfile

--- a/src/components/ProfileSelectionManager/ProfileSelectionManager.tsx
+++ b/src/components/ProfileSelectionManager/ProfileSelectionManager.tsx
@@ -14,7 +14,7 @@ export const ProfileSelectionManager = () => {
   const { queryParams } = useNavigationState();
   const { navigateToEditPage } = useNavigateToEditPage();
   const { changeRecordProfile } = useRecordControls();
-  const [selectedProfileId, setSelectedProfileId] = useState<string | number | null | undefined>();
+  const [selectedProfileId, setSelectedProfileId] = useState<string | number | null | undefined>(null);
 
   const onClose = () => {
     setIsProfileSelectionModalOpen(false);
@@ -39,7 +39,7 @@ export const ProfileSelectionManager = () => {
 
     const updatedSelectedProfileId = profileSelectionType.action === 'change' ? getRecordProfileId(record) : null;
     setSelectedProfileId(updatedSelectedProfileId);
-  }, [isProfileSelectionModalOpen, profileSelectionType.action]);
+  }, [isProfileSelectionModalOpen, profileSelectionType.action, record]);
 
   return isProfileSelectionModalOpen ? (
     <ModalChooseProfile

--- a/src/test/__tests__/components/ProfileSelectionManager.test.tsx
+++ b/src/test/__tests__/components/ProfileSelectionManager.test.tsx
@@ -3,11 +3,12 @@ import { createModalContainer } from '@src/test/__mocks__/common/misc/createModa
 import { setInitialGlobalState } from '@src/test/__mocks__/store';
 import { ProfileSelectionManager } from '@components/ProfileSelectionManager';
 import { ROUTES } from '@common/constants/routes.constants';
-import { useNavigationState, useProfileState, useUIState } from '@src/store';
+import { useInputsState, useNavigationState, useProfileState, useUIState } from '@src/store';
 
 const mockSetIsProfileSelectionModalOpen = jest.fn();
 const mockNavigateToEditPage = jest.fn();
 const mockChangeRecordProfile = jest.fn().mockResolvedValue(undefined);
+const mockGetRecordProfileId = jest.fn();
 
 jest.mock('@common/hooks/useNavigateToEditPage', () => ({
   useNavigateToEditPage: () => ({
@@ -18,6 +19,9 @@ jest.mock('@common/hooks/useRecordControls', () => ({
   useRecordControls: () => ({
     changeRecordProfile: mockChangeRecordProfile,
   }),
+}));
+jest.mock('@common/helpers/record.helper', () => ({
+  getRecordProfileId: () => mockGetRecordProfileId(),
 }));
 
 describe('ProfileSelectionManager', () => {
@@ -158,5 +162,243 @@ describe('ProfileSelectionManager', () => {
     const { container } = render(<ProfileSelectionManager />);
 
     expect(container.firstChild).toBeNull();
+  });
+
+  test('sets selectedProfileId to null when profileSelectionType.action is "set"', () => {
+    setInitialGlobalState([
+      {
+        store: useUIState,
+        state: {
+          isProfileSelectionModalOpen: true,
+          setIsProfileSelectionModalOpen: mockSetIsProfileSelectionModalOpen,
+          profileSelectionType: {
+            action: 'set',
+            resourceType: 'work',
+          },
+        },
+      },
+      {
+        store: useProfileState,
+        state: {
+          availableProfiles: {
+            work: [
+              { id: 'profile_1', name: 'Test Profile 1', resourceType: 'work' },
+              { id: 'profile_2', name: 'Test Profile 2', resourceType: 'work' },
+            ],
+          },
+        },
+      },
+    ]);
+
+    render(<ProfileSelectionManager />);
+
+    expect(screen.getByRole('combobox')).not.toHaveValue('profile_2');
+  });
+
+  test('sets selectedProfileId from record when profileSelectionType.action is "change"', () => {
+    mockGetRecordProfileId.mockReturnValue('profile_2');
+
+    setInitialGlobalState([
+      {
+        store: useUIState,
+        state: {
+          isProfileSelectionModalOpen: true,
+          setIsProfileSelectionModalOpen: mockSetIsProfileSelectionModalOpen,
+          profileSelectionType: {
+            action: 'change',
+            resourceType: 'work',
+          },
+        },
+      },
+      {
+        store: useProfileState,
+        state: {
+          availableProfiles: {
+            work: [
+              { id: 'profile_1', name: 'Test Profile 1', resourceType: 'work' },
+              { id: 'profile_2', name: 'Test Profile 2', resourceType: 'work' },
+            ],
+          },
+        },
+      },
+      {
+        store: useInputsState,
+        state: {
+          record: { profileId: 'profile_2' },
+        },
+      },
+    ]);
+
+    render(<ProfileSelectionManager />);
+
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).toHaveValue('profile_2');
+  });
+
+  test('resets selectedProfileId to null when modal is closed', async () => {
+    mockGetRecordProfileId.mockReturnValue('profile_2');
+
+    setInitialGlobalState([
+      {
+        store: useUIState,
+        state: {
+          isProfileSelectionModalOpen: true,
+          setIsProfileSelectionModalOpen: mockSetIsProfileSelectionModalOpen,
+          profileSelectionType: {
+            action: 'change',
+            resourceType: 'work',
+          },
+        },
+      },
+      {
+        store: useProfileState,
+        state: {
+          availableProfiles: {
+            work: [
+              { id: 'profile_1', name: 'Test Profile 1', resourceType: 'work' },
+              { id: 'profile_2', name: 'Test Profile 2', resourceType: 'work' },
+            ],
+          },
+        },
+      },
+      {
+        store: useInputsState,
+        state: {
+          record: { profileId: 'profile_2' },
+        },
+      },
+    ]);
+
+    const { unmount } = render(<ProfileSelectionManager />);
+
+    // Verify profile is selected initially
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).toHaveValue('profile_2');
+
+    // Close the modal
+    fireEvent.click(screen.getByTestId('modal-button-cancel'));
+
+    expect(mockSetIsProfileSelectionModalOpen).toHaveBeenCalledWith(false);
+
+    // Clean up the first render
+    unmount();
+
+    // Re-open modal with action 'set'
+    setInitialGlobalState([
+      {
+        store: useUIState,
+        state: {
+          isProfileSelectionModalOpen: true,
+          setIsProfileSelectionModalOpen: mockSetIsProfileSelectionModalOpen,
+          profileSelectionType: {
+            action: 'set',
+            resourceType: 'work',
+          },
+        },
+      },
+      {
+        store: useProfileState,
+        state: {
+          availableProfiles: {
+            work: [
+              { id: 'profile_1', name: 'Test Profile 1', resourceType: 'work' },
+              { id: 'profile_2', name: 'Test Profile 2', resourceType: 'work' },
+            ],
+          },
+        },
+      },
+      {
+        store: useInputsState,
+        state: {
+          record: { profileId: 'profile_2' },
+        },
+      },
+    ]);
+
+    // Render again to simulate reopening the modal
+    render(<ProfileSelectionManager />);
+
+    // No profile should be selected after reopening with 'set' action
+    const newSelectElement = screen.getByRole('combobox');
+    expect(newSelectElement).not.toHaveValue('profile_2');
+  });
+
+  test('updates selectedProfileId when record changes', () => {
+    // Initial render with record that has profileId 'profile_1'
+    mockGetRecordProfileId.mockReturnValue('profile_1');
+
+    setInitialGlobalState([
+      {
+        store: useUIState,
+        state: {
+          isProfileSelectionModalOpen: true,
+          setIsProfileSelectionModalOpen: mockSetIsProfileSelectionModalOpen,
+          profileSelectionType: {
+            action: 'change',
+            resourceType: 'work',
+          },
+        },
+      },
+      {
+        store: useProfileState,
+        state: {
+          availableProfiles: {
+            work: [
+              { id: 'profile_1', name: 'Test Profile 1', resourceType: 'work' },
+              { id: 'profile_2', name: 'Test Profile 2', resourceType: 'work' },
+            ],
+          },
+        },
+      },
+      {
+        store: useInputsState,
+        state: {
+          record: { profileId: 'profile_1' },
+        },
+      },
+    ]);
+
+    const { rerender } = render(<ProfileSelectionManager />);
+
+    // Initially profile_1 should be selected
+    expect(screen.getByRole('combobox')).toHaveValue('profile_1');
+
+    // Change the record but keep other dependencies the same
+    mockGetRecordProfileId.mockReturnValue('profile_2');
+
+    setInitialGlobalState([
+      {
+        store: useUIState,
+        state: {
+          isProfileSelectionModalOpen: true,
+          setIsProfileSelectionModalOpen: mockSetIsProfileSelectionModalOpen,
+          profileSelectionType: {
+            action: 'change',
+            resourceType: 'work',
+          },
+        },
+      },
+      {
+        store: useProfileState,
+        state: {
+          availableProfiles: {
+            work: [
+              { id: 'profile_1', name: 'Test Profile 1', resourceType: 'work' },
+              { id: 'profile_2', name: 'Test Profile 2', resourceType: 'work' },
+            ],
+          },
+        },
+      },
+      {
+        store: useInputsState,
+        state: {
+          record: { profileId: 'profile_2' },
+        },
+      },
+    ]);
+
+    rerender(<ProfileSelectionManager />);
+
+    expect(screen.getByRole('combobox')).toHaveValue('profile_2');
   });
 });


### PR DESCRIPTION
[https://folio-org.atlassian.net/browse/UILD-635](https://folio-org.atlassian.net/browse/UILD-635)

**Details:**
- When the action is 'change', the profile ID from the current record is used.
- When the action is 'set' or the modal is closed, the selected profile ID is reset to null, and the first item from the profiles list is selected.