### PR TITLE
UILD-736: Fix Hub preview issues on the Search page

### DIFF
--- a/src/common/hooks/usePreviewQuery.ts
+++ b/src/common/hooks/usePreviewQuery.ts
@@ -40,10 +40,11 @@ export function usePreviewQuery<TData>({
 }: UsePreviewQueryParams<TData>): UsePreviewQueryResult<TData> {
   const [previewMeta, setPreviewMeta] = useState<PreviewMeta | null>(null);
   const [selectedId, setSelectedId] = useState<string | undefined>();
+  const [requestKey, setRequestKey] = useState(0);
   const { addStatusMessagesItem } = useStatusState(['addStatusMessagesItem']);
 
   const { data, isLoading, isFetching, isError, error } = useQuery({
-    queryKey: [queryKey, selectedId],
+    queryKey: [queryKey, selectedId, requestKey],
     queryFn: async ({ signal }) => {
       if (!selectedId) return null;
 
@@ -70,11 +71,13 @@ export function usePreviewQuery<TData>({
 
   const loadPreview = useCallback((id: string, meta?: PreviewMeta) => {
     setSelectedId(id);
+    setRequestKey(prev => prev + 1);
     setPreviewMeta(meta ?? { id });
   }, []);
 
   const resetPreview = useCallback(() => {
     setSelectedId(undefined);
+    setRequestKey(0);
     setPreviewMeta(null);
   }, []);
 

--- a/src/test/__tests__/views/Search.test.tsx
+++ b/src/test/__tests__/views/Search.test.tsx
@@ -13,7 +13,7 @@ import * as FeatureConstants from '@/common/constants/feature.constants';
 import { ResourceType } from '@/common/constants/record.constants';
 import { Search } from '@/views';
 
-import { useSearchStore, useUIStore } from '@/store';
+import { useInputsStore, useSearchStore, useUIStore } from '@/store';
 
 const mockIsEmbeddedMode = getMockedImportedConstant(BuildConstants, 'IS_EMBEDDED_MODE');
 const mockSearchFiltersEnabled = getMockedImportedConstant(FeatureConstants, 'SEARCH_FILTERS_ENABLED');
@@ -62,9 +62,10 @@ describe('Search', () => {
   });
 
   describe('component unmount', () => {
-    test('clears fullDisplayComponentType and selectedInstances on unmount', () => {
+    test('clears fullDisplayComponentType, selectedInstances and previewContent on unmount', () => {
       const mockResetFullDisplayComponentType = jest.fn();
       const mockResetSelectedInstances = jest.fn();
+      const mockResetPreviewContent = jest.fn();
 
       setInitialGlobalState([
         {
@@ -79,6 +80,12 @@ describe('Search', () => {
             resetSelectedInstances: mockResetSelectedInstances,
           },
         },
+        {
+          store: useInputsStore,
+          state: {
+            resetPreviewContent: mockResetPreviewContent,
+          },
+        },
       ]);
 
       const { unmount } = renderWithProviders(<Search />);
@@ -87,6 +94,7 @@ describe('Search', () => {
 
       expect(mockResetFullDisplayComponentType).toHaveBeenCalled();
       expect(mockResetSelectedInstances).toHaveBeenCalled();
+      expect(mockResetPreviewContent).toHaveBeenCalled();
     });
   });
 

--- a/src/views/Search/hooks/useSearchCleanup.test.ts
+++ b/src/views/Search/hooks/useSearchCleanup.test.ts
@@ -2,7 +2,7 @@ import { setInitialGlobalState } from '@/test/__mocks__/store';
 
 import { renderHook } from '@testing-library/react';
 
-import { useSearchStore, useUIStore } from '@/store';
+import { useInputsStore, useSearchStore, useUIStore } from '@/store';
 
 import { useSearchCleanup } from './useSearchCleanup';
 
@@ -17,6 +17,7 @@ jest.mock('@/common/hooks/useContainerEvents', () => ({
 describe('useSearchCleanup', () => {
   const mockResetSelectedInstances = jest.fn();
   const mockResetFullDisplayComponentType = jest.fn();
+  const mockResetPreviewContent = jest.fn();
 
   beforeEach(() => {
     setInitialGlobalState([
@@ -30,6 +31,12 @@ describe('useSearchCleanup', () => {
         store: useUIStore,
         state: {
           resetFullDisplayComponentType: mockResetFullDisplayComponentType,
+        },
+      },
+      {
+        store: useInputsStore,
+        state: {
+          resetPreviewContent: mockResetPreviewContent,
         },
       },
     ]);
@@ -48,5 +55,6 @@ describe('useSearchCleanup', () => {
 
     expect(mockResetFullDisplayComponentType).toHaveBeenCalled();
     expect(mockResetSelectedInstances).toHaveBeenCalled();
+    expect(mockResetPreviewContent).toHaveBeenCalled();
   });
 });

--- a/src/views/Search/hooks/useSearchCleanup.ts
+++ b/src/views/Search/hooks/useSearchCleanup.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 import { useContainerEvents } from '@/common/hooks/useContainerEvents';
 
-import { useSearchState, useUIState } from '@/store';
+import { useInputsState, useSearchState, useUIState } from '@/store';
 
 /**
  * Custom hook that handles search component lifecycle and cleanup operations
@@ -11,6 +11,7 @@ export const useSearchCleanup = () => {
   const { dispatchDropNavigateToOriginEvent } = useContainerEvents();
   const { resetSelectedInstances } = useSearchState(['resetSelectedInstances']);
   const { resetFullDisplayComponentType } = useUIState(['resetFullDisplayComponentType']);
+  const { resetPreviewContent } = useInputsState(['resetPreviewContent']);
 
   // Dispatch navigation event on mount
   dispatchDropNavigateToOriginEvent();
@@ -20,6 +21,7 @@ export const useSearchCleanup = () => {
     return () => {
       resetFullDisplayComponentType();
       resetSelectedInstances();
+      resetPreviewContent();
     };
-  }, [resetFullDisplayComponentType, resetSelectedInstances]);
+  }, [resetFullDisplayComponentType, resetSelectedInstances, resetPreviewContent]);
 };


### PR DESCRIPTION
Fix Hub preview issues on the Search page: stale re-open and empty preview after navigation.

**Technical details:**
- Added a `requestKey` counter to the React Query key in `usePreviewQuery` so that calling `loadPreview` with the same hub ID always triggers a refetch, fixing the issue where re-clicking the same hub title after closing a preview did nothing
- Added `resetPreviewContent()` to the `useSearchCleanup` unmount effect so that navigating away from the Search page (e.g. to Create or Edit) clears the preview content, preventing an empty preview panel from appearing when returning