### PR TITLE
UILD-541: Field label "Assigning agency" of LOC Classification number is not shown on Work read only screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,11 +113,9 @@
 * Add support for the Geographic Coverage field. Fixes [UILD-665].
 * Change display order for titles. Refs [UILD-304].
 * Respond to the embedding application's locale config. Refs [UILD-786].
-<<<<<<< fix/UILD-743-search-results-preview
 * Hide preview when starting a new search on the Search page. Fixes [UILD-743].
-=======
 * Fix layout of Work title on the Search results page. Fixes [UILD-677].
->>>>>>> master
+* Fix missing preview field label. Fixes [UILD-541].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -230,11 +228,9 @@
 [UILD-665]:https://folio-org.atlassian.net/browse/UILD-665
 [UILD-304]:https://folio-org.atlassian.net/browse/UILD-304
 [UILD-786]:https://folio-org.atlassian.net/browse/UILD-786
-<<<<<<< fix/UILD-743-search-results-preview
 [UILD-743]:https://folio-org.atlassian.net/browse/UILD-743
-=======
 [UILD-677]:https://folio-org.atlassian.net/browse/UILD-677
->>>>>>> master
+[UILD-541]:https://folio-org.atlassian.net/browse/UILD-541
 
 ## 1.0.5 (2025-04-30)
 * Browser Back button navigates to Edit without duplicated title when navigated from Duplicate screen. Fixes [UILD-554].

--- a/src/common/helpers/preview.helper.ts
+++ b/src/common/helpers/preview.helper.ts
@@ -46,11 +46,12 @@ export const getPreviewFieldsConditions = ({
   const isBranchEnd = !hasChildren;
   const isBranchEndWithoutValues = !selectedUserValues && isBranchEnd;
   const isBranchEndWithValues = !!selectedUserValues;
+  const isWithoutComplexSearch = type !== AdvancedFieldType.complex || (type === AdvancedFieldType.complex && !bfid);
   const shouldRenderLabelOrPlaceholders =
     (!(isEntity && hideEntities) && isPreviewable && isGroupable) ||
     type === AdvancedFieldType.dropdown ||
     type === AdvancedFieldType.enumerated ||
-    (isBranchEndWithValues && type !== AdvancedFieldType.complex) ||
+    (isBranchEndWithValues && isWithoutComplexSearch) ||
     isBranchEndWithoutValues;
   const hasOnlyDropdownChildren =
     hasChildren &&

--- a/src/test/__tests__/common/helpers/preview.helper.test.ts
+++ b/src/test/__tests__/common/helpers/preview.helper.test.ts
@@ -270,11 +270,31 @@ describe('preview.helper', () => {
       expect(result.shouldRenderPlaceholders).toBe(true);
     });
 
-    test('handles branch end with complex type', () => {
+    test('handles branch end with non-search complex type', () => {
       const result = getPreviewFieldsConditions({
         ...baseParams,
         entry: {
           ...baseParams.entry,
+          type: AdvancedFieldType.complex,
+          children: undefined,
+        },
+        userValues: {
+          'test-uuid': {
+            uuid: 'test-uuid',
+            contents: [{ label: 'some value' }],
+          },
+        },
+      });
+
+      expect(result.shouldRenderLabelOrPlaceholders).toBe(true);
+    });
+
+    test('handles branch end with search complex type', () => {
+      const result = getPreviewFieldsConditions({
+        ...baseParams,
+        entry: {
+          ...baseParams.entry,
+          bfid: 'lde:test:search',
           type: AdvancedFieldType.complex,
           children: undefined,
         },


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-541

This bug seems to stem from an intentional choice to hide labels like "Search (authority source)" when a value is actually provided, but the filter catches everything that might have a complex search instead of the subset that definitely does. Adding a check for whether the `bfid` is set still hides these, though it will now allow field labels for LCCN assigning agency, Dewey Decimal assigner, hubs, and geographic coverage as these are all of `complex` type without a `bfid` defined.

<img width="527" height="230" alt="Screenshot 2026-04-13 at 17 18 30" src="https://github.com/user-attachments/assets/a9c36d81-9cc8-4824-b3b1-c44f27f74e7c" />
