### PR TITLE
UILD-574: Fix - broken Edit and Action buttons on the Edit page

### DIFF
--- a/src/views/Edit/Edit.tsx
+++ b/src/views/Edit/Edit.tsx
@@ -16,7 +16,7 @@ import { ViewMarcModal } from '@components/ViewMarcModal';
 import { useInputsState, useLoadingState, useMarcPreviewState, useStatusState, useUIState } from '@src/store';
 import './Edit.scss';
 
-const ignoreLoadingStatuses = [RecordStatus.saveAndClose, RecordStatus.saveAndKeepEditing, RecordStatus.close];
+const ignoreLoadingStatuses = [RecordStatus.saveAndClose, RecordStatus.saveAndKeepEditing];
 
 export const Edit = () => {
   const { getProfiles } = useConfig();
@@ -35,7 +35,6 @@ export const Edit = () => {
 
   const prevResourceId = useRef<string | null | undefined>(null);
   const prevCloneOf = useRef<string | null>(null);
-  const prevRecordStatusType = useRef<string | null>(null);
 
   function setEntitesBFIds() {
     const resourceDecriptionType = (typeParam as ResourceType) || ResourceType.instance;
@@ -85,19 +84,17 @@ export const Edit = () => {
     resetHasShownAuthorityWarning();
   }, [resourceId]);
 
+  // TODO: UILD-60, UILD-643 - refactor this after introducing Zustand selectors and React Query
   useEffect(() => {
     async function loadRecord() {
       if (!recordStatusType || ignoreLoadingStatuses.includes(recordStatusType)) return;
 
       const fetchableId = resourceId ?? cloneOfParam;
-      const statusChanged = prevRecordStatusType.current !== recordStatusType;
-      prevRecordStatusType.current = recordStatusType;
 
       if (
         (!cloneOfParam && resourceId && prevResourceId.current === resourceId) ||
         (cloneOfParam && prevCloneOf.current === cloneOfParam) ||
-        (!fetchableId && !refParam) ||
-        !statusChanged
+        (!fetchableId && !refParam)
       ) {
         return;
       }


### PR DESCRIPTION
[https://folio-org.atlassian.net/browse/UILD-574](https://folio-org.atlassian.net/browse/UILD-574)

Removed unused record status handling and cleaned up loading status checks in `Edit` component.
This was added to prevent unnecessary processing and API requests. In fact, this is what caused the regression.
This can be fixed by adding Zustand selectors and React Query. There are technical debt tickets for this:
[https://folio-org.atlassian.net/browse/UILD-643](https://folio-org.atlassian.net/browse/UILD-643)
[https://folio-org.atlassian.net/browse/UILD-60](https://folio-org.atlassian.net/browse/UILD-60)