### PR TITLE
UILD-730: Assigning Hubs as Subjects - Change Authority button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 * Update custom settings toggle behavior. Refs [UILD-727].
 * Add mandatory field handling in custom settings. Refs [UILD-728].
 * Add possibility to assign Hubs as Subjects. Refs [UILD-711].
+* Add possibility to change the assigned Hubs as Subjects. Refs [UILD-730].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -167,6 +168,7 @@
 [UILD-727]:https://folio-org.atlassian.net/browse/UILD-727
 [UILD-728]:https://folio-org.atlassian.net/browse/UILD-728
 [UILD-711]:https://folio-org.atlassian.net/browse/UILD-711
+[UILD-730]:https://folio-org.atlassian.net/browse/UILD-730
 
 ## 1.0.5 (2025-04-30)
 * Browser Back button navigates to Edit without duplicated title when navigated from Duplicate screen. Fixes [UILD-554].

--- a/src/common/constants/lookup.constants.ts
+++ b/src/common/constants/lookup.constants.ts
@@ -747,3 +747,13 @@ export const lookupConfig: Record<string, any> = {
     ],
   },
 };
+
+export const LOOKUP_TYPES = {
+  AUTHORITIES: 'authorities',
+  HUBS: 'hubs',
+} as const;
+
+export const SOURCE_TYPES = {
+  LOCAL: 'local',
+  LIBRARY_OF_CONGRESS: 'libraryOfCongress',
+} as const;

--- a/src/common/constants/lookup.constants.ts
+++ b/src/common/constants/lookup.constants.ts
@@ -6,7 +6,7 @@ export const VALUE_KEY = '@value';
 export const CODE_SEPARATOR = '/';
 
 // TODO: Make correct types
