### PR TITLE
UILD-593: Add support for Subclass in the Subject of work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 * Add hub preview functionality. Refs [UILD-736].
 * Fix profile cache management and drag and drop affecting modified state. Refs [UILD-739].
 * Fix profile setting application in editor and search state, minor UX adjustments. Refs [UILD-740].
+* Add Subclass for the Subject field. Refs [UILD-593].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -177,6 +178,7 @@
 [UILD-736]:https://folio-org.atlassian.net/browse/UILD-736
 [UILD-739]:https://folio-org.atlassian.net/browse/UILD-739
 [UILD-740]:https://folio-org.atlassian.net/browse/UILD-740
+[UILD-593]:https://folio-org.atlassian.net/browse/UILD-593
 
 ## 1.0.5 (2025-04-30)
 * Browser Back button navigates to Edit without duplicated title when navigated from Duplicate screen. Fixes [UILD-554].

--- a/src/common/constants/bibframeMapping.constants.ts
+++ b/src/common/constants/bibframeMapping.constants.ts
@@ -83,6 +83,7 @@ export const BFLITE_URIS = {
   CATALOGING_LANGUAGE: 'http://bibfra.me/vocab/lite/catalogingLanguage',
   PUBLICATION_FREQUENCY: 'http://bibfra.me/vocab/library/publicationFrequency',
   EXPRESSION_OF: 'http://bibfra.me/vocab/lite/expressionOf',
+  CONCEPT: 'http://bibfra.me/vocab/lite/Concept',
 };
 
 export const NON_BF_RECORD_ELEMENTS = {

--- a/src/common/services/recordNormalizing/recordProcessingCases.ts
+++ b/src/common/services/recordNormalizing/recordProcessingCases.ts
@@ -162,6 +162,7 @@ export const processSubjectComplexLookup = (record: RecordEntry, blockKey: strin
     const sourceType = getHubSourceType(hasRdfLink, hasHubId);
     const types = recordEntry.types as string[] | undefined;
     const lookupType = types?.includes(BFLITE_URIS.HUB) ? LOOKUP_TYPES.HUBS : LOOKUP_TYPES.AUTHORITIES;
+    const _subclass = recordEntry.types?.find(type => type !== BFLITE_URIS.CONCEPT);
 
     return {
       id: [recordEntry.id],
@@ -171,6 +172,7 @@ export const processSubjectComplexLookup = (record: RecordEntry, blockKey: strin
         sourceType,
         lookupType,
       },
+      ...(_subclass && { _subclass }),
     };
   }) as unknown as RecursiveRecordSchema;
 };

