### PR TITLE
UILD-743: Fix the preview pane staying open when a new search is submitted on the Search page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 * Add support for the Geographic Coverage field. Fixes [UILD-665].
 * Change display order for titles. Refs [UILD-304].
 * Respond to the embedding application's locale config. Refs [UILD-786].
+* Hide preview when starting a new search on the Search page. Fixes [UILD-743].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -225,6 +226,7 @@
 [UILD-665]:https://folio-org.atlassian.net/browse/UILD-665
 [UILD-304]:https://folio-org.atlassian.net/browse/UILD-304
 [UILD-786]:https://folio-org.atlassian.net/browse/UILD-786
+[UILD-743]:https://folio-org.atlassian.net/browse/UILD-743
 
 ## 1.0.5 (2025-04-30)
 * Browser Back button navigates to Edit without duplicated title when navigated from Duplicate screen. Fixes [UILD-554].

--- a/src/features/search/ui/hooks/useSearchControlsHandlers.test.ts
+++ b/src/features/search/ui/hooks/useSearchControlsHandlers.test.ts
@@ -426,6 +426,20 @@ describe('useSearchControlsHandlers', () => {
       expect(setSearchParams).not.toHaveBeenCalled();
       expect(setCommittedValues).toHaveBeenCalled();
     });
+
+    it('resets preview and comparison state on submit', () => {
+      const { result } = renderHook(() =>
+        useSearchControlsHandlers({ coreConfig: mockConfig, uiConfig: mockUIConfig, flow: 'url' }),
+      );
+
+      act(() => {
+        result.current.onSubmit();
+      });
+
+      expect(resetPreviewContent).toHaveBeenCalled();
+      expect(resetFullDisplayComponentType).toHaveBeenCalled();
+      expect(resetCurrentlyPreviewedEntityBfid).toHaveBeenCalled();
+    });
   });
 
   describe('onReset', () => {

--- a/src/features/search/ui/hooks/useSearchControlsHandlers.ts
+++ b/src/features/search/ui/hooks/useSearchControlsHandlers.ts
@@ -308,6 +308,12 @@ export const useSearchControlsHandlers = ({
     [setSearchParams, setCommittedValues],
   );
 
+  const resetPreview = () => {
+    resetPreviewContent();
+    resetFullDisplayComponentType();
+    resetCurrentlyPreviewedEntityBfid();
+  };
+
   const handleSubmit = useCallback(() => {
     const state = useSearchState.getState();
     const { query, searchBy, navigationState, draftBySegment, committedValues } = state;
@@ -366,6 +372,8 @@ export const useSearchControlsHandlers = ({
             { segment, query: normalizedQuery, searchBy: validSearchBy, source },
           );
 
+    resetPreview();
+
     if (flowRef.current === 'url') {
       // URL flow: update URL params
       const urlParams = buildSearchUrlParams(segment, normalizedQuery, validSearchBy, source);
@@ -396,10 +404,7 @@ export const useSearchControlsHandlers = ({
 
     resetQuery();
     resetSearchBy();
-    // Reset preview
-    resetPreviewContent();
-    resetFullDisplayComponentType();
-    resetCurrentlyPreviewedEntityBfid();
+    resetPreview();
 
     if (currentSegment) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
[https://folio-org.atlassian.net/browse/UILD-743](https://folio-org.atlassian.net/browse/UILD-743)

**Technical details:**
- Added a `resetPreview` helper in `useSearchControlsHandlers` that consolidates reset calls into a single reusable function
- Called `resetPreview` in `handleSubmit`, so the preview pane is now closed whenever a search is submitted - regardless of whether the search parameters changed
- Replaced the inline triple-call reset in `handleReset` with the new `resetPreview` helper (cleanup only, no behaviour change)
- Added a unit test to `useSearchControlsHandlers.test.ts` verifying that all three preview-reset functions are called on submit
