### PR TITLE
UILD-628: Add profile selection for Work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Update simple field widget to allow for single value selection. Refs [UILD-631].
 * Avoid cloning unique admin metadata when duplicating an instance. Refs [UILD-638].
 * Add profile changing scenarios. Refs [UILD-634].
+* Add profile selection for Work. Refs [UILD-628].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -81,6 +82,7 @@
 [UILD-631]:https://folio-org.atlassian.net/browse/UILD-631
 [UILD-638]:https://folio-org.atlassian.net/browse/UILD-638
 [UILD-634]:https://folio-org.atlassian.net/browse/UILD-634
+[UILD-628]:https://folio-org.atlassian.net/browse/UILD-628
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/common/hooks/useNavigateToCreatePage.ts
+++ b/src/common/hooks/useNavigateToCreatePage.ts
@@ -18,22 +18,27 @@ export const useNavigateToCreatePage = () => {
   const navigationStateRef = useRef<SearchParamsState>();
 
   // Creates query parameters object for resource creation
-  const createQueryParams = ({ type, refId }: { type: string; refId: string }) => {
-    if (!type || !refId) return null;
+  const createQueryParams = ({ type, refId }: { type: string; refId?: string | null }) => {
+    if (!type) return null;
 
-    return {
+    const queryParams = {
       [QueryParams.Type]: type,
-      [QueryParams.Ref]: refId,
     } as Record<QueryParams, string>;
+
+    if (refId) {
+      queryParams[QueryParams.Ref] = refId;
+    }
+
+    return queryParams;
   };
 
   // Handles navigation after profile selection
   const handleProfileSelection = (profileId: string | number) => {
-    if (!queryParamsRef.current.type || !queryParamsRef.current.refId) return;
+    if (!queryParamsRef.current.type) return;
 
     const params = createQueryParams({
       type: queryParamsRef.current.type,
-      refId: queryParamsRef.current.refId,
+      refId: queryParamsRef.current.refId ?? null,
     });
 
     if (params) {
@@ -57,10 +62,7 @@ export const useNavigateToCreatePage = () => {
     queryParams: { type?: string | null; refId?: string | null };
     navigationState?: SearchParamsState;
   }) => {
-    const params =
-      queryParams.type && queryParams.refId
-        ? createQueryParams({ type: queryParams.type, refId: queryParams.refId })
-        : null;
+    const params = queryParams.type ? createQueryParams({ type: queryParams.type, refId: queryParams.refId }) : null;
 
     // Store current query parameters and navigation state for later use
     queryParamsRef.current = queryParams;

--- a/src/test/__tests__/common/hooks/useNavigateToCreatePage.test.ts
+++ b/src/test/__tests__/common/hooks/useNavigateToCreatePage.test.ts
@@ -129,15 +129,15 @@ describe('useNavigateToCreatePage', () => {
       expect(navigateToEditPage).toHaveBeenCalledWith(testURL, testNavigationState);
     });
 
-    test('does not navigate when type or refId are missing', async () => {
+    test('does not navigate when type are missing', async () => {
       const { result } = renderHook(() => useNavigateToCreatePage());
 
       await act(async () => {
         result.current.onCreateNewResource({
           resourceTypeURL: testResourceTypeURL,
           queryParams: {
-            type: testType,
-            refId: null,
+            type: null,
+            refId: testRefId,
           },
         });
       });
@@ -151,7 +151,7 @@ describe('useNavigateToCreatePage', () => {
   });
 
   describe('createQueryParams', () => {
-    test('returns null when type or refId are missing', async () => {
+    test('returns null when type are missing', async () => {
       const { result } = renderHook(() => useNavigateToCreatePage());
 
       await act(async () => {
@@ -159,7 +159,7 @@ describe('useNavigateToCreatePage', () => {
           resourceTypeURL: testResourceTypeURL,
           queryParams: {
             type: null,
-            refId: null,
+            refId: testRefId,
           },
         });
       });

--- a/src/test/__tests__/views/Search.test.tsx
+++ b/src/test/__tests__/views/Search.test.tsx
@@ -1,11 +1,20 @@
 import '@src/test/__mocks__/common/helpers/pageScrolling.helper.mock';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { setInitialGlobalState } from '@src/test/__mocks__/store';
 import { useSearchStore, useUIStore } from '@src/store';
 import { Search } from '@views';
+import { TYPE_URIS } from '@common/constants/bibframe.constants';
+import { ResourceType } from '@common/constants/record.constants';
 
 jest.mock('@common/constants/build.constants', () => ({ IS_EMBEDDED_MODE: false }));
+
+const onCreateNewResource = jest.fn();
+jest.mock('@common/hooks/useNavigateToCreatePage', () => ({
+  useNavigateToCreatePage: () => ({
+    onCreateNewResource,
+  }),
+}));
 
 describe('Search', () => {
   beforeEach(() =>
@@ -54,6 +63,23 @@ describe('Search', () => {
 
       expect(mockResetFullDisplayComponentType).toHaveBeenCalled();
       expect(mockResetSelectedInstances).toHaveBeenCalled();
+    });
+  });
+
+  describe('Actions dropdown', () => {
+    test('calls onCreateNewResource when "Create a new resource" option is clicked', () => {
+      // Click the Actions dropdown button
+      fireEvent.click(screen.getByTestId('search-view-actions-dropdown'));
+
+      // Click the "Create a new resource" option
+      fireEvent.click(screen.getByTestId('search-view-actions-dropdown__option-ld.newResource'));
+
+      expect(onCreateNewResource).toHaveBeenCalledWith({
+        resourceTypeURL: TYPE_URIS.WORK,
+        queryParams: {
+          type: ResourceType.work,
+        },
+      });
     });
   });
 });

--- a/src/views/Search/Search.tsx
+++ b/src/views/Search/Search.tsx
@@ -7,7 +7,6 @@ import { SearchControlPane } from '@components/SearchControlPane';
 import { ModalImport } from '@components/ModalImport';
 import { useNavigateToEditPage } from '@common/hooks/useNavigateToEditPage';
 import { DropdownItemType, FullDisplayType } from '@common/constants/uiElements.constants';
-import { ROUTES } from '@common/constants/routes.constants';
 import { Dropdown } from '@components/Dropdown';
 import { ResourceType } from '@common/constants/record.constants';
 import { SEARCH_RESOURCE_API_ENDPOINT } from '@common/constants/api.constants';
@@ -17,8 +16,10 @@ import Transfer16 from '@src/assets/transfer-16.svg?react';
 import Lightning16 from '@src/assets/lightning-16.svg?react';
 import { filters } from './data/filters';
 import { useContainerEvents } from '@common/hooks/useContainerEvents';
+import { useNavigateToCreatePage } from '@common/hooks/useNavigateToCreatePage';
 import { useInputsState, useLoadingState, useSearchState, useStatusState, useUIState } from '@src/store';
 import { StatusType } from '@common/constants/status.constants';
+import { TYPE_URIS } from '@common/constants/bibframe.constants';
 import { useRecordControls } from '@common/hooks/useRecordControls';
 import { UserNotificationFactory } from '@common/services/userNotification';
 import './Search.scss';
@@ -33,6 +34,7 @@ export const SearchView = () => {
   const { setFullDisplayComponentType, resetFullDisplayComponentType } = useUIState();
   const { isImportModalOpen, setIsImportModalOpen } = useUIState();
   const { resetPreviewContent } = useInputsState();
+  const { onCreateNewResource } = useNavigateToCreatePage();
 
   useEffect(() => {
     return () => {
@@ -61,10 +63,19 @@ export const SearchView = () => {
     }
   };
 
-  const handleImport = async() => {
+  const handleImport = async () => {
     if (!isImportModalOpen) {
       setIsImportModalOpen(true);
     }
+  };
+
+  const onClickNewWork = () => {
+    onCreateNewResource({
+      resourceTypeURL: TYPE_URIS.WORK as ResourceTypeURL,
+      queryParams: {
+        type: ResourceType.work,
+      },
+    });
   };
 
   const items = useMemo(
@@ -78,9 +89,7 @@ export const SearchView = () => {
             type: DropdownItemType.basic,
             labelId: 'ld.newResource',
             icon: <Plus16 />,
-            action: () => {
-              navigateToEditPage(`${ROUTES.RESOURCE_CREATE.uri}?type=${ResourceType.work}`);
-            },
+            action: onClickNewWork,
           },
           {
             id: 'compare',


### PR DESCRIPTION
Added the ability to select a profile when the user clicks "Create a new resource" in the Actions menu.

[https://folio-org.atlassian.net/browse/UILD-628](https://folio-org.atlassian.net/browse/UILD-628)

**Technical details:**
Refactored the `useNavigateToCreatePage` hook since the `refId` parameter may be optional and not used when creating the Work resource type.