### PR TITLE
UILD-642: Fix: Update group processor for repeated fields

### DIFF
--- a/src/common/services/recordGenerator/processors/profileSchema/groupProcessor.ts
+++ b/src/common/services/recordGenerator/processors/profileSchema/groupProcessor.ts
@@ -144,7 +144,7 @@ export class GroupProcessor extends BaseFieldProcessor {
 
     if (!matchingEntry || !recordSchemaProperty) return;
 
-    this.processEntryByType(entryType, childEntry.uriBFLite, childValues, recordSchemaProperty, groupObject);
+    this.processEntryByType(entryType, childEntry.uriBFLite, childValues, recordSchemaProperty, groupObject, !!childEntry?.constraints?.repeatable);
   }
 
   private processEntryByType(
@@ -153,11 +153,12 @@ export class GroupProcessor extends BaseFieldProcessor {
     values: UserValueContents[],
     recordSchemaProperty: RecordSchemaEntry,
     groupObject: GeneratedValue,
+    repeatable: boolean,
   ) {
     if (entryType === AdvancedFieldType.complex) {
       this.processComplexEntry(values, recordSchemaProperty, groupObject);
     } else {
-      this.processSimpleEntry(uriBFLite, entryType, values, recordSchemaProperty, groupObject);
+      this.processSimpleEntry(uriBFLite, entryType, values, recordSchemaProperty, groupObject, repeatable);
     }
   }
 
@@ -184,11 +185,21 @@ export class GroupProcessor extends BaseFieldProcessor {
     values: UserValueContents[],
     recordSchemaProperty: RecordSchemaEntry,
     groupObject: GeneratedValue,
+    repeatable: boolean,
   ) {
     const processedValues = this.processSimpleValues(entryType, values, recordSchemaProperty);
 
     if (processedValues.length > 0) {
-      groupObject[uriBFLite] = Array.isArray(processedValues) ? processedValues : [processedValues];
+      const valuesArray = Array.isArray(processedValues) ? processedValues : [processedValues];
+      if (repeatable && groupObject[uriBFLite]) {
+        if (Array.isArray(groupObject[uriBFLite])) {
+          groupObject[uriBFLite].push(...valuesArray);
+        } else {
+          groupObject[uriBFLite] = [groupObject[uriBFLite], ...valuesArray];
+        }
+      } else {
+        groupObject[uriBFLite] = valuesArray;
+      }
     }
   }
 

--- a/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/groupProcessor.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/processors/profileSchema/groupProcessor.test.ts
@@ -372,6 +372,69 @@ describe('GroupProcessor', () => {
       expect(result).toEqual([{ uri_1: ['value 1', 'value 2'] }]);
     });
 
+    it('processes multiple values for the same repeatable child correctly', () => {
+      const profileSchemaEntry = {
+        type: AdvancedFieldType.group,
+        uuid: 'test_uuid',
+        children: ['child_1_0', 'child_1_1', 'child_1_2'],
+      } as SchemaEntry;
+      const userValues = {
+        child_1_0: {
+          contents: [{ label: 'value 1' }],
+        },
+        child_1_1: {
+          contents: [{ label: 'value 2' }],
+        },
+        child_1_2: {
+          contents: [{ label: 'value 3' }, { label: 'value 4'}],
+        },
+      } as unknown as UserValues;
+      const recordSchemaEntry = {
+        type: RecordSchemaEntryType.array,
+        value: RecordSchemaEntryType.object,
+        properties: {
+          uri_1: { type: RecordSchemaEntryType.string },
+        },
+      } as RecordSchemaEntry;
+
+      mockProfileSchemaManager.getSchemaEntry.mockImplementation((uuid => {
+        switch (uuid) {
+          case 'child_1_0':
+            return {
+              uuid: 'child_1_0',
+              type: AdvancedFieldType.literal,
+              uriBFLite: 'uri_1',
+              constraints: {
+                repeatable: true,
+              },
+            } as SchemaEntry;
+          case 'child_1_1':
+            return {
+              uuid: 'child_1_1',
+              type: AdvancedFieldType.literal,
+              uriBFLite: 'uri_1',
+              constraints: {
+                repeatable: true,
+              },
+            } as SchemaEntry;
+          case 'child_1_2':
+          default:
+            return {
+              uuid: 'child_1_2',
+              type: AdvancedFieldType.literal,
+              uriBFLite: 'uri_1',
+              constraints: {
+                repeatable: true,
+              },
+            } as SchemaEntry;
+        }
+      }));
+
+      const result = processor.process({ profileSchemaEntry, userValues, selectedEntries, recordSchemaEntry });
+
+      expect(result).toEqual([{ uri_1: ['value 1', 'value 2', 'value 3', 'value 4'] }]);
+    });
+
     it('processes multiple children with multiple values correctly', () => {
       const profileSchemaEntry = {
         type: AdvancedFieldType.group,


### PR DESCRIPTION
- https://folio-org.atlassian.net/browse/UILD-642 (describes bug)
- https://folio-org.atlassian.net/browse/UILD-632 (introduces repeatable literal fields)

The group processor presumes user values are returned as a list for more complex field types, but with the introduction of repeatable literal fields in a group, the implementation ends up replacing successive values in the final computed value object instead of combining them, resulting in a final DTO with just one value instead of all of them.

Update the group processor to combine multiple fields representing the same URI, only when repeatable.