### PR TITLE
UILD-759: Show property labels in Work preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 * Add Duplicate Hub functionality. Refs [UILD-772].
 * Move Actions menu to the Edit area. Refs [UILD-765].
 * Add Inventary View link. Refs [UILD-768].
+* Show property labels in Work preview. Refs [UILD-759].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -207,6 +208,7 @@
 [UILD-772]:https://folio-org.atlassian.net/browse/UILD-772
 [UILD-765]:https://folio-org.atlassian.net/browse/UILD-765
 [UILD-768]:https://folio-org.atlassian.net/browse/UILD-768
+[UILD-759]:https://folio-org.atlassian.net/browse/UILD-759
 
 ## 1.0.5 (2025-04-30)
 * Browser Back button navigates to Edit without duplicated title when navigated from Duplicate screen. Fixes [UILD-554].

--- a/src/common/services/recordToSchemaMapping/recordToSchemaMapping.service.ts
+++ b/src/common/services/recordToSchemaMapping/recordToSchemaMapping.service.ts
@@ -307,13 +307,19 @@ export class RecordToSchemaMappingService implements IRecordToSchemaMapping {
 
     if (type === AdvancedFieldTypeEnum.enumerated) {
       this.handleDropdownOptions(schemaUiElem, recordEntryValue as string);
+
+      const labelMap = this.buildEnumeratedLabelMap(schemaUiElem);
+
       await this.setUserValue({
         valueKey: newValueKey,
         data,
         fieldUri: recordKey,
         schemaUiElem,
         id,
+        labelMap,
       });
+
+      return;
     }
 
     if (type === AdvancedFieldTypeEnum.literal && constraints?.repeatable) {
@@ -346,6 +352,20 @@ export class RecordToSchemaMappingService implements IRecordToSchemaMapping {
         this.selectedEntriesService.addNew(undefined, dropdownOptionEntry.uuid);
       }
     }
+  }
+
+  private buildEnumeratedLabelMap(schemaUiElem: SchemaEntry): Record<string, string> {
+    const labelMap: Record<string, string> = {};
+
+    schemaUiElem.children?.forEach(childUuid => {
+      const child = this.updatedSchema?.get(childUuid);
+
+      if (child?.uriBFLite && child?.displayName) {
+        labelMap[child.uriBFLite] = child.displayName;
+      }
+    });
+
+    return labelMap;
   }
 
   private async handleRepeatableSubcomponents({
@@ -411,12 +431,14 @@ export class RecordToSchemaMappingService implements IRecordToSchemaMapping {
     fieldUri,
     schemaUiElem,
     id,
+    labelMap,
   }: {
     valueKey: string;
     data: RecordEntryValue;
     fieldUri: string;
     schemaUiElem: SchemaEntry;
     id?: string;
+    labelMap?: Record<string, string>;
   }) {
     const { type, constraints, uriBFLite } = schemaUiElem;
     const partialTemplateMatch = this.templateMetadata?.filter(({ path }) => path.at(-1) === fieldUri);
@@ -442,6 +464,7 @@ export class RecordToSchemaMappingService implements IRecordToSchemaMapping {
         blockUri: this.currentBlockUri,
         groupUri: this.currentRecordGroupKey,
         fieldUri,
+        labelMap,
       },
     });
   }

