### PR TITLE
UILD-711: Fix for Hub and Subject complex lookup modals

### DIFF
--- a/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
+++ b/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
@@ -4,7 +4,6 @@ import { FormattedMessage } from 'react-intl';
 import { LookupModal } from '@/features/complexLookup/components/LookupModal';
 import { HubsContent } from '@/features/complexLookup/components/content';
 import { useComplexLookupModalState, useModalWithHubPreview } from '@/features/complexLookup/hooks';
-import { getDefaultHubSource } from '@/features/complexLookup/utils';
 import { SOURCE_OPTIONS } from '@/features/search/ui';
 import { Search } from '@/features/search/ui/components/Search';
 
@@ -20,14 +19,13 @@ interface HubsModalProps {
  * Supports import-on-assign for external hubs and preview for local hubs.
  */
 export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, assignedValue, onAssign }) => {
-  const defaultSource = getDefaultHubSource(assignedValue);
-
   // Reset search state and set initial query when modal opens
+  // defaultSource is config default (LoC), assigned source is extracted from assignedValue.meta
   useComplexLookupModalState({
     isOpen,
     assignedValue,
     defaultSegment: 'hubsLookup',
-    defaultSource,
+    defaultSource: 'libraryOfCongress',
   });
 
   // Hub preview integration - handles preview state, assignment, and cleanup
@@ -41,7 +39,7 @@ export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, assignedValue, 
       <Search
         segments={['hubsLookup']}
         defaultSegment="hubsLookup"
-        defaultSource={defaultSource}
+        defaultSource="libraryOfCongress"
         flow="value"
         mode="custom"
       >
@@ -50,7 +48,7 @@ export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, assignedValue, 
           <Search.Controls.SubmitButton />
           <Search.Controls.MetaControls />
 
-          <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue={defaultSource} />
+          <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue="libraryOfCongress" />
         </Search.Controls>
 
         <Search.Content>

--- a/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
+++ b/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
@@ -1,6 +1,8 @@
 import { FC } from 'react';
 import { FormattedMessage } from 'react-intl';
 
+import { SOURCE_TYPES } from '@/common/constants/lookup.constants';
+
 import { LookupModal } from '@/features/complexLookup/components/LookupModal';
 import { HubsContent } from '@/features/complexLookup/components/content';
 import { useComplexLookupModalState, useModalWithHubPreview } from '@/features/complexLookup/hooks';
@@ -25,7 +27,7 @@ export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, assignedValue, 
     isOpen,
     assignedValue,
     defaultSegment: 'hubsLookup',
-    defaultSource: 'libraryOfCongress',
+    defaultSource: SOURCE_TYPES.LIBRARY_OF_CONGRESS,
   });
 
   // Hub preview integration - handles preview state, assignment, and cleanup
@@ -39,7 +41,7 @@ export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, assignedValue, 
       <Search
         segments={['hubsLookup']}
         defaultSegment="hubsLookup"
-        defaultSource="libraryOfCongress"
+        defaultSource={SOURCE_TYPES.LIBRARY_OF_CONGRESS}
         flow="value"
         mode="custom"
       >
@@ -48,7 +50,7 @@ export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, assignedValue, 
           <Search.Controls.SubmitButton />
           <Search.Controls.MetaControls />
 
-          <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue="libraryOfCongress" />
+          <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue={SOURCE_TYPES.LIBRARY_OF_CONGRESS} />
         </Search.Controls>
 
         <Search.Content>

