### PR TITLE
Fix profile selection logic

### DIFF
--- a/src/common/helpers/profileSelection.helper.ts
+++ b/src/common/helpers/profileSelection.helper.ts
@@ -45,9 +45,9 @@ export const isProfilePreferred = ({
   preferredProfiles?: ProfileDTO[];
   resourceTypeURL?: ResourceTypeURL;
 }) => {
-  if (!preferredProfiles || !resourceTypeURL) return false;
+  if (!profileId || !preferredProfiles || !resourceTypeURL) return false;
 
   return preferredProfiles.some(
-    ({ id, resourceType }) => id.toString() === profileId.toString() && resourceType === resourceTypeURL,
+    ({ id, resourceType }) => id?.toString() === profileId?.toString() && resourceType === resourceTypeURL,
   );
 };

--- a/src/common/hooks/useProfileSelection.ts
+++ b/src/common/hooks/useProfileSelection.ts
@@ -65,6 +65,8 @@ export const useProfileSelection = () => {
 
         // If no matching profile was found, show the modal
         if (!profileProcessed) {
+          await loadAvailableProfiles(resourceTypeURL);
+
           openModal({ action: 'set', resourceTypeURL });
         }
 

--- a/src/test/__tests__/common/hooks/useProfileSelection.test.ts
+++ b/src/test/__tests__/common/hooks/useProfileSelection.test.ts
@@ -100,9 +100,10 @@ describe('useProfileSelection', () => {
       expect(setIsLoading).toHaveBeenCalledWith(false);
     });
 
-    test('opens profile selection modal when no preferred profile matches resource type', async () => {
+    test('loads available profiles and opens modal when no preferred profile matches resource type', async () => {
       const nonMatchingProfiles = [{ id: 'other-profile', name: 'Other Profile', resourceType: 'other-type' }];
       (fetchPreferredProfiles as jest.Mock).mockResolvedValue(nonMatchingProfiles);
+      (fetchProfiles as jest.Mock).mockResolvedValue(mockProfiles);
 
       const { result } = renderHook(() => useProfileSelection());
       await act(async () => {
@@ -114,6 +115,8 @@ describe('useProfileSelection', () => {
 
       expect(setIsLoading).toHaveBeenCalledWith(true);
       expect(fetchPreferredProfiles).toHaveBeenCalledWith();
+      expect(fetchProfiles).toHaveBeenCalledWith(resourceTypeURL);
+      expect(setAvailableProfiles).toHaveBeenCalled();
       expect(callbackMock).not.toHaveBeenCalled();
       expect(setIsProfileSelectionModalOpen).toHaveBeenCalledWith(true);
       expect(setIsLoading).toHaveBeenCalledWith(false);

--- a/src/test/__tests__/helpers/profileSelection.helper.test.ts
+++ b/src/test/__tests__/helpers/profileSelection.helper.test.ts
@@ -259,6 +259,26 @@ describe('profileSelection.helper', () => {
       expect(result).toBe(false);
     });
 
+    it('returns false when profileId is undefined', () => {
+      const result = isProfilePreferred({
+        profileId: undefined as unknown as string,
+        preferredProfiles: mockPreferredProfiles,
+        resourceTypeURL: 'work_URL' as ResourceTypeURL,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when profileId is null', () => {
+      const result = isProfilePreferred({
+        profileId: null as unknown as string,
+        preferredProfiles: mockPreferredProfiles,
+        resourceTypeURL: 'work_URL' as ResourceTypeURL,
+      });
+
+      expect(result).toBe(false);
+    });
+
     it('handles string and number ID comparison correctly', () => {
       const profiles = [{ id: 123, name: 'Test', resourceType: 'work_URL' }] as ProfileDTO[];
 


### PR DESCRIPTION
Fix crash in profile selection modal when profileId is undefined and ensure available profiles are loaded before opening the modal.

**Technical details:**
- Added a nullish guard for `profileId` in `isProfilePreferred` helper to prevent `.toString()` crash when `profileId` is undefined (e.g., when profiles array is empty and no `selectedProfileId` is set)
- Added optional chaining on both `id` and `profileId` in the `.some()` comparison as a defensive measure
- Added `await loadAvailableProfiles(resourceTypeURL)` call in `checkProfileAndProceed` before opening the modal when preferred profiles exist but none match the requested resource type — previously the modal would open with an empty profiles list
- Updated unit tests