### PR TITLE
UILD-768: Inventory View for Instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 * Retrieve most value dictionaries from local API instead of id.loc.gov. Refs [UILD-754].
 * Add Duplicate Hub functionality. Refs [UILD-772].
 * Move Actions menu to the Edit area. Refs [UILD-765].
+* Add Inventary View link. Refs [UILD-768].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -205,6 +206,7 @@
 [UILD-754]:https://folio-org.atlassian.net/browse/UILD-754
 [UILD-772]:https://folio-org.atlassian.net/browse/UILD-772
 [UILD-765]:https://folio-org.atlassian.net/browse/UILD-765
+[UILD-768]:https://folio-org.atlassian.net/browse/UILD-768
 
 ## 1.0.5 (2025-04-30)
 * Browser Back button navigates to Edit without duplicated title when navigated from Duplicate screen. Fixes [UILD-554].

--- a/src/common/constants/routes.constants.ts
+++ b/src/common/constants/routes.constants.ts
@@ -72,3 +72,5 @@ export enum ForceNavigateToDest {
   CreatePage = 'createPage',
   CreatePageAsClone = 'createPageAsClone',
 }
+
+export const INVENTORY_VIEW_URL = '/inventory/view';

--- a/src/components/EditSection/BlockActions.tsx
+++ b/src/components/EditSection/BlockActions.tsx
@@ -2,8 +2,9 @@ import { FC } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { PROFILE_BFIDS } from '@/common/constants/bibframe.constants';
+import { BFLITE_URIS } from '@/common/constants/bibframeMapping.constants';
 import { IS_DISABLED_FOR_ALPHA } from '@/common/constants/feature.constants';
-import { RESOURCE_CREATE_URLS } from '@/common/constants/routes.constants';
+import { INVENTORY_VIEW_URL, RESOURCE_CREATE_URLS } from '@/common/constants/routes.constants';
 import { DropdownItemType } from '@/common/constants/uiElements.constants';
 import { useMarcData } from '@/common/hooks/useMarcData';
 import { useNavigateToEditPage } from '@/common/hooks/useNavigateToEditPage';
