### PR TITLE
UILD-631: Implement repeatable flag for simple profile type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Add support for publication frequency. Refs [UILD-618].
 * Add read-only editor field support. Refs [UILD-630].
 * Enable repeatable subcomponents for all groups. Refs [UILD-632].
+* Update simple field widget to allow for single value selection. Refs [UILD-631].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -69,6 +70,7 @@
 [UILD-618]:https://folio-org.atlassian.net/browse/UILD-618
 [UILD-630]:https://folio-org.atlassian.net/browse/UILD-630
 [UILD-632]:https://folio-org.atlassian.net/browse/UILD-632
+[UILD-631]:https://folio-org.atlassian.net/browse/UILD-631
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/components/EditSection/DrawComponent.tsx
+++ b/src/components/EditSection/DrawComponent.tsx
@@ -151,6 +151,7 @@ export const DrawComponent: FC<IDrawComponent & EditSectionDataProps> = ({
           parentUri={constraints?.valueDataType?.dataTypeURI}
           value={selectedUserValue?.contents}
           isDisabled={isDisabled}
+          isMulti={constraints?.repeatable}
           propertyUri={entry.uriBFLite}
           parentBlockUri={blockEntry?.uriBFLite}
           parentGroupUri={groupEntry?.uriBFLite}

--- a/src/components/SimpleLookupField/SimpleLookupField.tsx
+++ b/src/components/SimpleLookupField/SimpleLookupField.tsx
@@ -52,20 +52,31 @@ export const SimpleLookupField: FC<Props> = ({
   const { addStatusMessagesItem } = useStatusState();
   const { simpleLookupRef, forceDisplayOptionsAtTheTop } = useSimpleLookupObserver();
 
-  const [localValueMulti, setLocalValueMulti] = useState<MultiselectOption[]>(
-    value?.map(({ label = '', meta: { uri, basicLabel } = {} }) => ({
+  const userValuesToMultiselect = (value: UserValueContents[] | undefined) => {
+    return value?.map(({ label = '', meta: { uri, basicLabel } = {} }) => ({
       value: { label: basicLabel ?? label, uri },
       label,
       __isNew__: false,
-    })) || [],
+    }));
+  };
+
+  const multiselectToUserValues = (option: MultiselectOption) => {
+    return {
+      label: option.label,
+      meta: {
+        uri: option.value?.uri,
+        parentUri,
+        basicLabel: option.value.label,
+      },
+    };
+  };
+
+  const [localValueMulti, setLocalValueMulti] = useState<MultiselectOption[]>(
+    userValuesToMultiselect(value) || [],
   );
 
   const [localValueSingle, setLocalValueSingle] = useState<MultiselectOption | undefined>(
-    value?.map(({ label = '', meta: { uri, basicLabel } = {} }) => ({
-      value: { label: basicLabel ?? label, uri },
-      label,
-      __isNew__: false,
-    }))?.[0],
+    userValuesToMultiselect(value)?.[0],
   );
 
   const [isLoading, setIsLoading] = useState(false);
@@ -91,29 +102,13 @@ export const SimpleLookupField: FC<Props> = ({
   //   option.__isNew__ ? `${option.label} (uncontrolled)` : option.label;
 
   const handleOnChangeMulti = (options: MultiValue<MultiselectOption>) => {
-    const newValue = options.map<UserValueContents>(({ label, value }) => ({
-      label,
-      meta: {
-        uri: value?.uri,
-        parentUri,
-        basicLabel: value.label,
-      },
-    }));
-
+    const newValue = options.map<UserValueContents>(option => (multiselectToUserValues(option)));
     onChange(uuid, newValue);
     setLocalValueMulti([...options]);
   };
 
   const handleOnChangeSingle = (option: MultiselectOption) => {
-    const newValue = [{
-      label: option.label,
-      meta: {
-        uri: option.value?.uri,
-        parentUri,
-        basicLabel: option.value?.label,
-      },
-    }];
-
+    const newValue = [multiselectToUserValues(option)];
     onChange(uuid, newValue);
     setLocalValueSingle(option);
   }

--- a/src/components/SimpleLookupField/SimpleLookupField.tsx
+++ b/src/components/SimpleLookupField/SimpleLookupField.tsx
@@ -66,7 +66,7 @@ export const SimpleLookupField: FC<Props> = ({
       meta: {
         uri: option.value?.uri,
         parentUri,
-        basicLabel: option.value.label,
+        basicLabel: option.value?.label,
       },
     };
   };

--- a/src/test/__tests__/components/EditSection.test.tsx
+++ b/src/test/__tests__/components/EditSection.test.tsx
@@ -93,7 +93,7 @@ const schema = new Map([
       path: ['uuid0', 'uuid2'],
       uuid: 'uuid2',
       type: AdvancedFieldType.block,
-      children: ['uuid3', 'uuid4', 'uuid5', 'uuid6', 'uuid7', 'uuid9', 'uuid10', 'uuid13', 'uuid14'],
+      children: ['uuid3', 'uuid4', 'uuid5', 'uuid6', 'uuid7', 'uuid9', 'uuid10', 'uuid13'],
     },
   ],
   [

--- a/src/test/__tests__/components/EditSection.test.tsx
+++ b/src/test/__tests__/components/EditSection.test.tsx
@@ -13,7 +13,10 @@ const userValues = {
     uuid: 'uuid3',
     contents: [
       {
-        label: 'uuid3-uservalue-label',
+        label: 'uuid3-uservalue-label-1',
+      },
+      {
+        label: 'uuid3-uservalue-label-2',
       },
     ],
   },
@@ -61,6 +64,17 @@ const userValues = {
       },
     ],
   },
+  uuid14: {
+    uuid: 'uuid14',
+    contents: [
+      {
+        label: 'uuid14-uservalue-label-1',
+      },
+      {
+        label: 'uuid14-uservalue-label-2',
+      },
+    ],
+  },
 };
 
 const schema = new Map([
@@ -93,7 +107,7 @@ const schema = new Map([
       path: ['uuid0', 'uuid2'],
       uuid: 'uuid2',
       type: AdvancedFieldType.block,
-      children: ['uuid3', 'uuid4', 'uuid5', 'uuid6', 'uuid7', 'uuid9', 'uuid10', 'uuid13'],
+      children: ['uuid3', 'uuid4', 'uuid5', 'uuid6', 'uuid7', 'uuid9', 'uuid10', 'uuid13', 'uuid14'],
     },
   ],
   [
@@ -209,12 +223,27 @@ const schema = new Map([
     'uuid13',
     {
       bfid: 'uuid13Bfid',
-      uiBFLite: 'uuid13Uri',
+      uriBFLite: 'uuid13Uri',
       displayName: 'uuid13',
       type: AdvancedFieldType.literal,
       path: ['uuid0', 'uuid2', 'uuid13'],
       uuid: 'uuid13',
       constraints: { editable: false },
+    },
+  ],
+  [
+    'uuid14',
+    {
+      bfid: 'uuid14Bfid',
+      uriBFLite: 'uuid14Uri',
+      displayName: 'uuid14',
+      type: AdvancedFieldType.simple,
+      path: ['uuid0', 'uuid2', 'uuid14'],
+      uuid: 'uuid14',
+      constraints: {
+        repeatable: false,
+        useValuesFrom: ['uuid14-useValuesFromURI'], 
+      },
     },
   ],
 ]);
@@ -269,7 +298,7 @@ describe('EditSection', () => {
   test('renders literal; simple and complex lookup labels and values', async () => {
     const { findByText } = renderScreen();
 
-    expect(await findByText('uuid3-uservalue-label')).toBeInTheDocument();
+    expect(await findByText('uuid3-uservalue-label-1')).toBeInTheDocument();
     expect(await findByText('uuid4')).toBeInTheDocument();
     expect(await findByText('uuid5')).toBeInTheDocument();
   });
@@ -343,5 +372,31 @@ describe('EditSection', () => {
 
     const section = await getByTestId('field-with-meta-controls-uuid13')
     expect(within(section).getByTestId('literal-field')).toBeDisabled();
+  });
+
+  describe('simple lookup field repeatability', () => {
+    test('when repeatable, library uses multiselect', async () => {
+      const { getByTestId } = renderScreen();
+      const section = await getByTestId('field-with-meta-controls-uuid3');
+      expect(section.querySelector('.simple-lookup__multi-value')).toBeInTheDocument();
+    });
+
+    test('when repeatable, set value to all initial values', async () => {
+      const { findByText } = renderScreen();
+      expect(await findByText('uuid3-uservalue-label-1')).toBeInTheDocument();
+      expect(await findByText('uuid3-uservalue-label-2')).toBeInTheDocument();
+    });
+
+    test('when not repeatable, library uses single value select', async () => {
+      const { getByTestId } = renderScreen();
+      const section = await getByTestId('field-with-meta-controls-uuid14');
+      expect(section.querySelector('.simple-lookup__single-value')).toBeInTheDocument();
+    });
+
+    test('when not repeatable, set only the first initial value', async () => {
+      const { findByText, queryByText } = renderScreen();
+      expect(await findByText('uuid14-uservalue-label-1')).toBeInTheDocument();
+      expect(await queryByText('uuid14-uservalue-label-2')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/test/__tests__/components/EditSection.test.tsx
+++ b/src/test/__tests__/components/EditSection.test.tsx
@@ -13,10 +13,7 @@ const userValues = {
     uuid: 'uuid3',
     contents: [
       {
-        label: 'uuid3-uservalue-label-1',
-      },
-      {
-        label: 'uuid3-uservalue-label-2',
+        label: 'uuid3-uservalue-label',
       },
     ],
   },
@@ -61,17 +58,6 @@ const userValues = {
     contents: [
       {
         label: 'uuid13-uservalue-label',
-      },
-    ],
-  },
-  uuid14: {
-    uuid: 'uuid14',
-    contents: [
-      {
-        label: 'uuid14-uservalue-label-1',
-      },
-      {
-        label: 'uuid14-uservalue-label-2',
       },
     ],
   },
@@ -231,21 +217,6 @@ const schema = new Map([
       constraints: { editable: false },
     },
   ],
-  [
-    'uuid14',
-    {
-      bfid: 'uuid14Bfid',
-      uriBFLite: 'uuid14Uri',
-      displayName: 'uuid14',
-      type: AdvancedFieldType.simple,
-      path: ['uuid0', 'uuid2', 'uuid14'],
-      uuid: 'uuid14',
-      constraints: {
-        repeatable: false,
-        useValuesFrom: ['uuid14-useValuesFromURI'], 
-      },
-    },
-  ],
 ]);
 
 const monograph = {
@@ -298,7 +269,7 @@ describe('EditSection', () => {
   test('renders literal; simple and complex lookup labels and values', async () => {
     const { findByText } = renderScreen();
 
-    expect(await findByText('uuid3-uservalue-label-1')).toBeInTheDocument();
+    expect(await findByText('uuid3-uservalue-label')).toBeInTheDocument();
     expect(await findByText('uuid4')).toBeInTheDocument();
     expect(await findByText('uuid5')).toBeInTheDocument();
   });
@@ -306,7 +277,7 @@ describe('EditSection', () => {
   test('renders dropdown field', async () => {
     const { getByTestId, findByText } = renderScreen();
 
-    const section = await getByTestId('field-with-meta-controls-uuid6');
+    const section = getByTestId('field-with-meta-controls-uuid6');
     expect(await within(section).findByText('ld.type')).toBeInTheDocument();
     expect(await findByText('uuid7')).toBeInTheDocument();
   });
@@ -314,7 +285,7 @@ describe('EditSection', () => {
   test('renders enumerated field', async () => {
     const { getByTestId, findByText } = renderScreen();
 
-    const section = await getByTestId('field-with-meta-controls-uuid10')
+    const section = getByTestId('field-with-meta-controls-uuid10')
     expect(await within(section).findByText('ld.type')).toBeInTheDocument();
     expect(await findByText('uuid11')).toBeInTheDocument();
   });
@@ -328,7 +299,7 @@ describe('EditSection', () => {
   test('calls onchange and sets values', async () => {
     const { getByTestId, findByDisplayValue } = renderScreen();
 
-    const section = await getByTestId('field-with-meta-controls-uuid4');
+    const section = getByTestId('field-with-meta-controls-uuid4');
     fireEvent.change(within(section).getByTestId('literal-field'), { target: { value: 'sampleValue' } });
 
     await waitFor(async () => expect(await findByDisplayValue('sampleValue')).toBeInTheDocument());
@@ -337,7 +308,7 @@ describe('EditSection', () => {
   test('calls onchange for enumerated and sets values', async () => {
     const { getByTestId, findByDisplayValue } = renderScreen();
 
-    const section = await getByTestId('field-with-meta-controls-uuid10')
+    const section = getByTestId('field-with-meta-controls-uuid10')
     fireEvent.change(within(section).getByTestId('dropdown-field'), { target: { value: 'http://bibfra.me/vocab/lite/summaryLanguage' } });
 
     await waitFor(async () => expect(await findByDisplayValue('uuid12')).toBeInTheDocument());
@@ -370,33 +341,7 @@ describe('EditSection', () => {
 
     expect(await findByText('uuid13')).toBeInTheDocument();
 
-    const section = await getByTestId('field-with-meta-controls-uuid13')
+    const section = getByTestId('field-with-meta-controls-uuid13')
     expect(within(section).getByTestId('literal-field')).toBeDisabled();
-  });
-
-  describe('simple lookup field repeatability', () => {
-    test('when repeatable, library uses multiselect', async () => {
-      const { getByTestId } = renderScreen();
-      const section = await getByTestId('field-with-meta-controls-uuid3');
-      expect(section.querySelector('.simple-lookup__multi-value')).toBeInTheDocument();
-    });
-
-    test('when repeatable, set value to all initial values', async () => {
-      const { findByText } = renderScreen();
-      expect(await findByText('uuid3-uservalue-label-1')).toBeInTheDocument();
-      expect(await findByText('uuid3-uservalue-label-2')).toBeInTheDocument();
-    });
-
-    test('when not repeatable, library uses single value select', async () => {
-      const { getByTestId } = renderScreen();
-      const section = await getByTestId('field-with-meta-controls-uuid14');
-      expect(section.querySelector('.simple-lookup__single-value')).toBeInTheDocument();
-    });
-
-    test('when not repeatable, set only the first initial value', async () => {
-      const { findByText, queryByText } = renderScreen();
-      expect(await findByText('uuid14-uservalue-label-1')).toBeInTheDocument();
-      expect(await queryByText('uuid14-uservalue-label-2')).not.toBeInTheDocument();
-    });
   });
 });

--- a/src/test/__tests__/components/SimpleLookupField.test.tsx
+++ b/src/test/__tests__/components/SimpleLookupField.test.tsx
@@ -79,7 +79,7 @@ describe('Simple lookup field', () => {
     test('when not repeatable, set only the first initial value', async () => {
       const { findByText, queryByText } = renderScreen(false);
       expect(await findByText('value-1')).toBeInTheDocument();
-      expect(await queryByText('value-2')).not.toBeInTheDocument();
+      expect(queryByText('value-2')).not.toBeInTheDocument();
     });
 
     test('when not repeatable, library uses single value select', async () => {
@@ -92,8 +92,8 @@ describe('Simple lookup field', () => {
       await user.selectOptions(select, 'value-3');
       await user.keyboard('{enter}');
 
-      expect(await queryByText('value-1')).not.toBeInTheDocument();
-      expect(await queryByText('value-2')).not.toBeInTheDocument();
+      expect(queryByText('value-1')).not.toBeInTheDocument();
+      expect(queryByText('value-2')).not.toBeInTheDocument();
       expect(await findByText('value-3')).toBeInTheDocument();
     });
   });

--- a/src/test/__tests__/components/SimpleLookupField.test.tsx
+++ b/src/test/__tests__/components/SimpleLookupField.test.tsx
@@ -50,7 +50,7 @@ describe('Simple lookup field', () => {
     );
   };
 
-  describe('simple lookup field repeatability', () => {
+  describe('repeatability', () => {
     beforeEach(() => {
       jest.clearAllMocks();
     });

--- a/src/test/__tests__/components/SimpleLookupField.test.tsx
+++ b/src/test/__tests__/components/SimpleLookupField.test.tsx
@@ -1,0 +1,100 @@
+import '@src/test/__mocks__/common/hooks/useRecordControls.mock';
+import '@src/test/__mocks__/common/hooks/useConfig.mock';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MockServicesProvider } from '@src/test/__mocks__/providers/ServicesProvider.mock';
+import { SimpleLookupField } from '@components/SimpleLookupField';
+
+jest.mock('@common/constants/build.constants', () => ({ IS_EMBEDDED_MODE: false }));
+
+jest.mock('@common/hooks/useSimpleLookupData', () => ({
+  useSimpleLookupData: () => ({
+    getLookupData: jest.fn().mockReturnValue({
+      lookupUri: [
+        {
+          label: 'value-1',
+        },
+        {
+          label: 'value-2',
+        },
+        {
+          label: 'value-3',
+        },
+      ]
+    }),
+    loadLookupData: jest.fn(),
+  }),
+}));
+
+describe('Simple lookup field', () => {
+  const renderScreen = (isMulti: boolean) => {
+    const initialValue = [
+      {
+        label: 'value-1',
+      },
+      {
+        label: 'value-2',
+      },
+    ];
+
+    return render(
+      <MockServicesProvider>
+        <SimpleLookupField
+          uri='lookupUri'
+          uuid='uuid1'
+          onChange={() => {}}
+          value={initialValue}
+          isMulti={isMulti}
+          />
+      </MockServicesProvider>
+    );
+  };
+
+  describe('simple lookup field repeatability', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test('when repeatable, set value to all initial values', async () => {
+      const { findByText } = renderScreen(true);
+      expect(await findByText('value-1')).toBeInTheDocument();
+      expect(await findByText('value-2')).toBeInTheDocument();
+    });
+
+    test('when repeatable, library uses multiselect', async () => {
+      const user = userEvent.setup();
+      const { findByText, getByRole } = renderScreen(true);
+
+      const activate = getByRole('combobox');
+      await user.click(activate);
+      const select = getByRole('listbox');
+      await user.selectOptions(select, 'value-3');
+      await user.keyboard('{enter}');
+
+      expect(await findByText('value-1')).toBeInTheDocument();
+      expect(await findByText('value-2')).toBeInTheDocument();
+      expect(await findByText('value-3')).toBeInTheDocument();
+    });
+
+    test('when not repeatable, set only the first initial value', async () => {
+      const { findByText, queryByText } = renderScreen(false);
+      expect(await findByText('value-1')).toBeInTheDocument();
+      expect(await queryByText('value-2')).not.toBeInTheDocument();
+    });
+
+    test('when not repeatable, library uses single value select', async () => {
+      const user = userEvent.setup();
+      const { findByText, queryByText, getByRole } = renderScreen(false);
+
+      const activate = getByRole('combobox');
+      await user.click(activate);
+      const select = getByRole('listbox');
+      await user.selectOptions(select, 'value-3');
+      await user.keyboard('{enter}');
+
+      expect(await queryByText('value-1')).not.toBeInTheDocument();
+      expect(await queryByText('value-2')).not.toBeInTheDocument();
+      expect(await findByText('value-3')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-631

This brief screen recording demonstrates the following:

1. The current multiselect behavior where choosing another value adds it to the current list
2. Compared to the new single select behavior where choosing another value replaces the existing one

![single](https://github.com/user-attachments/assets/fed0651a-9184-4b6e-aa8f-b43a6b69ee54)
