### PR TITLE
UILD-632: Implement profile group member repeatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Add ability to change profiles from Instance Edit view. Refs [UILD-576].
 * Add support for publication frequency. Refs [UILD-618].
 * Add read-only editor field support. Refs [UILD-630].
+* Enable repeatable subcomponents for all groups. Refs [UILD-632].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -67,6 +68,7 @@
 [UILD-576]:https://folio-org.atlassian.net/browse/UILD-576
 [UILD-618]:https://folio-org.atlassian.net/browse/UILD-618
 [UILD-630]:https://folio-org.atlassian.net/browse/UILD-630
+[UILD-632]:https://folio-org.atlassian.net/browse/UILD-632
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/common/helpers/repeatableFields.helper.ts
+++ b/src/common/helpers/repeatableFields.helper.ts
@@ -1,7 +1,6 @@
 import { GROUP_BY_LEVEL } from '@common/constants/bibframe.constants';
-import { findParentEntryByProperty, hasChildEntry } from './schema.helper';
+import { hasChildEntry } from './schema.helper';
 import { AdvancedFieldType, UI_CONTROLS_LIST } from '@common/constants/uiControls.constants';
-import { BFLITE_URIS } from '@common/constants/bibframeMapping.constants';
 
 export const checkRepeatableGroup = ({
   schema,
@@ -31,26 +30,16 @@ export const checkRepeatableGroup = ({
 };
 
 export const checkRepeatableSubcomponent = ({
-  schema,
   entry,
   isDisabled,
 }: {
-  schema: Map<string, SchemaEntry>;
   entry: SchemaEntry;
   isDisabled: boolean;
 }) => {
-  const { type, path, constraints } = entry;
+  const { type, constraints } = entry;
   const isRepeatable =
     !isDisabled &&
     constraints?.repeatable &&
-    // show "Duplicate" button only for Provision Activity's subcomponents
-    // change or remove to display "Duplicate" button for other groups
-    findParentEntryByProperty({
-      schema,
-      path,
-      key: 'uriBFLite',
-      value: BFLITE_URIS.PROVISION_ACTIVITY,
-    }) &&
     // remove this condition after updating the profile
     type === AdvancedFieldType.literal;
 

--- a/src/components/FieldWithMetadataAndControls/FieldWithMetadataAndControls.tsx
+++ b/src/components/FieldWithMetadataAndControls/FieldWithMetadataAndControls.tsx
@@ -36,7 +36,7 @@ export const FieldWithMetadataAndControls: FC<IFieldWithMetadataAndControls> = (
   const { uuid, displayName, htmlId } = entry;
 
   const hasDuplicateGroupButton = checkRepeatableGroup({ schema, entry, level, isDisabled: disabled });
-  const hasDuplicateSubcomponentButton = checkRepeatableSubcomponent({ schema, entry, isDisabled: disabled });
+  const hasDuplicateSubcomponentButton = checkRepeatableSubcomponent({ entry, isDisabled: disabled });
 
   const onClickDuplicateGroup = () => {
     getSchemaWithCopiedEntries(entry, selectedEntries);

--- a/src/test/__tests__/common/helpers/repeatableFields.helper.test.ts
+++ b/src/test/__tests__/common/helpers/repeatableFields.helper.test.ts
@@ -1,4 +1,5 @@
-import { checkRepeatableGroup } from '@common/helpers/repeatableFields.helper';
+import { AdvancedFieldType } from '@common/constants/uiControls.constants';
+import { checkRepeatableGroup, checkRepeatableSubcomponent } from '@common/helpers/repeatableFields.helper';
 import * as SchemaHelper from '@common/helpers/schema.helper';
 
 describe('repeatableFields.helper', () => {
@@ -83,6 +84,80 @@ describe('repeatableFields.helper', () => {
       const result = checkRepeatableGroup(options);
 
       expect(result).toBeTruthy();
+    });
+  });
+
+  describe('checkRepeatableSubcomponent', () => {
+    test('returns true for repeatable, enabled literal field', () => {
+      const options = {
+        entry: {
+          type: AdvancedFieldType.literal,
+          constraints: {
+            repeatable: true,
+          },
+          path: [''],
+          uuid: '',
+        } as SchemaEntry,
+        isDisabled: false,
+      };
+
+      const result = checkRepeatableSubcomponent(options);
+
+      expect(result).toBeTruthy();
+    });
+
+    test('returns false for repeatable, disabled literal field', () => {
+      const options = {
+        entry: {
+          type: AdvancedFieldType.literal,
+          constraints: {
+            repeatable: true,
+          },
+          path: [''],
+          uuid: '',
+        } as SchemaEntry,
+        isDisabled: true,
+      };
+
+      const result = checkRepeatableSubcomponent(options);
+
+      expect(result).toBeFalsy();
+    });
+
+    test('returns false for non-repeatable, enabled literal field', () => {
+      const options = {
+        entry: {
+          type: AdvancedFieldType.literal,
+          constraints: {
+            repeatable: false,
+          },
+          path: [''],
+          uuid: '',
+        } as SchemaEntry,
+        isDisabled: false,
+      };
+
+      const result = checkRepeatableSubcomponent(options);
+
+      expect(result).toBeFalsy();
+    });
+
+    test('returns false for repeatable, enabled non-literal field', () => {
+      const options = {
+        entry: {
+          type: AdvancedFieldType.simple,
+          constraints: {
+            repeatable: true,
+          },
+          path: [''],
+          uuid: '',
+        } as SchemaEntry,
+        isDisabled: false,
+      };
+
+      const result = checkRepeatableSubcomponent(options);
+
+      expect(result).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-632

Remove the restriction for repeating only provision activity submcomponents, and enable globally for any group literal type.