### PR TITLE
UILD-646: Fix - Search results: error is shown when no results found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Add profile selection for Work. Refs [UILD-628].
 * Add tooltips with MARC labels. Refs [UILD-538].
 * Update vocabulary term IRIs to replace 'marc' with 'library'. Refs [UILD-603].
+* Search results: error is shown when no results found. Fixes [UILD-646].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -87,6 +88,7 @@
 [UILD-628]:https://folio-org.atlassian.net/browse/UILD-628
 [UILD-538]:https://folio-org.atlassian.net/browse/UILD-538
 [UILD-603]:https://folio-org.atlassian.net/browse/UILD-603
+[UILD-646]:https://folio-org.atlassian.net/browse/UILD-646
 
 ## 1.0.5 (2025-04-30)
 * Fixed incorrect behavior when navigating between duplicated resources. Fixes [UILD-553].

--- a/src/common/hooks/useFetchSearchData.ts
+++ b/src/common/hooks/useFetchSearchData.ts
@@ -153,7 +153,7 @@ export const useFetchSearchData = () => {
 
         const { content, totalPages, totalRecords, prev, next } = result;
 
-        if (!content.length) return setMessage('ld.searchNoRdsMatch');
+        if (!content?.length) return setMessage('ld.searchNoRdsMatch');
 
         setData(content);
         setPageMetadata({ totalPages, totalElements: totalRecords, prev, next });


### PR DESCRIPTION
Fixes an error when the API response does not contain the `content` field.

[https://folio-org.atlassian.net/browse/UILD-646](https://folio-org.atlassian.net/browse/UILD-646)
