### PR TITLE
UILD-629: Remove repeat button from non-repeatable group section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Enable repeatable subcomponents for all groups. Refs [UILD-632].
 * Add profile ID to generated record. Fixes [UILD-637].
 * Add ability to set profile as default. Refs [UILD-574].
+* Remove buttons when a group is not repeatable. Refs [UILD-629].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -73,6 +74,7 @@
 [UILD-632]:https://folio-org.atlassian.net/browse/UILD-632
 [UILD-637]:https://folio-org.atlassian.net/browse/UILD-637
 [UILD-574]:https://folio-org.atlassian.net/browse/UILD-574
+[UILD-629]:https://folio-org.atlassian.net/browse/UILD-629
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/common/helpers/repeatableFields.helper.ts
+++ b/src/common/helpers/repeatableFields.helper.ts
@@ -13,9 +13,12 @@ export const checkRepeatableGroup = ({
   level?: number;
   isDisabled: boolean;
 }) => {
-  const { type, children } = entry;
+  const { type, children, constraints } = entry;
 
-  let isRepeatableGroup = level === GROUP_BY_LEVEL && !isDisabled;
+  let isRepeatableGroup =
+    level === GROUP_BY_LEVEL &&
+    !isDisabled &&
+    (constraints?.repeatable !== false || typeof constraints === 'undefined');
 
   if (isRepeatableGroup) {
     const isGroupType = type === AdvancedFieldType.group;
@@ -39,7 +42,7 @@ export const checkRepeatableSubcomponent = ({
   const { type, constraints } = entry;
   const isRepeatable =
     !isDisabled &&
-    constraints?.repeatable &&
+    (constraints?.repeatable !== false || typeof constraints === 'undefined' ) &&
     // remove this condition after updating the profile
     type === AdvancedFieldType.literal;
 

--- a/src/test/__tests__/common/helpers/repeatableFields.helper.test.ts
+++ b/src/test/__tests__/common/helpers/repeatableFields.helper.test.ts
@@ -45,6 +45,68 @@ describe('repeatableFields.helper', () => {
       expect(result).toBeFalsy();
     });
 
+    test('returns false if entry is not repeatable', () => {
+      const options = {
+        schema,
+        entry: {
+          constraints: {
+            repeatable: false,
+          },
+        } as SchemaEntry,
+        level: 2,
+        isDisabled: false,
+      };
+
+      const result = checkRepeatableGroup(options);
+
+      expect(result).toBeFalsy();
+    });
+
+    test('returns true if no constraints', () => {
+      const options = {
+        schema,
+        entry: {} as SchemaEntry,
+        level: 2,
+        isDisabled: false,
+      };
+
+      const result = checkRepeatableGroup(options);
+
+      expect(result).toBeTruthy();
+    });
+
+    test('returns true if repeatable not set in constraints', () => {
+      const options = {
+        schema,
+        entry: {
+          constraints: {},
+        } as SchemaEntry,
+        level: 2,
+        isDisabled: false,
+      };
+
+      const result = checkRepeatableGroup(options);
+
+      expect(result).toBeTruthy();
+    });
+
+    test('returns true when repeatable constraint is true', () => {
+      const options = {
+        schema,
+        entry: {
+          constraints: {
+            repeatable: true,
+          },
+        } as SchemaEntry,
+        level: 2,
+        isDisabled: false,
+      };
+
+      const result = checkRepeatableGroup(options);
+
+      expect(result).toBeTruthy();
+    });
+
     test('returns true if entry type is not a group', () => {
       const options = {
         schema,


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-629

The Admin metadata section would previously have had button controls for adding another instance or removing if more than one were available; this change removes the buttons entirely as this section should not be repeated or removed.

<img width="1563" height="815" alt="Screenshot 2025-08-28 at 15 44 26" src="https://github.com/user-attachments/assets/d39084df-148c-468c-8ea2-1b5135b33515" />
