### PR TITLE
UILD-637: Fix - Add profile ID to generated record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Add support for publication frequency. Refs [UILD-618].
 * Add read-only editor field support. Refs [UILD-630].
 * Enable repeatable subcomponents for all groups. Refs [UILD-632].
+* Add profile ID to generated record. Fixes [UILD-637].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -69,6 +70,7 @@
 [UILD-618]:https://folio-org.atlassian.net/browse/UILD-618
 [UILD-630]:https://folio-org.atlassian.net/browse/UILD-630
 [UILD-632]:https://folio-org.atlassian.net/browse/UILD-632
+[UILD-637]:https://folio-org.atlassian.net/browse/UILD-637
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/common/services/recordGenerator/recordGenerator.ts
+++ b/src/common/services/recordGenerator/recordGenerator.ts
@@ -77,8 +77,8 @@ export class RecordGenerator implements IRecordGenerator {
       const processedValue = this.processRootEntry(rootKey, rootProperty);
 
       if (this.isValidValue(processedValue)) {
-        if (rootKey === rootEntryKey && rootProperty.options?.references && this.referenceIds?.length) {
-          this.addReferencesToRootEntry(processedValue, rootProperty.options.references);
+        if (rootKey === rootEntryKey) {
+          this.addReferencesToRootEntry(processedValue, rootProperty);
           this.addProfileId(processedValue as unknown as SchemaEntry);
         }
 
@@ -128,12 +128,14 @@ export class RecordGenerator implements IRecordGenerator {
     return entityKeys.length > 0 ? entityKeys[0] : null;
   }
 
-  private addReferencesToRootEntry(entryNode: SchemaPropertyValue, references: RecordSchemaReferenceDefinition[]) {
-    if (typeof entryNode !== 'object' || entryNode === null) {
+  private addReferencesToRootEntry(entryNode: SchemaPropertyValue, recordSchemaEntry: RecordSchemaEntry) {
+    const hasReferences = recordSchemaEntry.options?.references && this.referenceIds?.length;
+
+    if (typeof entryNode !== 'object' || entryNode === null || !hasReferences) {
       return;
     }
 
-    references.forEach(refDef => {
+    recordSchemaEntry.options?.references?.forEach(refDef => {
       (entryNode as Record<string, SchemaPropertyValue>)[refDef.outputProperty] = this
         .referenceIds as unknown as SchemaPropertyValue;
     });

--- a/src/test/__tests__/common/services/recordGenerator/recordGenerator.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/recordGenerator.test.ts
@@ -206,5 +206,77 @@ describe('RecordGenerator', () => {
         },
       });
     });
+
+    it('adds references to root entry with multiple output properties', () => {
+      const mockMultiRefSchema = {
+        root: {
+          options: {
+            isRootEntry: true,
+            references: [
+              { outputProperty: 'refs_1' },
+              { outputProperty: 'refs_2' }
+            ],
+          },
+        } as RecordSchemaEntry,
+      };
+      jest.spyOn(RecordSchemaFactory, 'getRecordSchema').mockReturnValue(mockMultiRefSchema);
+
+      const multiRefIds = [
+        { id: 'ref-id-1' },
+        { id: 'ref-id-2' }
+      ];
+
+      jest
+        .spyOn(generator['profileSchemaManager'], 'findSchemaEntriesByUriBFLite')
+        .mockReturnValue([{ id: 'test-entry' } as unknown as SchemaEntry]);
+
+      jest
+        .spyOn(generator['recordSchemaEntryManager'], 'processEntry')
+        .mockReturnValue({ value: { rootProperty: 'root value' } } as unknown as ValueResult);
+
+      const result = generator.generate({
+        schema: mockSchema,
+        userValues: mockUserValues,
+        selectedEntries: mockSelectedEntries,
+        referenceIds: multiRefIds,
+      });
+
+      expect(result).toEqual({
+        resource: {
+          root: {
+            rootProperty: 'root value',
+            refs_1: multiRefIds,
+            refs_2: multiRefIds,
+          },
+        },
+      });
+    });
+
+    it('does not add references when root entry value is not an object', () => {
+      jest
+        .spyOn(generator['profileSchemaManager'], 'findSchemaEntriesByUriBFLite')
+        .mockReturnValue([{ id: 'test-entry' } as unknown as SchemaEntry]);
+
+      jest
+        .spyOn(generator['recordSchemaEntryManager'], 'processEntry')
+        .mockReturnValueOnce({ value: 'string value' } as unknown as ValueResult)
+        .mockReturnValueOnce({ value: { test: 'value' } } as unknown as ValueResult);
+
+      const result = generator.generate({
+        schema: mockSchema,
+        userValues: mockUserValues,
+        selectedEntries: mockSelectedEntries,
+        referenceIds: mockReferenceIds,
+      });
+
+      expect(result).toEqual({
+        resource: {
+          root: 'string value',
+          property_1: {
+            test: 'value',
+          },
+        },
+      });
+    });
   });
 });


### PR DESCRIPTION
Enhance reference handling in `RecordGenerator` service. 
Fixes the case: when reference check failed, then the profile ID was not added to the generated record.

[https://folio-org.atlassian.net/browse/UILD-637](https://folio-org.atlassian.net/browse/UILD-637)