-export const lookupConfig: Record<string, any> = {
+export const lookupConfig: Record<string, unknown> = {
   'http://id.loc.gov/authorities/childrensSubjects': {
     name: 'childrensSubjects',
     type: 'complex',

--- a/src/common/services/recordNormalizing/recordProcessingCases.ts
+++ b/src/common/services/recordNormalizing/recordProcessingCases.ts
@@ -1,8 +1,7 @@
 import { BFLITE_URIS } from '@/common/constants/bibframeMapping.constants';
+import { LOOKUP_TYPES, SOURCE_TYPES } from '@/common/constants/lookup.constants';
 import { ensureArray } from '@/common/helpers/common.helper';
 import { getLookupLabelKey } from '@/common/helpers/schema.helper';
-
-import { LOOKUP_TYPES, SOURCE_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
 
 const getHubSourceType = (hasRdfLink: boolean, hasHubId: boolean): string | undefined => {
   if (hasRdfLink) return SOURCE_TYPES.LIBRARY_OF_CONGRESS;

--- a/src/common/services/recordNormalizing/recordProcessingCases.ts
+++ b/src/common/services/recordNormalizing/recordProcessingCases.ts
@@ -2,6 +2,8 @@ import { BFLITE_URIS } from '@/common/constants/bibframeMapping.constants';
 import { ensureArray } from '@/common/helpers/common.helper';
 import { getLookupLabelKey } from '@/common/helpers/schema.helper';
 
+import { LOOKUP_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
+
 const getHubSourceType = (hasRdfLink: boolean, hasHubId: boolean): string | undefined => {
   if (hasRdfLink) return 'libraryOfCongress';
   if (hasHubId) return 'local';
@@ -150,4 +152,21 @@ export const extractDropdownOption = (
 
     return { [recordEntry[fieldName][0]]: updatedValues };
   }) as unknown as RecursiveRecordSchema;
+};
+
+export const processSubjectComplexLookup = (record: RecordEntry, blockKey: string, key: string) => {
+  const originalEntries = record[blockKey][key] as unknown as RecordProcessingDTO;
+
+  processComplexLookup(record, blockKey, key, 'label');
+
+  const normalizedEntries = record[blockKey][key] as unknown as RecursiveRecordSchema[];
+
+  normalizedEntries.forEach((entry, index) => {
+    const original = originalEntries[index] as Record<string, unknown>;
+    const types = original?.types as string[] | undefined;
+
+    (entry as Record<string, unknown>).lookupType = types?.includes(BFLITE_URIS.HUB)
+      ? LOOKUP_TYPES.HUBS
+      : LOOKUP_TYPES.AUTHORITIES;
+  });
 };

--- a/src/common/services/recordNormalizing/recordProcessingCases.ts
+++ b/src/common/services/recordNormalizing/recordProcessingCases.ts
@@ -2,11 +2,11 @@ import { BFLITE_URIS } from '@/common/constants/bibframeMapping.constants';
 import { ensureArray } from '@/common/helpers/common.helper';
 import { getLookupLabelKey } from '@/common/helpers/schema.helper';
 
-import { LOOKUP_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
+import { LOOKUP_TYPES, SOURCE_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
 
 const getHubSourceType = (hasRdfLink: boolean, hasHubId: boolean): string | undefined => {
-  if (hasRdfLink) return 'libraryOfCongress';
-  if (hasHubId) return 'local';
+  if (hasRdfLink) return SOURCE_TYPES.LIBRARY_OF_CONGRESS;
+  if (hasHubId) return SOURCE_TYPES.LOCAL;
 
   return undefined;
 };

--- a/src/common/services/recordNormalizing/recordProcessingMap.ts
+++ b/src/common/services/recordNormalizing/recordProcessingMap.ts
@@ -8,6 +8,7 @@ import {
   notesMapping,
   processComplexLookup,
   processHubsComplexLookup,
+  processSubjectComplexLookup,
   wrapSimpleLookupData,
   wrapWithContainer,
 } from './recordProcessingCases';
@@ -17,9 +18,6 @@ const processProvisionActivity = (record: RecordEntry, blockKey: string, groupKe
 
 const processContributorComplexLookup = (record: RecordEntry, blockKey: string, groupKey: string) =>
   processComplexLookup(record, blockKey, groupKey, '_name');
-
-const processSubjectComplexLookup = (record: RecordEntry, blockKey: string, groupKey: string) =>
-  processComplexLookup(record, blockKey, groupKey, 'label');
 
 export const RECORD_NORMALIZING_CASES = {
   [BFLITE_URIS.PRODUCTION]: {

--- a/src/common/services/userValues/userValueTypes/complexLookup.ts
+++ b/src/common/services/userValues/userValueTypes/complexLookup.ts
@@ -18,7 +18,12 @@ export class ComplexLookupUserValueService implements IUserValueType {
     return data.map(item => ({
       id: this.getInternalId(item) ?? this.getId(item, id),
       label: this.getLabel(item),
-      meta: { type, uri: this.getUri(item), sourceType: this.getSourceType(item) },
+      meta: {
+        type,
+        uri: this.getUri(item),
+        sourceType: this.getSourceType(item),
+        lookupType: this.getLookupType(item),
+      },
     }));
   }
 
@@ -30,6 +35,7 @@ export class ComplexLookupUserValueService implements IUserValueType {
         type,
         uri: this.getUri(data),
         sourceType: this.getSourceType(data),
+        lookupType: this.getLookupType(data),
         ...this.getPreferredMeta(data),
       },
     };
@@ -67,6 +73,10 @@ export class ComplexLookupUserValueService implements IUserValueType {
 
   private getSourceType(data: unknown) {
     return (data as { sourceType?: string })?.sourceType;
+  }
+
+  private getLookupType(data: unknown) {
+    return (data as { lookupType?: string })?.lookupType;
   }
 
   private getInternalId(data: unknown) {

--- a/src/features/complexLookup/components/ComplexLookupField/ComplexLookupField.tsx
+++ b/src/features/complexLookup/components/ComplexLookupField/ComplexLookupField.tsx
@@ -69,7 +69,6 @@ export const ComplexLookupField: FC<Props> = ({ value = undefined, id, entry, on
       isOpen: isModalOpen,
       onClose: handleCloseModal,
       onAssign: handleAssign,
-      initialQuery: localValue?.[0]?.label,
       assignedValue: localValue?.[0],
       ...modalDefaultProps,
     };

--- a/src/features/complexLookup/components/ComplexLookupField/ComplexLookupField.tsx
+++ b/src/features/complexLookup/components/ComplexLookupField/ComplexLookupField.tsx
@@ -70,6 +70,7 @@ export const ComplexLookupField: FC<Props> = ({ value = undefined, id, entry, on
       onClose: handleCloseModal,
       onAssign: handleAssign,
       initialQuery: localValue?.[0]?.label,
+      assignedValue: localValue?.[0],
       ...modalDefaultProps,
     };
 

--- a/src/features/complexLookup/components/modals/AuthoritiesModal/AuthoritiesModal.test.tsx
+++ b/src/features/complexLookup/components/modals/AuthoritiesModal/AuthoritiesModal.test.tsx
@@ -256,14 +256,15 @@ describe('AuthoritiesModal', () => {
       });
     });
 
-    it('passes initialQuery to useComplexLookupModalState', () => {
+    it('passes assignedValue to useComplexLookupModalState', () => {
+      const assignedValue = { label: 'Test Query' } as UserValueContents;
       render(
-        <AuthoritiesModal isOpen={true} onClose={mockOnClose} onAssign={mockOnAssign} initialQuery="Test Query" />,
+        <AuthoritiesModal isOpen={true} onClose={mockOnClose} onAssign={mockOnAssign} assignedValue={assignedValue} />,
       );
 
       expect(ComplexLookupHooks.useComplexLookupModalState).toHaveBeenCalledWith(
         expect.objectContaining({
-          initialQuery: 'Test Query',
+          assignedValue: { label: 'Test Query' },
         }),
       );
     });

--- a/src/features/complexLookup/components/modals/AuthoritiesModal/AuthoritiesModal.tsx
+++ b/src/features/complexLookup/components/modals/AuthoritiesModal/AuthoritiesModal.tsx
@@ -14,8 +14,8 @@ import { Search } from '@/features/search/ui/components/Search';
 interface AuthoritiesModalProps {
   isOpen: boolean;
   onClose: VoidFunction;
-  initialQuery?: string;
   initialSegment?: 'search' | 'browse';
+  assignedValue?: UserValueContents;
   entry?: SchemaEntry;
   lookupContext?: string;
   modalConfig?: ModalConfig;
@@ -28,8 +28,8 @@ interface AuthoritiesModalProps {
 export const AuthoritiesModal: FC<AuthoritiesModalProps> = ({
   isOpen,
   onClose,
-  initialQuery,
   initialSegment = 'browse',
+  assignedValue,
   entry,
   lookupContext,
   modalConfig,
@@ -40,7 +40,7 @@ export const AuthoritiesModal: FC<AuthoritiesModalProps> = ({
   // Reset search state and set initial query when modal opens
   useComplexLookupModalState({
     isOpen,
-    initialQuery,
+    assignedValue,
     defaultSegment: `authorities:${initialSegment}`,
   });
 

--- a/src/features/complexLookup/components/modals/HubsModal/HubsModal.test.tsx
+++ b/src/features/complexLookup/components/modals/HubsModal/HubsModal.test.tsx
@@ -116,26 +116,26 @@ describe('HubsModal', () => {
 
   describe('Modal state management', () => {
     it('calls useComplexLookupModalState with correct parameters', () => {
-      const initialQuery = 'Test Hub';
+      const assignedValue = { label: 'Test Hub' } as UserValueContents;
 
       renderWithProviders(
-        <HubsModal isOpen={true} onClose={mockOnClose} onAssign={mockOnAssign} initialQuery={initialQuery} />,
+        <HubsModal isOpen={true} onClose={mockOnClose} onAssign={mockOnAssign} assignedValue={assignedValue} />,
       );
 
       expect(ComplexLookupHooks.useComplexLookupModalState).toHaveBeenCalledWith({
         isOpen: true,
-        initialQuery: 'Test Hub',
+        assignedValue: { label: 'Test Hub' },
         defaultSegment: 'hubsLookup',
         defaultSource: 'libraryOfCongress',
       });
     });
 
-    it('calls useComplexLookupModalState without initialQuery when not provided', () => {
+    it('calls useComplexLookupModalState without assignedValue when not provided', () => {
       renderWithProviders(<HubsModal isOpen={true} onClose={mockOnClose} onAssign={mockOnAssign} />);
 
       expect(ComplexLookupHooks.useComplexLookupModalState).toHaveBeenCalledWith({
         isOpen: true,
-        initialQuery: undefined,
+        assignedValue: undefined,
         defaultSegment: 'hubsLookup',
         defaultSource: 'libraryOfCongress',
       });

--- a/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
+++ b/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
@@ -11,7 +11,6 @@ import { Search } from '@/features/search/ui/components/Search';
 interface HubsModalProps {
   isOpen: boolean;
   onClose: VoidFunction;
-  initialQuery?: string;
   assignedValue?: UserValueContents;
   onAssign: (value: UserValueContents | ComplexLookupAssignRecordDTO) => void;
 }
@@ -20,13 +19,13 @@ interface HubsModalProps {
  * HubsModal - Modal wrapper for Hub lookup using new Search feature.
  * Supports import-on-assign for external hubs.
  */
-export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, initialQuery, assignedValue, onAssign }) => {
+export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, assignedValue, onAssign }) => {
   const defaultSource = getDefaultHubSource(assignedValue);
 
   // Reset search state and set initial query when modal opens
   useComplexLookupModalState({
     isOpen,
-    initialQuery,
+    assignedValue,
     defaultSegment: 'hubsLookup',
     defaultSource,
   });

--- a/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
+++ b/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { LookupModal } from '@/features/complexLookup/components/LookupModal';
 import { HubsContent } from '@/features/complexLookup/components/content';
 import { useComplexLookupModalState } from '@/features/complexLookup/hooks';
+import { getDefaultHubSource } from '@/features/complexLookup/utils';
 import { SOURCE_OPTIONS } from '@/features/search/ui';
 import { Search } from '@/features/search/ui/components/Search';
 
@@ -11,6 +12,7 @@ interface HubsModalProps {
   isOpen: boolean;
   onClose: VoidFunction;
   initialQuery?: string;
+  assignedValue?: UserValueContents;
   onAssign: (value: UserValueContents | ComplexLookupAssignRecordDTO) => void;
 }
 
@@ -18,13 +20,15 @@ interface HubsModalProps {
  * HubsModal - Modal wrapper for Hub lookup using new Search feature.
  * Supports import-on-assign for external hubs.
  */
-export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, initialQuery, onAssign }) => {
+export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, initialQuery, assignedValue, onAssign }) => {
+  const defaultSource = getDefaultHubSource(assignedValue);
+
   // Reset search state and set initial query when modal opens
   useComplexLookupModalState({
     isOpen,
     initialQuery,
     defaultSegment: 'hubsLookup',
-    defaultSource: 'libraryOfCongress',
+    defaultSource,
   });
 
   return (
@@ -32,7 +36,7 @@ export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, initialQuery, o
       <Search
         segments={['hubsLookup']}
         defaultSegment="hubsLookup"
-        defaultSource="libraryOfCongress"
+        defaultSource={defaultSource}
         flow="value"
         mode="custom"
       >
@@ -41,7 +45,7 @@ export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, initialQuery, o
           <Search.Controls.SubmitButton />
           <Search.Controls.MetaControls />
 
-          <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue="libraryOfCongress" />
+          <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue={defaultSource} />
         </Search.Controls>
 
         <Search.Content>

--- a/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.test.tsx
+++ b/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.test.tsx
@@ -153,7 +153,7 @@ describe('SubjectModal', () => {
 
       expect(ComplexLookupHooks.useComplexLookupModalState).toHaveBeenCalledWith({
         isOpen: true,
-        initialQuery: undefined,
+        assignedValue: undefined,
         defaultSegment: 'authorities:browse',
       });
     });
@@ -163,17 +163,20 @@ describe('SubjectModal', () => {
 
       expect(ComplexLookupHooks.useComplexLookupModalState).toHaveBeenCalledWith({
         isOpen: true,
-        initialQuery: undefined,
+        assignedValue: undefined,
         defaultSegment: 'authorities:search',
       });
     });
 
-    it('passes initialQuery to useComplexLookupModalState', () => {
-      render(<SubjectModal isOpen={true} onClose={mockOnClose} onAssign={mockOnAssign} initialQuery="Test Query" />);
+    it('passes assignedValue to useComplexLookupModalState', () => {
+      const assignedValue = { label: 'Test Query' } as UserValueContents;
+      render(
+        <SubjectModal isOpen={true} onClose={mockOnClose} onAssign={mockOnAssign} assignedValue={assignedValue} />,
+      );
 
       expect(ComplexLookupHooks.useComplexLookupModalState).toHaveBeenCalledWith(
         expect.objectContaining({
-          initialQuery: 'Test Query',
+          assignedValue: { label: 'Test Query' },
         }),
       );
     });

--- a/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
+++ b/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react';
 import { FormattedMessage } from 'react-intl';
 
+import { LOOKUP_TYPES } from '@/common/constants/lookup.constants';
+
 import { LookupModal } from '@/features/complexLookup/components/LookupModal';
 import { AuthoritiesContent, HubsContent } from '@/features/complexLookup/components/content';
 import { ModalConfig } from '@/features/complexLookup/configs/modalRegistry';
-import { LOOKUP_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
 import {
   useAuthoritiesModalLogic,
   useComplexLookupModalCleanup,

--- a/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
+++ b/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
@@ -17,7 +17,6 @@ import { Search } from '@/features/search/ui/components/Search';
 interface SubjectModalProps {
   isOpen: boolean;
   onClose: VoidFunction;
-  initialQuery?: string;
   initialSegment?: 'search' | 'browse';
   assignedValue?: UserValueContents;
   entry?: SchemaEntry;
@@ -33,7 +32,6 @@ interface SubjectModalProps {
 export const SubjectModal: FC<SubjectModalProps> = ({
   isOpen,
   onClose,
-  initialQuery,
   initialSegment = 'browse',
   assignedValue,
   entry,
@@ -49,7 +47,7 @@ export const SubjectModal: FC<SubjectModalProps> = ({
 
   useComplexLookupModalState({
     isOpen,
-    initialQuery,
+    assignedValue,
     defaultSegment,
     ...(defaultSource ? { defaultSource } : {}),
   });

--- a/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
+++ b/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { LookupModal } from '@/features/complexLookup/components/LookupModal';
 import { AuthoritiesContent, HubsContent } from '@/features/complexLookup/components/content';
 import { ModalConfig } from '@/features/complexLookup/configs/modalRegistry';
-import { LOOKUP_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
+import { LOOKUP_TYPES, SOURCE_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
 import {
   useAuthoritiesModalLogic,
   useComplexLookupModalCleanup,
@@ -44,7 +44,7 @@ export const SubjectModal: FC<SubjectModalProps> = ({
   const isAssignedHub = assignedValue?.meta?.lookupType === LOOKUP_TYPES.HUBS;
 
   const defaultSegment = isAssignedHub ? 'hubsLookup' : `authorities:${initialSegment}`;
-  const defaultSource = isAssignedHub ? assignedValue?.meta?.sourceType || 'libraryOfCongress' : undefined;
+  const defaultSource = isAssignedHub ? assignedValue?.meta?.sourceType || SOURCE_TYPES.LIBRARY_OF_CONGRESS : undefined;
 
   useComplexLookupModalState({
     isOpen,

--- a/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
+++ b/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
@@ -4,12 +4,13 @@ import { FormattedMessage } from 'react-intl';
 import { LookupModal } from '@/features/complexLookup/components/LookupModal';
 import { AuthoritiesContent, HubsContent } from '@/features/complexLookup/components/content';
 import { ModalConfig } from '@/features/complexLookup/configs/modalRegistry';
-import { LOOKUP_TYPES, SOURCE_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
+import { LOOKUP_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
 import {
   useAuthoritiesModalLogic,
   useComplexLookupModalCleanup,
   useComplexLookupModalState,
 } from '@/features/complexLookup/hooks';
+import { getDefaultHubSource } from '@/features/complexLookup/utils';
 import { SOURCE_OPTIONS } from '@/features/search/ui';
 import { Search } from '@/features/search/ui/components/Search';
 
@@ -44,7 +45,7 @@ export const SubjectModal: FC<SubjectModalProps> = ({
   const isAssignedHub = assignedValue?.meta?.lookupType === LOOKUP_TYPES.HUBS;
 
   const defaultSegment = isAssignedHub ? 'hubsLookup' : `authorities:${initialSegment}`;
-  const defaultSource = isAssignedHub ? assignedValue?.meta?.sourceType || SOURCE_TYPES.LIBRARY_OF_CONGRESS : undefined;
+  const defaultSource = isAssignedHub ? getDefaultHubSource(assignedValue) : undefined;
 
   useComplexLookupModalState({
     isOpen,
@@ -114,7 +115,7 @@ export const SubjectModal: FC<SubjectModalProps> = ({
           <Search.Controls.MetaControls />
 
           <Search.Controls.SegmentContent segment="hubsLookup">
-            <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue="libraryOfCongress" />
+            <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue={defaultSource} />
           </Search.Controls.SegmentContent>
         </Search.Controls>
 

--- a/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
+++ b/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
@@ -43,6 +43,7 @@ export const SubjectModal: FC<SubjectModalProps> = ({
   const hasComplexFlow = !!(entry && lookupContext && modalConfig);
   const isAssignedHub = assignedValue?.meta?.lookupType === LOOKUP_TYPES.HUBS;
 
+  // TODO: refactor this to use a constant or enum instead of hardcoded values
   const defaultSegment = isAssignedHub ? 'hubsLookup' : `authorities:${initialSegment}`;
   const defaultSource = isAssignedHub ? getDefaultHubSource(assignedValue) : undefined;
 

--- a/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
+++ b/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { LookupModal } from '@/features/complexLookup/components/LookupModal';
 import { AuthoritiesContent, HubsContent } from '@/features/complexLookup/components/content';
 import { ModalConfig } from '@/features/complexLookup/configs/modalRegistry';
+import { LOOKUP_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
 import {
   useAuthoritiesModalLogic,
   useComplexLookupModalCleanup,
@@ -17,6 +18,7 @@ interface SubjectModalProps {
   onClose: VoidFunction;
   initialQuery?: string;
   initialSegment?: 'search' | 'browse';
+  assignedValue?: UserValueContents;
   entry?: SchemaEntry;
   lookupContext?: string;
   modalConfig?: ModalConfig;
@@ -32,17 +34,23 @@ export const SubjectModal: FC<SubjectModalProps> = ({
   onClose,
   initialQuery,
   initialSegment = 'browse',
+  assignedValue,
   entry,
   lookupContext,
   modalConfig,
   onAssign,
 }) => {
   const hasComplexFlow = !!(entry && lookupContext && modalConfig);
+  const isAssignedHub = assignedValue?.meta?.lookupType === LOOKUP_TYPES.HUBS;
+
+  const defaultSegment = isAssignedHub ? 'hubsLookup' : `authorities:${initialSegment}`;
+  const defaultSource = isAssignedHub ? assignedValue?.meta?.sourceType || 'libraryOfCongress' : undefined;
 
   useComplexLookupModalState({
     isOpen,
     initialQuery,
-    defaultSegment: `authorities:${initialSegment}`,
+    defaultSegment,
+    ...(defaultSource ? { defaultSource } : {}),
   });
 
   const {
@@ -73,7 +81,7 @@ export const SubjectModal: FC<SubjectModalProps> = ({
     <LookupModal isOpen={isOpen} onClose={handleModalClose} title={<FormattedMessage id="ld.searchSubjectAuthority" />}>
       <Search
         segments={['authorities:search', 'authorities:browse', 'hubsLookup']}
-        defaultSegment={`authorities:${initialSegment}`}
+        defaultSegment={defaultSegment}
         flow="value"
         mode="custom"
       >

--- a/src/features/complexLookup/constants/complexLookup.constants.ts
+++ b/src/features/complexLookup/constants/complexLookup.constants.ts
@@ -37,6 +37,11 @@ export const LOOKUP_TYPES = {
   HUBS: 'hubs',
 } as const;
 
+export const SOURCE_TYPES = {
+  LOCAL: 'local',
+  LIBRARY_OF_CONGRESS: 'libraryOfCongress',
+} as const;
+
 export enum Authority {
   Creator = 'creator',
   Subject = 'subject',

--- a/src/features/complexLookup/constants/complexLookup.constants.ts
+++ b/src/features/complexLookup/constants/complexLookup.constants.ts
@@ -32,6 +32,11 @@ export const COMPLEX_LOOKUPS_LINKED_FIELDS_MAPPING = {
 export const EMPTY_LINKED_DROPDOWN_OPTION_SUFFIX = 'empty';
 export const VALUE_DIVIDER = ' ,';
 
+export const LOOKUP_TYPES = {
+  AUTHORITIES: 'authorities',
+  HUBS: 'hubs',
+} as const;
+
 export enum Authority {
   Creator = 'creator',
   Subject = 'subject',

--- a/src/features/complexLookup/constants/complexLookup.constants.ts
+++ b/src/features/complexLookup/constants/complexLookup.constants.ts
@@ -32,16 +32,6 @@ export const COMPLEX_LOOKUPS_LINKED_FIELDS_MAPPING = {
 export const EMPTY_LINKED_DROPDOWN_OPTION_SUFFIX = 'empty';
 export const VALUE_DIVIDER = ' ,';
 
-export const LOOKUP_TYPES = {
-  AUTHORITIES: 'authorities',
-  HUBS: 'hubs',
-} as const;
-
-export const SOURCE_TYPES = {
-  LOCAL: 'local',
-  LIBRARY_OF_CONGRESS: 'libraryOfCongress',
-} as const;
-
 export enum Authority {
   Creator = 'creator',
   Subject = 'subject',

--- a/src/features/complexLookup/hooks/useAuthoritiesAssignment.test.ts
+++ b/src/features/complexLookup/hooks/useAuthoritiesAssignment.test.ts
@@ -2,6 +2,7 @@ import { setInitialGlobalState } from '@/test/__mocks__/store';
 
 import { renderHook, waitFor } from '@testing-library/react';
 
+import { LOOKUP_TYPES } from '@/common/constants/lookup.constants';
 import { StatusType } from '@/common/constants/status.constants';
 import { AdvancedFieldType } from '@/common/constants/uiControls.constants';
 
@@ -187,6 +188,7 @@ describe('useAuthoritiesAssignment', () => {
         label: 'Test Title',
         meta: {
           type: AdvancedFieldType.complex,
+          lookupType: LOOKUP_TYPES.AUTHORITIES,
           srsId: 'srs-id',
         },
       });

--- a/src/features/complexLookup/hooks/useAuthoritiesAssignment.ts
+++ b/src/features/complexLookup/hooks/useAuthoritiesAssignment.ts
@@ -5,6 +5,8 @@ import { AdvancedFieldType } from '@/common/constants/uiControls.constants';
 import { useServicesContext } from '@/common/hooks/useServicesContext';
 import { UserNotificationFactory } from '@/common/services/userNotification';
 
+import { LOOKUP_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
+
 import { useInputsState, useMarcPreviewState, useProfileState, useStatusState } from '@/store';
 
 import { ModalConfig } from '../configs/modalRegistry';
@@ -126,6 +128,7 @@ export function useAuthoritiesAssignment({
           meta: {
             type: AdvancedFieldType.complex,
             srsId,
+            lookupType: LOOKUP_TYPES.AUTHORITIES,
           },
         };
 

--- a/src/features/complexLookup/hooks/useAuthoritiesAssignment.ts
+++ b/src/features/complexLookup/hooks/useAuthoritiesAssignment.ts
@@ -1,11 +1,10 @@
 import { useCallback, useState } from 'react';
 
+import { LOOKUP_TYPES } from '@/common/constants/lookup.constants';
 import { StatusType } from '@/common/constants/status.constants';
 import { AdvancedFieldType } from '@/common/constants/uiControls.constants';
 import { useServicesContext } from '@/common/hooks/useServicesContext';
 import { UserNotificationFactory } from '@/common/services/userNotification';
-
-import { LOOKUP_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
 
 import { useInputsState, useMarcPreviewState, useProfileState, useStatusState } from '@/store';
 

--- a/src/features/complexLookup/hooks/useComplexLookupModalState.test.ts
+++ b/src/features/complexLookup/hooks/useComplexLookupModalState.test.ts
@@ -41,7 +41,7 @@ describe('useComplexLookupModalState', () => {
       renderHook(() =>
         useComplexLookupModalState({
           isOpen: true,
-          initialQuery: 'test',
+          assignedValue: { label: 'test' } as UserValueContents,
           defaultSegment: 'authorities:browse',
         }),
       );
@@ -55,7 +55,7 @@ describe('useComplexLookupModalState', () => {
       renderHook(() =>
         useComplexLookupModalState({
           isOpen: true,
-          initialQuery: 'test query',
+          assignedValue: { label: 'test query' } as UserValueContents,
           defaultSegment: 'authorities:browse',
         }),
       );
@@ -73,7 +73,7 @@ describe('useComplexLookupModalState', () => {
       renderHook(() =>
         useComplexLookupModalState({
           isOpen: true,
-          initialQuery: 'test',
+          assignedValue: { label: 'test' } as UserValueContents,
           defaultSegment: 'authorities:browse',
         }),
       );
@@ -92,7 +92,7 @@ describe('useComplexLookupModalState', () => {
       renderHook(() =>
         useComplexLookupModalState({
           isOpen: true,
-          initialQuery: 'test',
+          assignedValue: { label: 'test' } as UserValueContents,
           defaultSegment: 'hubs',
           defaultSource: 'external',
         }),
@@ -109,7 +109,7 @@ describe('useComplexLookupModalState', () => {
       );
     });
 
-    it('resets drafts when no initial query', () => {
+    it('resets drafts when no assigned value', () => {
       renderHook(() =>
         useComplexLookupModalState({
           isOpen: true,
@@ -127,7 +127,7 @@ describe('useComplexLookupModalState', () => {
       renderHook(() =>
         useComplexLookupModalState({
           isOpen: false,
-          initialQuery: 'test',
+          assignedValue: { label: 'test' } as UserValueContents,
           defaultSegment: 'authorities:browse',
         }),
       );
@@ -143,7 +143,7 @@ describe('useComplexLookupModalState', () => {
       renderHook(() =>
         useComplexLookupModalState({
           isOpen: false,
-          initialQuery: 'test',
+          assignedValue: { label: 'test' } as UserValueContents,
           defaultSegment: 'authorities:browse',
         }),
       );
@@ -155,12 +155,12 @@ describe('useComplexLookupModalState', () => {
   });
 
   describe('state transitions', () => {
-    it('reinitializes when query changes', () => {
+    it('reinitializes when assigned value changes', () => {
       const { rerender } = renderHook(
         ({ query }) =>
           useComplexLookupModalState({
             isOpen: true,
-            initialQuery: query,
+            assignedValue: { label: query } as UserValueContents,
             defaultSegment: 'authorities:browse',
           }),
         { initialProps: { query: 'first' } },
@@ -179,7 +179,7 @@ describe('useComplexLookupModalState', () => {
         ({ isOpen }) =>
           useComplexLookupModalState({
             isOpen,
-            initialQuery: 'test',
+            assignedValue: { label: 'test' } as UserValueContents,
             defaultSegment: 'authorities:browse',
           }),
         { initialProps: { isOpen: true } },

--- a/src/features/complexLookup/hooks/useComplexLookupModalState.ts
+++ b/src/features/complexLookup/hooks/useComplexLookupModalState.ts
@@ -4,22 +4,23 @@ import { useSearchState } from '@/store';
 
 interface UseComplexLookupModalStateParams {
   isOpen: boolean;
-  initialQuery?: string;
+  assignedValue?: UserValueContents;
   defaultSegment: string;
   defaultSource?: string;
 }
 
 /**
  * Custom hook to manage search state lifecycle for complex lookup modals.
- * Resets all search state when modal opens and sets initial query if provided.
+ * Resets all search state when modal opens and sets initial query from assignedValue if provided.
  * This ensures each modal starts with a clean state regardless of previous modal usage.
  */
 export function useComplexLookupModalState({
   isOpen,
-  initialQuery,
+  assignedValue,
   defaultSegment,
   defaultSource,
 }: UseComplexLookupModalStateParams) {
+  const initialQuery = assignedValue?.label;
   const {
     setQuery,
     resetQuery,

--- a/src/features/complexLookup/hooks/useHubAssignment.test.ts
+++ b/src/features/complexLookup/hooks/useHubAssignment.test.ts
@@ -2,6 +2,7 @@ import { setInitialGlobalState } from '@/test/__mocks__/store';
 
 import { renderHook, waitFor } from '@testing-library/react';
 
+import { LOOKUP_TYPES } from '@/common/constants/lookup.constants';
 import { StatusType } from '@/common/constants/status.constants';
 import { AdvancedFieldType } from '@/common/constants/uiControls.constants';
 import { UserNotificationFactory } from '@/common/services/userNotification';
@@ -58,6 +59,7 @@ describe('useHubAssignment', () => {
         label: 'Local Hub Title',
         meta: {
           type: AdvancedFieldType.complex,
+          lookupType: LOOKUP_TYPES.HUBS,
           uri: 'http://example.com/hub1',
           sourceType: 'local',
         },
@@ -102,6 +104,7 @@ describe('useHubAssignment', () => {
         label: 'External Hub Title',
         meta: {
           type: AdvancedFieldType.complex,
+          lookupType: LOOKUP_TYPES.HUBS,
           uri: 'http://example.com/hub2',
           sourceType: 'libraryOfCongress',
         },
@@ -204,6 +207,7 @@ describe('useHubAssignment', () => {
         label: 'Hub Without URI',
         meta: {
           type: AdvancedFieldType.complex,
+          lookupType: LOOKUP_TYPES.HUBS,
           uri: undefined,
           sourceType: 'libraryOfCongress',
         },

--- a/src/features/complexLookup/hooks/useHubAssignment.ts
+++ b/src/features/complexLookup/hooks/useHubAssignment.ts
@@ -4,6 +4,8 @@ import { StatusType } from '@/common/constants/status.constants';
 import { AdvancedFieldType } from '@/common/constants/uiControls.constants';
 import { UserNotificationFactory } from '@/common/services/userNotification';
 
+import { LOOKUP_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
+
 import { useStatusState } from '@/store';
 
 import { useHubImportAssignmentMutation } from './useHubImportAssignmentMutation';
@@ -50,6 +52,7 @@ export function useHubAssignment({ onAssignSuccess }: UseHubAssignmentParams): U
             type: AdvancedFieldType.complex,
             uri,
             sourceType,
+            lookupType: LOOKUP_TYPES.HUBS,
           },
         };
 

--- a/src/features/complexLookup/hooks/useHubAssignment.ts
+++ b/src/features/complexLookup/hooks/useHubAssignment.ts
@@ -4,7 +4,7 @@ import { StatusType } from '@/common/constants/status.constants';
 import { AdvancedFieldType } from '@/common/constants/uiControls.constants';
 import { UserNotificationFactory } from '@/common/services/userNotification';
 
-import { LOOKUP_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
+import { LOOKUP_TYPES, SOURCE_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
 
 import { useStatusState } from '@/store';
 
@@ -39,7 +39,7 @@ export function useHubAssignment({ onAssignSuccess }: UseHubAssignmentParams): U
         let assignId = id;
 
         // External hubs require import to generate a local resource id
-        if (sourceType !== 'local' && uri) {
+        if (sourceType !== SOURCE_TYPES.LOCAL && uri) {
           const { importedId } = await importForAssignment({ hubUri: uri });
 
           assignId = importedId;

--- a/src/features/complexLookup/hooks/useHubAssignment.ts
+++ b/src/features/complexLookup/hooks/useHubAssignment.ts
@@ -1,10 +1,9 @@
 import { useCallback } from 'react';
 
+import { LOOKUP_TYPES, SOURCE_TYPES } from '@/common/constants/lookup.constants';
 import { StatusType } from '@/common/constants/status.constants';
 import { AdvancedFieldType } from '@/common/constants/uiControls.constants';
 import { UserNotificationFactory } from '@/common/services/userNotification';
-
-import { LOOKUP_TYPES, SOURCE_TYPES } from '@/features/complexLookup/constants/complexLookup.constants';
 
 import { useStatusState } from '@/store';
 

--- a/src/features/complexLookup/types/complexLookup.types.ts
+++ b/src/features/complexLookup/types/complexLookup.types.ts
@@ -1,0 +1,3 @@
+import { SOURCE_TYPES } from '../constants/complexLookup.constants';
+
+export type SourceType = (typeof SOURCE_TYPES)[keyof typeof SOURCE_TYPES];

--- a/src/features/complexLookup/types/complexLookup.types.ts
+++ b/src/features/complexLookup/types/complexLookup.types.ts
@@ -1,3 +1,3 @@
-import { SOURCE_TYPES } from '../constants/complexLookup.constants';
+import { SOURCE_TYPES } from '@/common/constants/lookup.constants';
 
 export type SourceType = (typeof SOURCE_TYPES)[keyof typeof SOURCE_TYPES];

--- a/src/features/complexLookup/types/index.ts
+++ b/src/features/complexLookup/types/index.ts
@@ -1,0 +1,1 @@
+export type { SourceType } from './complexLookup.types';

--- a/src/features/complexLookup/utils/complexLookup.helper.test.ts
+++ b/src/features/complexLookup/utils/complexLookup.helper.test.ts
@@ -7,6 +7,7 @@ import { AuthorityValidationTarget } from '@/features/complexLookup/constants/co
 import {
   generateEmptyValueUuid,
   generateValidationRequestBody,
+  getDefaultHubSource,
   getLinkedField,
   getUpdatedSelectedEntries,
   updateLinkedFieldValue,
@@ -180,6 +181,56 @@ describe('complexLookup.helper', () => {
 
       expect(result.rawMarc).toContain('\\r');
       expect(result.rawMarc).toContain('\\n');
+    });
+  });
+
+  describe('getDefaultHubSource', () => {
+    it('returns sourceType from assignedValue meta when available', () => {
+      const assignedValue = {
+        meta: {
+          sourceType: 'local',
+        },
+      } as UserValueContents;
+
+      const result = getDefaultHubSource(assignedValue);
+
+      expect(result).toBe('local');
+    });
+
+    it('returns libraryOfCongress as default when assignedValue has no sourceType', () => {
+      const assignedValue = {
+        meta: {},
+      } as UserValueContents;
+
+      const result = getDefaultHubSource(assignedValue);
+
+      expect(result).toBe('libraryOfCongress');
+    });
+
+    it('returns libraryOfCongress as default when assignedValue is undefined', () => {
+      const result = getDefaultHubSource();
+
+      expect(result).toBe('libraryOfCongress');
+    });
+
+    it('returns libraryOfCongress as default when assignedValue has no meta', () => {
+      const assignedValue = {} as UserValueContents;
+
+      const result = getDefaultHubSource(assignedValue);
+
+      expect(result).toBe('libraryOfCongress');
+    });
+
+    it('returns libraryOfCongress sourceType from assignedValue meta', () => {
+      const assignedValue = {
+        meta: {
+          sourceType: 'libraryOfCongress',
+        },
+      } as UserValueContents;
+
+      const result = getDefaultHubSource(assignedValue);
+
+      expect(result).toBe('libraryOfCongress');
     });
   });
 });

--- a/src/features/complexLookup/utils/complexLookup.helper.ts
+++ b/src/features/complexLookup/utils/complexLookup.helper.ts
@@ -1,10 +1,10 @@
+import { SOURCE_TYPES } from '@/common/constants/lookup.constants';
 import { AdvancedFieldType } from '@/common/constants/uiControls.constants';
 
 import {
   AuthorityValidationTarget,
   COMPLEX_LOOKUPS_LINKED_FIELDS_MAPPING,
   EMPTY_LINKED_DROPDOWN_OPTION_SUFFIX,
-  SOURCE_TYPES,
   VALUE_DIVIDER,
 } from '@/features/complexLookup/constants/complexLookup.constants';
 import { SourceType } from '@/features/complexLookup/types';

--- a/src/features/complexLookup/utils/complexLookup.helper.ts
+++ b/src/features/complexLookup/utils/complexLookup.helper.ts
@@ -7,6 +7,7 @@ import {
   SOURCE_TYPES,
   VALUE_DIVIDER,
 } from '@/features/complexLookup/constants/complexLookup.constants';
+import { SourceType } from '@/features/complexLookup/types';
 
 export const generateEmptyValueUuid = (uuid: string) => `${uuid}_${EMPTY_LINKED_DROPDOWN_OPTION_SUFFIX}`;
 
@@ -99,6 +100,6 @@ export const formatComplexLookupDisplayValue = (values?: UserValueContents[]) =>
     .join(VALUE_DIVIDER);
 };
 
-export const getDefaultHubSource = (assignedValue?: UserValueContents) => {
-  return assignedValue?.meta?.sourceType || SOURCE_TYPES.LIBRARY_OF_CONGRESS;
+export const getDefaultHubSource = (assignedValue?: UserValueContents): SourceType => {
+  return (assignedValue?.meta?.sourceType as SourceType) || SOURCE_TYPES.LIBRARY_OF_CONGRESS;
 };

--- a/src/features/complexLookup/utils/complexLookup.helper.ts
+++ b/src/features/complexLookup/utils/complexLookup.helper.ts
@@ -4,6 +4,7 @@ import {
   AuthorityValidationTarget,
   COMPLEX_LOOKUPS_LINKED_FIELDS_MAPPING,
   EMPTY_LINKED_DROPDOWN_OPTION_SUFFIX,
+  SOURCE_TYPES,
   VALUE_DIVIDER,
 } from '@/features/complexLookup/constants/complexLookup.constants';
 
@@ -96,4 +97,8 @@ export const formatComplexLookupDisplayValue = (values?: UserValueContents[]) =>
     .filter(({ label }) => label)
     .map(({ label }) => label)
     .join(VALUE_DIVIDER);
+};
+
+export const getDefaultHubSource = (assignedValue?: UserValueContents) => {
+  return assignedValue?.meta?.sourceType || SOURCE_TYPES.LIBRARY_OF_CONGRESS;
 };

--- a/src/features/complexLookup/utils/index.ts
+++ b/src/features/complexLookup/utils/index.ts
@@ -5,4 +5,5 @@ export {
   getUpdatedSelectedEntries,
   generateValidationRequestBody,
   formatComplexLookupDisplayValue,
+  getDefaultHubSource,
 } from './complexLookup.helper';

--- a/src/test/__tests__/common/services/userValues/userValueTypes/complexLookup.test.ts
+++ b/src/test/__tests__/common/services/userValues/userValueTypes/complexLookup.test.ts
@@ -314,4 +314,142 @@ describe('ComplexLookupUserValueService', () => {
 
     expect(result).toEqual(testResult);
   });
+
+  test('generates user value with lookupType from normalized authority data', () => {
+    const complexLookupUserValueService = new ComplexLookupUserValueService();
+    const testResult = {
+      uuid: 'testUuid_1',
+      contents: [
+        {
+          id: 'auth_id_1',
+          label: 'Authority Label',
+          meta: {
+            type: 'COMPLEX',
+            uri: 'test_uri',
+            sourceType: undefined,
+            lookupType: 'authorities',
+          },
+        },
+      ],
+    };
+
+    const result = complexLookupUserValueService.generate({
+      id: 'fallback_id',
+      data: [
+        {
+          id: ['auth_id_1'],
+          label: ['Authority Label'],
+          uri: ['test_uri'],
+          lookupType: 'authorities',
+        },
+      ] as unknown as RecordBasic[],
+      uuid: 'testUuid_1',
+      type: 'COMPLEX',
+    });
+
+    expect(result).toEqual(testResult);
+  });
+
+  test('generates user value with lookupType from normalized hub data', () => {
+    const complexLookupUserValueService = new ComplexLookupUserValueService();
+    const testResult = {
+      uuid: 'testUuid_1',
+      contents: [
+        {
+          id: 'hub_id_1',
+          label: 'Hub Label',
+          meta: {
+            type: 'COMPLEX',
+            uri: 'test_hub_uri',
+            sourceType: 'libraryOfCongress',
+            lookupType: 'hubs',
+          },
+        },
+      ],
+    };
+
+    const result = complexLookupUserValueService.generate({
+      id: 'fallback_id',
+      data: [
+        {
+          id: ['hub_id_1'],
+          label: ['Hub Label'],
+          uri: ['test_hub_uri'],
+          sourceType: 'libraryOfCongress',
+          lookupType: 'hubs',
+        },
+      ] as unknown as RecordBasic[],
+      uuid: 'testUuid_1',
+      type: 'COMPLEX',
+    });
+
+    expect(result).toEqual(testResult);
+  });
+
+  test('generates user value with lookupType from single normalized data object', () => {
+    const complexLookupUserValueService = new ComplexLookupUserValueService();
+    const testResult = {
+      uuid: 'subject_uuid',
+      contents: [
+        {
+          id: 'subject_id_1',
+          label: 'Subject Label',
+          meta: {
+            type: 'COMPLEX',
+            uri: 'subject_uri',
+            sourceType: undefined,
+            lookupType: 'authorities',
+          },
+        },
+      ],
+    };
+
+    const result = complexLookupUserValueService.generate({
+      id: 'fallback_id',
+      data: {
+        value: ['Subject Label'],
+        uri: ['subject_uri'],
+        id: ['subject_id_1'],
+        lookupType: 'authorities',
+      } as unknown as RecordBasic,
+      uuid: 'subject_uuid',
+      type: 'COMPLEX',
+    });
+
+    expect(result).toEqual(testResult);
+  });
+
+  test('generates user value without lookupType when not provided', () => {
+    const complexLookupUserValueService = new ComplexLookupUserValueService();
+    const testResult = {
+      uuid: 'testUuid_1',
+      contents: [
+        {
+          id: 'test_id_1',
+          label: 'Test Label',
+          meta: {
+            type: 'COMPLEX',
+            uri: 'test_uri',
+            sourceType: undefined,
+            lookupType: undefined,
+          },
+        },
+      ],
+    };
+
+    const result = complexLookupUserValueService.generate({
+      id: 'fallback_id',
+      data: [
+        {
+          id: ['test_id_1'],
+          label: ['Test Label'],
+          uri: ['test_uri'],
+        },
+      ] as unknown as RecordBasic[],
+      uuid: 'testUuid_1',
+      type: 'COMPLEX',
+    });
+
+    expect(result).toEqual(testResult);
+  });
 });

--- a/src/types/render.d.ts
+++ b/src/types/render.d.ts
@@ -10,6 +10,7 @@ type UserValueContents = {
     srsId?: string;
     isPreferred?: boolean;
     sourceType?: string;
+    lookupType?: string;
   };
 };
 


### PR DESCRIPTION
Implement proper Subject modal segment selection for Hubs and Authorities based on assigned value type.

[https://folio-org.atlassian.net/browse/UILD-730](https://folio-org.atlassian.net/browse/UILD-730)

**Technical details:**
- Added `lookupType` field to `UserValueContents.meta` to track whether an entry is a Hub or Authority
- Created `processSubjectComplexLookup` function that detects Hubs via types array during record normalization and sets appropriate `lookupType`
- Introduced `LOOKUP_TYPES` and `SOURCE_TYPES` constants in common layer to replace hardcoded string literals
- Refactored modal components (`SubjectModal`, `HubsModal`, `AuthoritiesModal`) to accept `assignedValue` instead of `initialQuery` for cleaner state management
- Created `getDefaultHubSource` utility function to determine default source (local vs LoC) based on assigned Hub's `sourceType`
- Updated `useComplexLookupModalState` hook to derive `initialQuery` from `assignedValue.label` internally, removing redundancy