--- a/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
+++ b/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
@@ -21,13 +21,15 @@ interface HubsModalProps {
  * Supports import-on-assign for external hubs and preview for local hubs.
  */
 export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, assignedValue, onAssign }) => {
+  const defaultSource = SOURCE_TYPES.LIBRARY_OF_CONGRESS;
+
   // Reset search state and set initial query when modal opens
   // defaultSource is config default (LoC), assigned source is extracted from assignedValue.meta
   useComplexLookupModalState({
     isOpen,
     assignedValue,
     defaultSegment: 'hubsLookup',
-    defaultSource: SOURCE_TYPES.LIBRARY_OF_CONGRESS,
+    defaultSource,
   });
 
   // Hub preview integration - handles preview state, assignment, and cleanup
@@ -41,7 +43,7 @@ export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, assignedValue, 
       <Search
         segments={['hubsLookup']}
         defaultSegment="hubsLookup"
-        defaultSource={SOURCE_TYPES.LIBRARY_OF_CONGRESS}
+        defaultSource={defaultSource}
         flow="value"
         mode="custom"
       >
@@ -50,7 +52,7 @@ export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, assignedValue, 
           <Search.Controls.SubmitButton />
           <Search.Controls.MetaControls />
 
-          <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue={SOURCE_TYPES.LIBRARY_OF_CONGRESS} />
+          <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue={defaultSource} />
         </Search.Controls>
 
         <Search.Content>

--- a/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
+++ b/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { LOOKUP_TYPES } from '@/common/constants/lookup.constants';
+import { LOOKUP_TYPES, SOURCE_TYPES } from '@/common/constants/lookup.constants';
 
 import { LookupModal } from '@/features/complexLookup/components/LookupModal';
 import { AuthoritiesContent, HubsContent } from '@/features/complexLookup/components/content';
@@ -45,7 +45,7 @@ export const SubjectModal: FC<SubjectModalProps> = ({
   // TODO: refactor this to use a constant or enum instead of hardcoded values
   const defaultSegment = isAssignedHub ? 'hubsLookup' : `authorities:${initialSegment}`;
   // defaultSource is config default (LoC for hubs), assigned source extracted from assignedValue.meta
-  const defaultSource = isAssignedHub ? 'libraryOfCongress' : undefined;
+  const defaultSource = isAssignedHub ? SOURCE_TYPES.LIBRARY_OF_CONGRESS : undefined;
 
   useComplexLookupModalState({
     isOpen,
@@ -126,7 +126,7 @@ export const SubjectModal: FC<SubjectModalProps> = ({
           <Search.Controls.MetaControls />
 
           <Search.Controls.SegmentContent segment="hubsLookup">
-            <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue="libraryOfCongress" />
+            <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue={SOURCE_TYPES.LIBRARY_OF_CONGRESS} />
           </Search.Controls.SegmentContent>
         </Search.Controls>
 

--- a/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
+++ b/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
@@ -11,7 +11,6 @@ import {
   useComplexLookupModalState,
   useModalWithHubPreview,
 } from '@/features/complexLookup/hooks';
-import { getDefaultHubSource } from '@/features/complexLookup/utils';
 import { SOURCE_OPTIONS } from '@/features/search/ui';
 import { Search } from '@/features/search/ui/components/Search';
 
@@ -45,7 +44,8 @@ export const SubjectModal: FC<SubjectModalProps> = ({
 
   // TODO: refactor this to use a constant or enum instead of hardcoded values
   const defaultSegment = isAssignedHub ? 'hubsLookup' : `authorities:${initialSegment}`;
-  const defaultSource = isAssignedHub ? getDefaultHubSource(assignedValue) : undefined;
+  // defaultSource is config default (LoC for hubs), assigned source extracted from assignedValue.meta
+  const defaultSource = isAssignedHub ? 'libraryOfCongress' : undefined;
 
   useComplexLookupModalState({
     isOpen,
@@ -126,7 +126,7 @@ export const SubjectModal: FC<SubjectModalProps> = ({
           <Search.Controls.MetaControls />
 
           <Search.Controls.SegmentContent segment="hubsLookup">
-            <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue={defaultSource} />
+            <Search.Controls.SourceSelector options={SOURCE_OPTIONS} defaultValue="libraryOfCongress" />
           </Search.Controls.SegmentContent>
         </Search.Controls>
 

--- a/src/features/complexLookup/hooks/useComplexLookupModalState.test.ts
+++ b/src/features/complexLookup/hooks/useComplexLookupModalState.test.ts
@@ -63,7 +63,7 @@ describe('useComplexLookupModalState', () => {
       expect(mockSetCommittedValues).toHaveBeenCalledWith({
         segment: 'authorities:browse',
         query: 'test query',
-        searchBy: '',
+        searchBy: undefined,
         source: undefined,
         offset: 0,
       });
@@ -82,7 +82,7 @@ describe('useComplexLookupModalState', () => {
       expect(mockSetDraftBySegment).toHaveBeenCalledWith({
         'authorities:browse': {
           query: 'test',
-          searchBy: '',
+          searchBy: undefined,
           source: undefined,
         },
       });

--- a/src/features/complexLookup/hooks/useComplexLookupModalState.test.ts
+++ b/src/features/complexLookup/hooks/useComplexLookupModalState.test.ts
@@ -167,7 +167,7 @@ describe('useComplexLookupModalState', () => {
       expect(mockSetQuery).toHaveBeenCalledWith("O'Brien");
     });
 
-    it('stores normalized query in segment draft', () => {
+    it('stores raw query in segment draft', () => {
       renderHook(() =>
         useComplexLookupModalState({
           isOpen: true,
@@ -178,7 +178,7 @@ describe('useComplexLookupModalState', () => {
 
       expect(mockSetDraftBySegment).toHaveBeenCalledWith({
         'authorities:browse': {
-          query: String.raw`O\'Brien`,
+          query: "O'Brien",
           searchBy: undefined,
           source: undefined,
         },

--- a/src/features/complexLookup/hooks/useComplexLookupModalState.test.ts
+++ b/src/features/complexLookup/hooks/useComplexLookupModalState.test.ts
@@ -120,6 +120,70 @@ describe('useComplexLookupModalState', () => {
       expect(mockSetQuery).not.toHaveBeenCalled();
       expect(mockResetDraftBySegment).toHaveBeenCalled();
     });
+
+    it('uses assigned source from meta over default source', () => {
+      renderHook(() =>
+        useComplexLookupModalState({
+          isOpen: true,
+          assignedValue: { label: 'test', meta: { sourceType: 'local' } } as UserValueContents,
+          defaultSegment: 'hubsLookup',
+          defaultSource: 'libraryOfCongress',
+        }),
+      );
+
+      expect(mockSetNavigationState).toHaveBeenCalledWith({
+        segment: 'hubsLookup',
+        source: 'local',
+      });
+      expect(mockSetCommittedValues).toHaveBeenCalledWith(expect.objectContaining({ source: 'local' }));
+    });
+
+    it('uses assigned source from meta when no default source', () => {
+      renderHook(() =>
+        useComplexLookupModalState({
+          isOpen: true,
+          assignedValue: { label: 'test', meta: { sourceType: 'local' } } as UserValueContents,
+          defaultSegment: 'hubsLookup',
+        }),
+      );
+
+      expect(mockSetNavigationState).toHaveBeenCalledWith({
+        segment: 'hubsLookup',
+        source: 'local',
+      });
+    });
+
+    it('normalizes initial query with special characters for committed values', () => {
+      renderHook(() =>
+        useComplexLookupModalState({
+          isOpen: true,
+          assignedValue: { label: "O'Brien" } as UserValueContents,
+          defaultSegment: 'authorities:browse',
+        }),
+      );
+
+      expect(mockSetCommittedValues).toHaveBeenCalledWith(expect.objectContaining({ query: String.raw`O\'Brien` }));
+      // Input field receives the original label for user editing
+      expect(mockSetQuery).toHaveBeenCalledWith("O'Brien");
+    });
+
+    it('stores normalized query in segment draft', () => {
+      renderHook(() =>
+        useComplexLookupModalState({
+          isOpen: true,
+          assignedValue: { label: "O'Brien" } as UserValueContents,
+          defaultSegment: 'authorities:browse',
+        }),
+      );
+
+      expect(mockSetDraftBySegment).toHaveBeenCalledWith({
+        'authorities:browse': {
+          query: String.raw`O\'Brien`,
+          searchBy: undefined,
+          source: undefined,
+        },
+      });
+    });
   });
 
   describe('when modal closes', () => {

--- a/src/features/complexLookup/hooks/useComplexLookupModalState.ts
+++ b/src/features/complexLookup/hooks/useComplexLookupModalState.ts
@@ -21,6 +21,10 @@ export function useComplexLookupModalState({
   defaultSource,
 }: UseComplexLookupModalStateParams) {
   const initialQuery = assignedValue?.label;
+  // Extract assigned source from meta (if editing existing value with source)
+  const assignedSource = assignedValue?.meta?.sourceType;
+  // Use assigned source if exists, otherwise use config default
+  const initialSource = assignedSource || defaultSource;
   const {
     setQuery,
     resetQuery,
@@ -45,19 +49,18 @@ export function useComplexLookupModalState({
 
   useEffect(() => {
     if (isOpen) {
-      // Set navigation state with the default segment to ensure correct tab is selected
       setNavigationState({
         segment: defaultSegment,
-        ...(defaultSource ? { source: defaultSource } : {}),
+        ...(initialSource ? { source: initialSource } : {}),
       });
 
-      // Set committed values with initial query if provided
+      // Set committed values with initial query and source
       // This triggers useSearchQuery to auto-execute the search via its enabled flag
       setCommittedValues({
         segment: defaultSegment,
         query: initialQuery || '',
         searchBy: '',
-        source: defaultSource,
+        source: initialSource,
         offset: 0,
       });
 
@@ -70,7 +73,7 @@ export function useComplexLookupModalState({
           [defaultSegment]: {
             query: initialQuery,
             searchBy: '',
-            source: defaultSource,
+            source: initialSource,
           },
         });
       } else {
@@ -85,5 +88,5 @@ export function useComplexLookupModalState({
       resetCommittedValues();
       resetDraftBySegment();
     }
-  }, [isOpen, initialQuery, defaultSegment, defaultSource]);
+  }, [isOpen, initialQuery, defaultSegment, initialSource]);
 }

--- a/src/features/complexLookup/hooks/useComplexLookupModalState.ts
+++ b/src/features/complexLookup/hooks/useComplexLookupModalState.ts
@@ -70,10 +70,10 @@ export function useComplexLookupModalState({
         // Store the original query in the input field for user editing
         setQuery(initialQuery);
 
-        // Save normalized query to segment draft for consistency with handleSubmit
+        // Save raw query to segment draft
         setDraftBySegment({
           [defaultSegment]: {
-            query: normalizedInitialQuery,
+            query: initialQuery,
             searchBy: undefined,
             source: initialSource,
           },

--- a/src/features/complexLookup/hooks/useComplexLookupModalState.ts
+++ b/src/features/complexLookup/hooks/useComplexLookupModalState.ts
@@ -59,7 +59,7 @@ export function useComplexLookupModalState({
       setCommittedValues({
         segment: defaultSegment,
         query: initialQuery || '',
-        searchBy: '',
+        searchBy: undefined,
         source: initialSource,
         offset: 0,
       });
@@ -72,7 +72,7 @@ export function useComplexLookupModalState({
         setDraftBySegment({
           [defaultSegment]: {
             query: initialQuery,
-            searchBy: '',
+            searchBy: undefined,
             source: initialSource,
           },
         });

--- a/src/features/complexLookup/hooks/useComplexLookupModalState.ts
+++ b/src/features/complexLookup/hooks/useComplexLookupModalState.ts
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 
+import { normalizeQuery } from '@/features/search/core';
+
 import { useSearchState } from '@/store';
 
 interface UseComplexLookupModalStateParams {
@@ -21,6 +23,7 @@ export function useComplexLookupModalState({
   defaultSource,
 }: UseComplexLookupModalStateParams) {
   const initialQuery = assignedValue?.label;
+  const normalizedInitialQuery = initialQuery ? (normalizeQuery(initialQuery) ?? '') : '';
   // Extract assigned source from meta (if editing existing value with source)
   const assignedSource = assignedValue?.meta?.sourceType;
   // Use assigned source if exists, otherwise use config default
@@ -54,11 +57,11 @@ export function useComplexLookupModalState({
         ...(initialSource ? { source: initialSource } : {}),
       });
 
-      // Set committed values with initial query and source
+      // Set committed values with normalized initial query and source
       // This triggers useSearchQuery to auto-execute the search via its enabled flag
       setCommittedValues({
         segment: defaultSegment,
-        query: initialQuery || '',
+        query: normalizedInitialQuery,
         searchBy: undefined,
         source: initialSource,
         offset: 0,
@@ -66,12 +69,13 @@ export function useComplexLookupModalState({
 
       // Set draft query to populate the input field and save to segment draft
       if (initialQuery) {
+        // Store the original query in the input field for user editing
         setQuery(initialQuery);
 
-        // Save initial query to segment draft so it persists when switching segments
+        // Save normalized query to segment draft for consistency with handleSubmit
         setDraftBySegment({
           [defaultSegment]: {
-            query: initialQuery,
+            query: normalizedInitialQuery,
             searchBy: undefined,
             source: initialSource,
           },
@@ -88,5 +92,5 @@ export function useComplexLookupModalState({
       resetCommittedValues();
       resetDraftBySegment();
     }
-  }, [isOpen, initialQuery, defaultSegment, initialSource]);
+  }, [isOpen, initialQuery, normalizedInitialQuery, defaultSegment, initialSource]);
 }

--- a/src/features/complexLookup/hooks/useComplexLookupModalState.ts
+++ b/src/features/complexLookup/hooks/useComplexLookupModalState.ts
@@ -24,9 +24,7 @@ export function useComplexLookupModalState({
 }: UseComplexLookupModalStateParams) {
   const initialQuery = assignedValue?.label;
   const normalizedInitialQuery = initialQuery ? (normalizeQuery(initialQuery) ?? '') : '';
-  // Extract assigned source from meta (if editing existing value with source)
   const assignedSource = assignedValue?.meta?.sourceType;
-  // Use assigned source if exists, otherwise use config default
   const initialSource = assignedSource || defaultSource;
   const {
     setQuery,

--- a/src/features/search/core/config/searchRegistry.test.ts
+++ b/src/features/search/core/config/searchRegistry.test.ts
@@ -1,0 +1,37 @@
+import { getDefaultSourceForSegment } from './searchRegistry';
+
+describe('searchRegistry', () => {
+  describe('getDefaultSourceForSegment', () => {
+    it('returns undefined when segment is undefined', () => {
+      expect(getDefaultSourceForSegment()).toBeUndefined();
+    });
+
+    it('returns undefined for unknown segment', () => {
+      expect(getDefaultSourceForSegment('unknown_segment_1')).toBeUndefined();
+    });
+
+    it('returns undefined for resources segment (no composite id)', () => {
+      expect(getDefaultSourceForSegment('resources')).toBeUndefined();
+    });
+
+    it('returns undefined for hubs:local segment (segment is already composite, not segment:source)', () => {
+      expect(getDefaultSourceForSegment('hubs:local')).toBeUndefined();
+    });
+
+    it('returns undefined for authorities:search segment (category:type, not segment:source)', () => {
+      expect(getDefaultSourceForSegment('authorities:search')).toBeUndefined();
+    });
+
+    it('returns undefined for authorities:browse segment', () => {
+      expect(getDefaultSourceForSegment('authorities:browse')).toBeUndefined();
+    });
+
+    it('returns libraryOfCongress for hubsLookup segment', () => {
+      expect(getDefaultSourceForSegment('hubsLookup')).toBe('libraryOfCongress');
+    });
+
+    it('returns libraryOfCongress for hubs segment', () => {
+      expect(getDefaultSourceForSegment('hubs')).toBe('libraryOfCongress');
+    });
+  });
+});

--- a/src/features/search/core/config/searchRegistry.ts
+++ b/src/features/search/core/config/searchRegistry.ts
@@ -66,13 +66,9 @@ export function getDefaultSourceForSegment(segment?: string): string | undefined
   const baseConfig = searchRegistry[segment];
   if (!baseConfig) return undefined;
 
-  // Check if the base config ID is a composite key in the format `${segment}:${source}`
-  // This distinguishes source variants (hubsLookup:libraryOfCongress) from
-  // category types (authorities:search) where both parts form the segment name
   const expectedPrefix = `${segment}:`;
 
   if (baseConfig.id.startsWith(expectedPrefix)) {
-    // Extract the source part after the segment prefix
     const source = baseConfig.id.substring(expectedPrefix.length);
 
     return source;

--- a/src/features/search/core/config/searchRegistry.ts
+++ b/src/features/search/core/config/searchRegistry.ts
@@ -52,3 +52,31 @@ export function resolveCoreConfig(segment?: string, source?: string): SearchType
 
   return undefined;
 }
+
+/**
+ * Extract the default source from a segment's base config.
+ * If the base config has a composite ID with the pattern `${segment}:${source}`
+ * (e.g., base config for 'hubsLookup' has ID 'hubsLookup:libraryOfCongress'),
+ * returns the source part ('libraryOfCongress').
+ * Otherwise, returns undefined (no default source).
+ */
+export function getDefaultSourceForSegment(segment?: string): string | undefined {
+  if (!segment) return undefined;
+
+  const baseConfig = searchRegistry[segment];
+  if (!baseConfig) return undefined;
+
+  // Check if the base config ID is a composite key in the format `${segment}:${source}`
+  // This distinguishes source variants (hubsLookup:libraryOfCongress) from
+  // category types (authorities:search) where both parts form the segment name
+  const expectedPrefix = `${segment}:`;
+
+  if (baseConfig.id.startsWith(expectedPrefix)) {
+    // Extract the source part after the segment prefix
+    const source = baseConfig.id.substring(expectedPrefix.length);
+
+    return source;
+  }
+
+  return undefined;
+}

--- a/src/features/search/core/strategies/requestBuilders/HubsLoCRequestBuilder.test.ts
+++ b/src/features/search/core/strategies/requestBuilders/HubsLoCRequestBuilder.test.ts
@@ -75,7 +75,7 @@ describe('HubsLoCRequestBuilder', () => {
       expect(result.urlParams.count).toBe('100');
     });
 
-    it('falls back to default when searchBy not in map', () => {
+    it('falls back to hubNameKeyword when searchBy not in map', () => {
       const builder = new HubsLoCRequestBuilder(mockMap);
       const result = builder.build({
         query: 'test',
@@ -83,7 +83,9 @@ describe('HubsLoCRequestBuilder', () => {
         limit: 100,
       });
 
-      expect(result.urlParams.q).toBe('test');
+      expect(result.urlParams.label).toBe('test');
+      expect(result.urlParams.rdftype).toBe('Hub');
+      expect(result.urlParams.q).toBeUndefined();
     });
   });
 

--- a/src/features/search/core/strategies/requestBuilders/HubsLoCRequestBuilder.ts
+++ b/src/features/search/core/strategies/requestBuilders/HubsLoCRequestBuilder.ts
@@ -28,7 +28,10 @@ export class HubsLoCRequestBuilder extends BaseRequestBuilder {
   }
 
   private buildQueryParams(searchBy: string, value: string): Record<string, string> {
-    const indexConfig = this.searchableIndicesMap?.[searchBy as keyof HubSearchableIndicesMap];
+    const resolvedSearchBy =
+      this.searchableIndicesMap && !(searchBy in this.searchableIndicesMap) ? SearchableIndex.HubNameKeyword : searchBy;
+
+    const indexConfig = this.searchableIndicesMap?.[resolvedSearchBy as keyof HubSearchableIndicesMap];
     const config = indexConfig?.query;
 
     if (typeof config === 'object' && config !== null) {
@@ -38,7 +41,6 @@ export class HubsLoCRequestBuilder extends BaseRequestBuilder {
       };
     }
 
-    // Default fallback
     return { q: value };
   }
 

--- a/src/features/search/core/strategies/requestBuilders/HubsLoCRequestBuilder.ts
+++ b/src/features/search/core/strategies/requestBuilders/HubsLoCRequestBuilder.ts
@@ -29,7 +29,9 @@ export class HubsLoCRequestBuilder extends BaseRequestBuilder {
 
   private buildQueryParams(searchBy: string, value: string): Record<string, string> {
     const resolvedSearchBy =
-      this.searchableIndicesMap && !(searchBy in this.searchableIndicesMap) ? SearchableIndex.HubNameKeyword : searchBy;
+      this.searchableIndicesMap && !Object.hasOwn(this.searchableIndicesMap, searchBy)
+        ? SearchableIndex.HubNameKeyword
+        : searchBy;
 
     const indexConfig = this.searchableIndicesMap?.[resolvedSearchBy as keyof HubSearchableIndicesMap];
     const config = indexConfig?.query;

--- a/src/features/search/ui/config/hubsUI.config.ts
+++ b/src/features/search/ui/config/hubsUI.config.ts
@@ -1,4 +1,6 @@
-import type { SearchTypeUIConfig } from '../types';
+import { SearchableIndex } from '@/common/constants/searchableIndex.constants';
+
+import type { SearchTypeUIConfig, SearchableIndexUI } from '../types';
 
 export const hubsUIConfig: SearchTypeUIConfig = {
   limit: 50, // UI shows all 50 results per page
@@ -27,4 +29,10 @@ export const hubsUIConfig: SearchTypeUIConfig = {
     isVisibleSubLabel: true,
     isVisibleEmptySearchPlaceholder: true,
   },
+  searchableIndices: [
+    {
+      labelId: 'ld.search.hubNameLeftAnchored',
+      value: SearchableIndex.HubNameLeftAnchored,
+    },
+  ] as SearchableIndexUI[],
 };

--- a/src/features/search/ui/formatters/hubs/HubLinkFormatter.scss
+++ b/src/features/search/ui/formatters/hubs/HubLinkFormatter.scss
@@ -3,6 +3,8 @@
 }
 
 button.hub-link {
+  text-align: left;
+
   &:hover {
     text-decoration-line: underline;
   }

--- a/src/features/search/ui/hooks/useSearchControlsHandlers.test.ts
+++ b/src/features/search/ui/hooks/useSearchControlsHandlers.test.ts
@@ -452,11 +452,11 @@ describe('useSearchControlsHandlers', () => {
       });
 
       expect(setNavigationState).toHaveBeenCalledWith({
-        segment: 'test',
+        segment: 'search',
       });
     });
 
-    it('resets navigation state with segment from config id', () => {
+    it('resets navigation state using active segment from navigationState', () => {
       const configWithoutDefaults: SearchTypeConfig = {
         id: 'test',
       };
@@ -468,7 +468,7 @@ describe('useSearchControlsHandlers', () => {
         result.current.onReset();
       });
 
-      expect(setNavigationState).toHaveBeenCalledWith({ segment: 'test' });
+      expect(setNavigationState).toHaveBeenCalledWith({ segment: 'search' });
     });
 
     it('clears URL params in URL flow', () => {

--- a/src/features/search/ui/hooks/useSearchControlsHandlers.test.ts
+++ b/src/features/search/ui/hooks/useSearchControlsHandlers.test.ts
@@ -518,6 +518,49 @@ describe('useSearchControlsHandlers', () => {
       expect(resetFullDisplayComponentType).toHaveBeenCalled();
       expect(resetCurrentlyPreviewedEntityBfid).toHaveBeenCalled();
     });
+
+    it('sets default source in navigation state when segment has a default source', () => {
+      setInitialGlobalState([
+        {
+          store: useSearchStore,
+          state: {
+            query: 'test query',
+            searchBy: 'keyword',
+            navigationState: { segment: 'hubsLookup' },
+            draftBySegment: {},
+            setNavigationState,
+            resetQuery,
+            resetSearchBy,
+            setQuery,
+            setSearchBy,
+            setDraftBySegment,
+            setCommittedValues,
+            resetCommittedValues,
+          },
+        },
+        {
+          store: useInputsState,
+          state: { resetPreviewContent },
+        },
+        {
+          store: useUIState,
+          state: { resetFullDisplayComponentType, resetCurrentlyPreviewedEntityBfid },
+        },
+      ]);
+
+      const { result } = renderHook(() =>
+        useSearchControlsHandlers({ coreConfig: mockConfig, uiConfig: mockUIConfig, flow: 'url' }),
+      );
+
+      act(() => {
+        result.current.onReset();
+      });
+
+      expect(setNavigationState).toHaveBeenCalledWith({
+        segment: 'hubsLookup',
+        source: 'libraryOfCongress',
+      });
+    });
   });
 
   describe('Handler stability', () => {

--- a/src/features/search/ui/hooks/useSearchControlsHandlers.ts
+++ b/src/features/search/ui/hooks/useSearchControlsHandlers.ts
@@ -254,8 +254,9 @@ export const useSearchControlsHandlers = ({
           params.set(SearchParam.SEGMENT, newSegment);
 
           // If restored segment has query, include full search params (auto-search)
+          // Normalize query for URL (CQL escaping) - drafts store raw user input
           if (hasPreservedQuery) {
-            params.set(SearchParam.QUERY, restoredDraft.query);
+            params.set(SearchParam.QUERY, normalizeQuery(restoredDraft.query) ?? '');
             params.set(SearchParam.SEARCH_BY, restoredDraft.searchBy);
 
             if (restoredDraft.source) {
@@ -267,9 +268,10 @@ export const useSearchControlsHandlers = ({
         });
       } else if (hasPreservedQuery) {
         // Value flow: only update committedValues if there's a query to preserve
+        // Normalize query for committed values (CQL escaping) - drafts store raw user input
         setCommittedValues({
           segment: newSegment,
-          query: restoredDraft.query,
+          query: normalizeQuery(restoredDraft.query) ?? '',
           searchBy: restoredDraft.searchBy,
           source: restoredDraft.source,
           offset: 0,
@@ -330,11 +332,12 @@ export const useSearchControlsHandlers = ({
       : searchBy;
 
     // Save current draft on submit (with validated searchBy)
+    // Store raw query in draft (drafts store user-facing text, not CQL-escaped)
     if (segment) {
       setDraftBySegment({
         ...draftBySegment,
         [segment]: {
-          query: normalizedQuery,
+          query,
           searchBy: validSearchBy,
           source,
         },

--- a/src/features/search/ui/hooks/useSearchQuery.ts
+++ b/src/features/search/ui/hooks/useSearchQuery.ts
@@ -67,19 +67,13 @@ export function useSearchQuery({
 
   // Validate searchBy against the effective configs' valid options
   // If the URL has an invalid searchBy for this segment, use the config's default
-  // For advanced search (query without searchBy), keep it undefined
   const effectiveSearchBy = useMemo(() => {
-    // Advanced search: query exists but searchBy is undefined - keep it undefined
-    if (committed.query && !committed.searchBy) {
-      return undefined;
-    }
-
     if (!effectiveCoreConfig || !effectiveUIConfig) {
       return committed.searchBy;
     }
 
     return getValidSearchBy(committed.searchBy, effectiveUIConfig, effectiveCoreConfig);
-  }, [committed.query, committed.searchBy, effectiveCoreConfig, effectiveUIConfig]);
+  }, [committed.searchBy, effectiveCoreConfig, effectiveUIConfig]);
 
   const queryKey = useMemo(
     () =>

--- a/src/features/search/ui/hooks/useSearchQuery.ts
+++ b/src/features/search/ui/hooks/useSearchQuery.ts
@@ -69,7 +69,7 @@ export function useSearchQuery({
   // If the URL has an invalid searchBy for this segment, use the config's default
   // For advanced search (pre-formatted CQL query without searchBy), keep it undefined
   const effectiveSearchBy = useMemo(() => {
-    // Keep searchBy as undefined for advanced search
+    // Advanced search: query exists but searchBy is undefined - keep it undefined
     if (committed.query && !committed.searchBy && committed.query.trim().startsWith('(')) {
       return undefined;
     }

--- a/src/features/search/ui/hooks/useSearchQuery.ts
+++ b/src/features/search/ui/hooks/useSearchQuery.ts
@@ -67,13 +67,19 @@ export function useSearchQuery({
 
   // Validate searchBy against the effective configs' valid options
   // If the URL has an invalid searchBy for this segment, use the config's default
+  // For advanced search (pre-formatted CQL query without searchBy), keep it undefined
   const effectiveSearchBy = useMemo(() => {
+    // Keep searchBy as undefined for advanced search
+    if (committed.query && !committed.searchBy && committed.query.trim().startsWith('(')) {
+      return undefined;
+    }
+
     if (!effectiveCoreConfig || !effectiveUIConfig) {
       return committed.searchBy;
     }
 
     return getValidSearchBy(committed.searchBy, effectiveUIConfig, effectiveCoreConfig);
-  }, [committed.searchBy, effectiveCoreConfig, effectiveUIConfig]);
+  }, [committed.query, committed.searchBy, effectiveCoreConfig, effectiveUIConfig]);
 
   const queryKey = useMemo(
     () =>

--- a/src/store/stores/search.ts
+++ b/src/store/stores/search.ts
@@ -12,7 +12,7 @@ type SourceData = SourceDataDTO | null;
 
 export interface SegmentDraft {
   query: string;
-  searchBy: SearchIdentifiers;
+  searchBy: SearchIdentifiers | undefined;
   source?: string;
 }
 
@@ -21,7 +21,7 @@ export type DraftBySegment = Record<string, SegmentDraft>;
 export interface CommittedValues {
   segment?: string;
   query: string;
-  searchBy: string;
+  searchBy: string | undefined;
   source?: string;
   offset: number;
   selector?: 'query' | 'prev' | 'next'; // Browse pagination selector


### PR DESCRIPTION
Fix two bugs in the complex lookup modals: incorrect source handling after Reset and search query parameters not properly resolved for different `searchBy` values.

[https://folio-org.atlassian.net/browse/UILD-711?focusedCommentId=295289](https://folio-org.atlassian.net/browse/UILD-711?focusedCommentId=295289)

**Technical details:**
- Fixed Reset button behavior to correctly restore the default LoC source in Hubs modal. Previously, clicking Reset after changing source to Local would delete the source parameter, leaving the modal in an inconsistent state. Now `onReset` handler uses `getDefaultSourceForSegment` utility to restore the appropriate default source (LoC) in navigation state
- Fixed disappearing Source dropdown in Subject modal when Reset was clicked after switching to Hubs tab. Previously, segment was incorrectly read from `coreConfig.id` instead of active `navigationState`, causing the segment to be overwritten. Now segment is preserved from `navigationState`, ensuring the Source dropdown remains visible
- Implemented proper source precedence: assigned source from `assignedValue.meta.sourceType` now takes priority over config default in `useComplexLookupModalState`
- Fixed incorrect LoC query parameters when `searchBy` is not in the searchable indices map. Previously, `HubsLoCRequestBuilder` would fall back to generic `q=value`, which doesn't work properly for Hub searches. Now falls back to `HubNameKeyword` index with correct parameters
- Changed `searchBy` type from `string` to `string | undefined` in store types to accurately represent optional search index
- Fixed hub link button alignment in `HubLinkFormatter.scss`