### PR TITLE
UILD-647: Fix for broken search

### DIFF
--- a/src/common/hooks/useFetchSearchData.ts
+++ b/src/common/hooks/useFetchSearchData.ts
@@ -42,7 +42,7 @@ export const useFetchSearchData = () => {
     endpointUrlsBySegments?: EndpointUrlsBySegments;
     endpointUrl: string;
   }) => {
-    return selectedSegment ? endpointUrlsBySegments?.[selectedSegment] : endpointUrl;
+    return selectedSegment && endpointUrlsBySegments ? endpointUrlsBySegments[selectedSegment] : endpointUrl;
   };
 
   const generateQuery = ({


### PR DESCRIPTION
Regression fix: Ensure that `undefined` value of `endpointUrlsBySegments` is handled when retrieving the endpoint URL, since the base search does not contain any segments and corresponding configuration.

[https://folio-org.atlassian.net/browse/UILD-647](https://folio-org.atlassian.net/browse/UILD-647)