### PR TITLE
UILD-711: fix tests for the Authority assignment

### DIFF
--- a/src/features/complexLookup/hooks/useAuthoritiesAssignment.test.ts
+++ b/src/features/complexLookup/hooks/useAuthoritiesAssignment.test.ts
@@ -1,6 +1,6 @@
 import { setInitialGlobalState } from '@/test/__mocks__/store';
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { LOOKUP_TYPES } from '@/common/constants/lookup.constants';
 import { StatusType } from '@/common/constants/status.constants';
@@ -180,7 +180,9 @@ describe('useAuthoritiesAssignment', () => {
       }),
     );
 
-    await result.current.handleAssign(mockRecord);
+    await act(async () => {
+      await result.current.handleAssign(mockRecord);
+    });
 
     await waitFor(() => {
       expect(mockOnAssignSuccess).toHaveBeenCalledWith({
@@ -224,7 +226,9 @@ describe('useAuthoritiesAssignment', () => {
       }),
     );
 
-    await result.current.handleAssign(mockRecord);
+    await act(async () => {
+      await result.current.handleAssign(mockRecord);
+    });
 
     await waitFor(() => {
       expect(mockAddFailedEntryId).toHaveBeenCalledWith('test-id');
@@ -255,7 +259,9 @@ describe('useAuthoritiesAssignment', () => {
       }),
     );
 
-    await result.current.handleAssign(mockRecord);
+    await act(async () => {
+      await result.current.handleAssign(mockRecord);
+    });
 
     await waitFor(() => {
       expect(mockAddFailedEntryId).toHaveBeenCalledWith('test-id');
@@ -285,7 +291,9 @@ describe('useAuthoritiesAssignment', () => {
       }),
     );
 
-    await result.current.handleAssign(mockRecord);
+    await act(async () => {
+      await result.current.handleAssign(mockRecord);
+    });
 
     expect(mockGetMarcDataForAssignment).not.toHaveBeenCalled();
     expect(mockOnAssignSuccess).not.toHaveBeenCalled();
@@ -297,7 +305,7 @@ describe('useAuthoritiesAssignment', () => {
       title: 'Test Title',
     };
 
-    mockGetMarcDataForAssignment.mockImplementation(() => delayedResolve({ srsId: 'srs-id', marcData: {} }, 50));
+    mockGetMarcDataForAssignment.mockImplementation(() => delayedResolve({ srsId: 'srs-id', marcData: {} }, 150));
 
     mockValidateMarcRecord.mockResolvedValue({
       validAssignment: true,


### PR DESCRIPTION
Fix timing issues and React Testing Library warnings in `useAuthoritiesAssignment` tests.

[https://folio-org.atlassian.net/browse/UILD-711](https://folio-org.atlassian.net/browse/UILD-711)

**Technical details:**
- Import and wrap async `handleAssign` calls with `act()` to properly handle React state updates
- Increase mock delay from 50ms to 150ms in state transition test to ensure reliable observation of intermediate states