--- a/src/common/services/userValues/userValueTypes/enumerated.ts
+++ b/src/common/services/userValues/userValueTypes/enumerated.ts
@@ -4,7 +4,7 @@ import { IUserValueType } from './userValueType.interface';
 export class EnumeratedUserValueService extends UserValueType implements IUserValueType {
   private contents?: UserValueContents[];
 
-  async generate({ data, uuid, type }: UserValueDTO) {
+  async generate({ data, uuid, type, labelMap }: UserValueDTO) {
     this.contents = [];
 
     if (Array.isArray(data)) {
@@ -13,6 +13,7 @@ export class EnumeratedUserValueService extends UserValueType implements IUserVa
         this.generateContentItem({
           itemUri,
           type,
+          labelMap,
         });
       }
     } else {
@@ -20,6 +21,7 @@ export class EnumeratedUserValueService extends UserValueType implements IUserVa
       this.generateContentItem({
         itemUri,
         type,
+        labelMap,
       });
     }
 
@@ -31,13 +33,22 @@ export class EnumeratedUserValueService extends UserValueType implements IUserVa
     return this.value;
   }
 
-  private generateContentItem({ itemUri, type }: { itemUri?: string; type?: AdvancedFieldType }) {
+  private generateContentItem({
+    itemUri,
+    type,
+    labelMap,
+  }: {
+    itemUri?: string;
+    type?: AdvancedFieldType;
+    labelMap?: Record<string, string>;
+  }) {
+    const resolvedLabel = (itemUri && labelMap?.[itemUri]) || itemUri;
     const contentItem = {
-      label: itemUri,
+      label: resolvedLabel,
       meta: {
         uri: itemUri,
         type,
-        basicLabel: itemUri,
+        basicLabel: resolvedLabel,
       },
     };
 

--- a/src/components/Preview/Values.tsx
+++ b/src/components/Preview/Values.tsx
@@ -19,16 +19,7 @@ export const Values: FC<ValuesProps> = ({
     ? userValues[uuid]?.contents?.map(({ label, meta: { uri, parentUri, basicLabel } = {} } = {}) => {
         if (!label && !basicLabel) return;
 
-        let selectedLabel = basicLabel ?? label;
-
-        if (
-          htmlId &&
-          htmlId?.indexOf('__hubs') >= 0 &&
-          selectedLabel &&
-          selectedLabel?.indexOf('http://bibfra.me/vocab') >= 0
-        ) {
-          selectedLabel = '';
-        }
+        const selectedLabel = basicLabel ?? label;
 
         return (
           selectedLabel && (

--- a/src/test/__tests__/common/services/recordToSchemaMapping/data/updatedSchema.data.ts
+++ b/src/test/__tests__/common/services/recordToSchemaMapping/data/updatedSchema.data.ts
@@ -1,4 +1,4 @@
-import { getLabelEntry } from './schema.data';
+﻿import { getLabelEntry } from './schema.data';
 
 export const updatedSchema = new Map([
   [

--- a/src/test/__tests__/common/services/recordToSchemaMapping/recordToSchemaMapping.service.test.ts
+++ b/src/test/__tests__/common/services/recordToSchemaMapping/recordToSchemaMapping.service.test.ts
@@ -169,6 +169,122 @@ describe('RecordToSchemaMappingService', () => {
     });
   });
 
+  describe('enumerated fields handling', () => {
+    const enumeratedSchema = new Map([
+      [
+        'block_key',
+        {
+          bfid: 'blockId',
+          children: ['group_key'],
+          displayName: 'Block',
+          path: ['block_key'],
+          type: 'block',
+          uri: 'blockUri',
+          uriBFLite: 'block_1',
+          uuid: 'block_key',
+        },
+      ],
+      [
+        'group_key',
+        {
+          children: ['enum_key'],
+          displayName: 'Hubs group',
+          path: ['block_key', 'group_key'],
+          type: 'group',
+          uriBFLite: 'uriBFLite_hubs',
+          uuid: 'group_key',
+        },
+      ],
+      [
+        'enum_key',
+        {
+          children: ['option_key_1', 'option_key_2'],
+          constraints: {},
+          displayName: 'Relationship',
+          path: ['block_key', 'group_key', 'enum_key'],
+          type: 'enumerated',
+          uriBFLite: '_relation',
+          uuid: 'enum_key',
+        },
+      ],
+      [
+        'option_key_1',
+        {
+          displayName: 'Enum option 1',
+          path: ['block_key', 'group_key', 'enum_key', 'option_key_1'],
+          type: 'dropdownOption',
+          uriBFLite: 'uriBFLite_enumOption_1',
+          uuid: 'option_key_1',
+        },
+      ],
+      [
+        'option_key_2',
+        {
+          displayName: 'Enum option 2',
+          path: ['block_key', 'group_key', 'enum_key', 'option_key_2'],
+          type: 'dropdownOption',
+          uriBFLite: 'uriBFLite_enumOption_2',
+          uuid: 'option_key_2',
+        },
+      ],
+    ]);
+
+    test('passes labelMap with resolved display names for enumerated fields', async () => {
+      jest.spyOn(repeatableFieldsService, 'get').mockReturnValue(enumeratedSchema as unknown as Schema);
+
+      const mockRecord = {
+        block_1: {
+          uriBFLite_hubs: [
+            {
+              _relation: 'uriBFLite_enumOption_1',
+            },
+          ],
+        },
+      };
+
+      await service.init({
+        schema: enumeratedSchema as unknown as Schema,
+        record: mockRecord as unknown as RecordEntry,
+        recordBlocks: ['block_1'],
+      });
+
+      expect(userValuesService.setValue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'enumerated',
+          value: expect.objectContaining({
+            data: 'uriBFLite_enumOption_1',
+            labelMap: {
+              uriBFLite_enumOption_1: 'Enum option 1',
+              uriBFLite_enumOption_2: 'Enum option 2',
+            },
+          }),
+        }),
+      );
+    });
+
+    test('selects matching dropdown option for enumerated field', async () => {
+      jest.spyOn(repeatableFieldsService, 'get').mockReturnValue(enumeratedSchema as unknown as Schema);
+
+      const mockRecord = {
+        block_1: {
+          uriBFLite_hubs: [
+            {
+              _relation: 'uriBFLite_enumOption_2',
+            },
+          ],
+        },
+      };
+
+      await service.init({
+        schema: enumeratedSchema as unknown as Schema,
+        record: mockRecord as unknown as RecordEntry,
+        recordBlocks: ['block_1'],
+      });
+
+      expect(selectedEntriesService.addNew).toHaveBeenCalledWith(undefined, 'option_key_2');
+    });
+  });
+
   test('returns updated schema with repeatable subcomponents', async () => {
     jest.spyOn(repeatableFieldsService, 'get').mockReturnValue(updatedSchemaWithRepeatableSubcomponents as Schema);
 

--- a/src/test/__tests__/common/services/userValues/userValueTypes/enumerated.test.ts
+++ b/src/test/__tests__/common/services/userValues/userValueTypes/enumerated.test.ts
@@ -40,4 +40,58 @@ describe('EnumeratedUserValueService', () => {
   test('generates user value for array data', () => {
     testGeneratedData(['testValue_1']);
   });
+
+  test('resolves label from labelMap when URI matches', async () => {
+    const labelMap = {
+      'http://bibfra.me/vocab/lite/expressionOf': 'Expression Of',
+    };
+
+    const result = await enumeratedUserValueService.generate({
+      data: 'http://bibfra.me/vocab/lite/expressionOf',
+      uuid: 'testUuid',
+      type: AdvancedFieldType.enumerated,
+      labelMap,
+    });
+
+    expect(result).toEqual({
+      uuid: 'testUuid',
+      contents: [
+        {
+          label: 'Expression Of',
+          meta: {
+            basicLabel: 'Expression Of',
+            type: 'enumerated',
+            uri: 'http://bibfra.me/vocab/lite/expressionOf',
+          },
+        },
+      ],
+    });
+  });
+
+  test('falls back to URI when labelMap has no match', async () => {
+    const labelMap = {
+      'http://bibfra.me/vocab/lite/expressionOf': 'Expression Of',
+    };
+
+    const result = await enumeratedUserValueService.generate({
+      data: 'http://bibfra.me/vocab/lite/unknownRelation',
+      uuid: 'testUuid',
+      type: AdvancedFieldType.enumerated,
+      labelMap,
+    });
+
+    expect(result).toEqual({
+      uuid: 'testUuid',
+      contents: [
+        {
+          label: 'http://bibfra.me/vocab/lite/unknownRelation',
+          meta: {
+            basicLabel: 'http://bibfra.me/vocab/lite/unknownRelation',
+            type: 'enumerated',
+            uri: 'http://bibfra.me/vocab/lite/unknownRelation',
+          },
+        },
+      ],
+    });
+  });
 });

--- a/src/types/recordProcessing.d.ts
+++ b/src/types/recordProcessing.d.ts
@@ -9,6 +9,7 @@ type UserValueDTO = {
   blockUri?: string;
   groupUri?: string;
   fieldUri?: string;
+  labelMap?: Record<string, string>;
 };
 
 type RecordNormalizingCasesMap = Record<


### PR DESCRIPTION
Display property labels in Work preview for Hub and Language code fields.

[https://folio-org.atlassian.net/browse/UILD-759](https://folio-org.atlassian.net/browse/UILD-759)

**Technical details:**
- `EnumeratedUserValueService` previously stored raw URIs as both `label` and `basicLabel`; it now accepts an optional `labelMap` and resolves URIs to human-readable display names
- `RecordToSchemaMappingService` builds a `labelMap` from an enumerated field's `dropdownOption` children (URI -> displayName) and passes it through `setUserValue`; a missing return after the enumerated block was also fixed to prevent the fallthrough else from overwriting the value without `labelMap`
- Removed a workaround in `Values.tsx` that was blanking out any label containing `http://bibfra.me/vocab` in the hub preview section