@@ -32,12 +33,16 @@ export const BlockActions: FC<BlockActionsProps> = ({ entry }) => {
   const { fetchMarcData } = useMarcData(setBasicValue);
   const { exportInstanceRdf } = useResourceExport();
   const { openModalForProfileChange } = useProfileSelection();
-  const { selectedRecordBlocks } = useInputsState(['selectedRecordBlocks']);
+  const { selectedRecordBlocks, record } = useInputsState(['selectedRecordBlocks', 'record']);
 
   if (isInCreateMode) return null;
 
   const isInstance = entry.bfid === PROFILE_BFIDS.INSTANCE;
   const isWork = entry.bfid === PROFILE_BFIDS.WORK;
+  const inventoryId = (record?.resource?.[BFLITE_URIS.INSTANCE] as Record<string, unknown>)?.folioMetadata as
+    | Record<string, string>
+    | undefined;
+  const inventoryViewId = inventoryId?.inventoryId;
 
   const handleDuplicate = () => {
     if (resourceId) {
@@ -46,6 +51,12 @@ export const BlockActions: FC<BlockActionsProps> = ({ entry }) => {
   };
 
   const handleFetchMarcData = async () => fetchMarcData(resourceId);
+
+  const viewInInventary = () => {
+    if (inventoryViewId) {
+      globalThis.location.assign(`${INVENTORY_VIEW_URL}/${inventoryViewId}`);
+    }
+  };
 
   const handleExportInstanceRdf = () => {
     if (resourceId) {
@@ -88,12 +99,13 @@ export const BlockActions: FC<BlockActionsProps> = ({ entry }) => {
           action: handleFetchMarcData,
         },
         {
-          id: 'viewInInventory',
+          id: 'inventoryView',
           type: DropdownItemType.basic,
-          labelId: 'ld.viewInInventory',
+          labelId: 'ld.inventoryView',
           icon: <ExternalLink16 />,
-          isDisabled: IS_DISABLED_FOR_ALPHA,
-          hidden: true,
+          hidden: !isInstance,
+          isDisabled: !inventoryViewId,
+          action: viewInInventary,
         },
         {
           id: 'exportInstanceRdf',

--- a/src/test/__tests__/components/BlockActions.test.tsx
+++ b/src/test/__tests__/components/BlockActions.test.tsx
@@ -8,6 +8,7 @@ import { fireEvent, render } from '@testing-library/react';
 
 import * as recordsApi from '@/common/api/records.api';
 import { PROFILE_BFIDS } from '@/common/constants/bibframe.constants';
+import { BFLITE_URIS } from '@/common/constants/bibframeMapping.constants';
 import { ROUTES } from '@/common/constants/routes.constants';
 import * as useProfileSelectionHook from '@/common/hooks/useProfileSelection';
 import { BlockActions } from '@/components/EditSection/BlockActions';
@@ -33,11 +34,11 @@ const workEntry = {
   path: ['uuid_work'],
 } as SchemaEntry;
 
-const renderBlockActions = (entry: SchemaEntry) => {
+const renderBlockActions = (entry: SchemaEntry, record?: Record<string, unknown>) => {
   setInitialGlobalState([
     {
       store: useInputsState,
-      state: { selectedRecordBlocks: { block: 'test-block' } },
+      state: { selectedRecordBlocks: { block: 'test-block' }, record: record ?? null },
     },
   ]);
 
@@ -153,5 +154,32 @@ describe('BlockActions', () => {
     fireEvent.click(await findByText('ld.changeInstanceProfile'));
 
     expect(openModalForProfileChangeMock).toHaveBeenCalledWith({ resourceTypeURL: 'test-block' });
+  });
+
+  test('enables inventory view button when inventoryId is available', async () => {
+    const record = {
+      resource: {
+        [BFLITE_URIS.INSTANCE]: {
+          id: 'resource_1',
+          folioMetadata: { inventoryId: 'inventory_1' },
+        },
+      },
+    };
+
+    const { findByText, findByTestId } = renderBlockActions(instanceEntry, record);
+
+    fireEvent.click(await findByTestId('block-actions-toggle'));
+
+    const button = await findByText('ld.inventoryView');
+    expect(button.closest('button')).not.toBeDisabled();
+  });
+
+  test('disables inventory view button when inventoryId is not available', async () => {
+    const { findByText, findByTestId } = renderBlockActions(instanceEntry);
+
+    fireEvent.click(await findByTestId('block-actions-toggle'));
+
+    const button = await findByText('ld.inventoryView');
+    expect(button.closest('button')).toBeDisabled();
   });
 });

--- a/translations/ui-linked-data/en.json
+++ b/translations/ui-linked-data/en.json
@@ -137,7 +137,7 @@
   "ld.cantLoadHubPreview": "Can't load preview for this hub resource",
   "ld.duplicate": "Duplicate",
   "ld.viewLinkedData": "View linked data",
-  "ld.viewInInventory": "View in Inventory app",
+  "ld.inventoryView": "Inventory View",
   "ld.authorityType": "Authority Type",
   "ld.person": "Person",
   "ld.source": "Source",


### PR DESCRIPTION
Add "Inventory View" option to the Actions dropdown, allowing users to navigate to the Inventory application for Instance records.

[https://folio-org.atlassian.net/browse/UILD-768](https://folio-org.atlassian.net/browse/UILD-768)

**Technical details:**
- Extract inventoryId from the loaded Instance record's `folioMetadata` in BlockActions component
- Navigate to `/inventory/view/{inventoryId}` in the same browser tab
- Disable the menu item when inventoryId is unavailable
- Show the "Inventory View" action only for Instance entries