--- a/src/test/__tests__/common/services/recordNormalizing/recordProcessingCases.test.ts
+++ b/src/test/__tests__/common/services/recordNormalizing/recordProcessingCases.test.ts
@@ -844,9 +844,18 @@ describe('recordProcessingCases', () => {
 
   describe('processSubjectComplexLookup', () => {
     const hubUri = 'http://bibfra.me/vocab/lite/Hub';
+    const conceptUri = 'http://bibfra.me/vocab/lite/Concept';
+    const authorityUri = 'http://bibfra.me/vocab/lite/Authority';
+    const topicUri = 'http://bibfra.me/vocab/lite/Topic';
+    const workUri = 'http://bibfra.me/vocab/lite/Work';
 
     beforeEach(() => {
-      mockedBFLiteUris({ HUB: hubUri, LINK: linkBFLiteUri, LABEL: labelBFLiteUri });
+      mockedBFLiteUris({
+        HUB: hubUri,
+        LINK: linkBFLiteUri,
+        LABEL: labelBFLiteUri,
+        CONCEPT: conceptUri,
+      });
     });
 
     test('transforms subject entry and sets lookupType to authorities when types array does not include Hub', () => {
@@ -856,7 +865,7 @@ describe('recordProcessingCases', () => {
             {
               id: 'auth_id_1',
               label: 'Authority Subject',
-              types: ['http://bibfra.me/vocab/lite/Authority'],
+              types: [authorityUri],
             },
           ],
         },
@@ -873,6 +882,7 @@ describe('recordProcessingCases', () => {
                 lookupType: 'authorities',
                 sourceType: 'local',
               },
+              _subclass: authorityUri,
             },
           ],
         },
@@ -890,7 +900,7 @@ describe('recordProcessingCases', () => {
             {
               id: 'hub_id_1',
               label: 'Hub Subject',
-              types: [hubUri, 'http://bibfra.me/vocab/lite/Topic'],
+              types: [hubUri, topicUri],
             },
           ],
         },
@@ -907,6 +917,7 @@ describe('recordProcessingCases', () => {
                 lookupType: 'hubs',
                 sourceType: 'local',
               },
+              _subclass: hubUri,
             },
           ],
         },
@@ -962,12 +973,12 @@ describe('recordProcessingCases', () => {
             {
               id: 'auth_id_1',
               label: 'Authority Subject',
-              types: ['http://bibfra.me/vocab/lite/Topic'],
+              types: [topicUri],
             },
             {
               id: 'hub_id_2',
               label: 'Another Hub',
-              types: ['http://bibfra.me/vocab/lite/Work', hubUri],
+              types: [workUri, hubUri],
             },
           ],
         },
@@ -984,6 +995,7 @@ describe('recordProcessingCases', () => {
                 lookupType: 'hubs',
                 sourceType: 'local',
               },
+              _subclass: hubUri,
             },
             {
               id: ['auth_id_1'],
@@ -993,6 +1005,7 @@ describe('recordProcessingCases', () => {
                 lookupType: 'authorities',
                 sourceType: 'local',
               },
+              _subclass: topicUri,
             },
             {
               id: ['hub_id_2'],
@@ -1002,6 +1015,7 @@ describe('recordProcessingCases', () => {
                 lookupType: 'hubs',
                 sourceType: 'local',
               },
+              _subclass: workUri,
             },
           ],
         },
@@ -1037,6 +1051,7 @@ describe('recordProcessingCases', () => {
                 lookupType: 'hubs',
                 sourceType: 'local',
               },
+              _subclass: hubUri,
             },
           ],
         },
@@ -1045,6 +1060,76 @@ describe('recordProcessingCases', () => {
       RecordProcessingCases.processSubjectComplexLookup(record, blockKey, groupKey);
 
       expect(record).toEqual(testResult);
+    });
+
+    test('includes _subclass when types contains a non-CONCEPT type', () => {
+      const record = {
+        [blockKey]: {
+          [groupKey]: [
+            {
+              id: 'auth_id_1',
+              label: 'Topic Subject',
+              types: [conceptUri, topicUri],
+            },
+          ],
+        },
+      } as unknown as RecordEntry;
+
+      const testResult = {
+        [blockKey]: {
+          [groupKey]: [
+            {
+              id: ['auth_id_1'],
+              label: {
+                value: ['Topic Subject'],
+                isPreferred: undefined,
+                lookupType: 'authorities',
+                sourceType: 'local',
+              },
+              _subclass: topicUri,
+            },
+          ],
+        },
+      };
+
+      RecordProcessingCases.processSubjectComplexLookup(record, blockKey, groupKey);
+
+      expect(record).toEqual(testResult);
+    });
+
+    test('omits _subclass when all types are CONCEPT', () => {
+      const record = {
+        [blockKey]: {
+          [groupKey]: [
+            {
+              id: 'auth_id_2',
+              label: 'Pure Concept Subject',
+              types: [conceptUri],
+            },
+          ],
+        },
+      } as unknown as RecordEntry;
+
+      const testResult = {
+        [blockKey]: {
+          [groupKey]: [
+            {
+              id: ['auth_id_2'],
+              label: {
+                value: ['Pure Concept Subject'],
+                isPreferred: undefined,
+                lookupType: 'authorities',
+                sourceType: 'local',
+              },
+            },
+          ],
+        },
+      };
+
+      RecordProcessingCases.processSubjectComplexLookup(record, blockKey, groupKey);
+
+      expect(record).toEqual(testResult);
+      expect((record[blockKey][groupKey] as unknown as RecordBasic[])[0]).not.toHaveProperty('_subclass');
     });
   });
 });


### PR DESCRIPTION
Add support for Subclass in the Subject of work field by updating record normalization.

[https://folio-org.atlassian.net/browse/UILD-593](https://folio-org.atlassian.net/browse/UILD-593)

**Technical details:**
- Updated `processSubjectComplexLookup` in `recordProcessingCases.ts` to detect the subclass by finding the first type in the types array that is not Concept, then conditionally spreading `_subclass` into the normalized subject entry
- Updated existing tests and added new test cases to cover new logic