### PR TITLE
UILD-709: Fix - hide preview in complex lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,11 +113,9 @@
 * Add support for the Geographic Coverage field. Fixes [UILD-665].
 * Change display order for titles. Refs [UILD-304].
 * Respond to the embedding application's locale config. Refs [UILD-786].
-<<<<<<< fix/UILD-743-search-results-preview
 * Hide preview when starting a new search on the Search page. Fixes [UILD-743].
-=======
 * Fix layout of Work title on the Search results page. Fixes [UILD-677].
->>>>>>> master
+* Hide preview in complex lookups. Fixes [UILD-709].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -230,11 +228,9 @@
 [UILD-665]:https://folio-org.atlassian.net/browse/UILD-665
 [UILD-304]:https://folio-org.atlassian.net/browse/UILD-304
 [UILD-786]:https://folio-org.atlassian.net/browse/UILD-786
-<<<<<<< fix/UILD-743-search-results-preview
 [UILD-743]:https://folio-org.atlassian.net/browse/UILD-743
-=======
 [UILD-677]:https://folio-org.atlassian.net/browse/UILD-677
->>>>>>> master
+[UILD-709]:https://folio-org.atlassian.net/browse/UILD-709
 
 ## 1.0.5 (2025-04-30)
 * Browser Back button navigates to Edit without duplicated title when navigated from Duplicate screen. Fixes [UILD-554].

--- a/src/features/complexLookup/components/modals/AuthoritiesModal/AuthoritiesModal.test.tsx
+++ b/src/features/complexLookup/components/modals/AuthoritiesModal/AuthoritiesModal.test.tsx
@@ -62,9 +62,14 @@ jest.mock('@/components/Modal', () => ({
     ) : null,
 }));
 
+let capturedSearchOnSubmitCallback: (() => void) | undefined;
+
 jest.mock('@/features/search/ui/components/Search', () => {
   const MockSearch = Object.assign(
-    ({ children }: { children: React.ReactNode }) => <div data-testid="search">{children}</div>,
+    ({ children, onSubmitCallback }: { children: React.ReactNode; onSubmitCallback?: () => void }) => {
+      capturedSearchOnSubmitCallback = onSubmitCallback;
+      return <div data-testid="search">{children}</div>;
+    },
     {
       Controls: Object.assign(({ children }: { children: React.ReactNode }) => <div>{children}</div>, {
         SegmentGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -425,6 +430,12 @@ describe('AuthoritiesModal', () => {
 
       expect(mockHandleAuthoritiesAssign).toHaveBeenCalledWith({ id: 'auth-1', title: 'Authority 1' });
       expect(mockOnAssign).not.toHaveBeenCalled();
+    });
+
+    it('passes handleCloseMarcPreview as onSubmitCallback to Search', () => {
+      render(<AuthoritiesModal isOpen={true} onClose={mockOnClose} onAssign={mockOnAssign} />);
+
+      expect(capturedSearchOnSubmitCallback).toBe(mockHandleCloseMarcPreview);
     });
   });
 

--- a/src/features/complexLookup/components/modals/AuthoritiesModal/AuthoritiesModal.tsx
+++ b/src/features/complexLookup/components/modals/AuthoritiesModal/AuthoritiesModal.tsx
@@ -80,6 +80,7 @@ export const AuthoritiesModal: FC<AuthoritiesModalProps> = ({
         defaultSegment={`authorities:${initialSegment}`}
         flow="value"
         mode="custom"
+        onSubmitCallback={handleCloseMarcPreview}
       >
         <Search.Controls>
           {/* Segment tabs - clicking triggers onSegmentChange, auto-resolves new config */}

--- a/src/features/complexLookup/components/modals/HubsModal/HubsModal.test.tsx
+++ b/src/features/complexLookup/components/modals/HubsModal/HubsModal.test.tsx
@@ -37,9 +37,14 @@ jest.mock('@/components/Loading', () => ({
   Loading: () => <div data-testid="loading">Loading...</div>,
 }));
 
+let capturedSearchOnSubmitCallback: (() => void) | undefined;
+
 jest.mock('@/features/search/ui/components/Search', () => {
   const MockSearch = Object.assign(
-    ({ children }: { children: React.ReactNode }) => <div data-testid="search">{children}</div>,
+    ({ children, onSubmitCallback }: { children: React.ReactNode; onSubmitCallback?: () => void }) => {
+      capturedSearchOnSubmitCallback = onSubmitCallback;
+      return <div data-testid="search">{children}</div>;
+    },
     {
       Controls: Object.assign(({ children }: { children: React.ReactNode }) => <div>{children}</div>, {
         InputsWrapper: () => <div />,
@@ -197,6 +202,29 @@ describe('HubsModal', () => {
 
       expect(mockHandleHubAssign).toHaveBeenCalledWith({ id: 'hub-1', title: 'Hub 1' });
       expect(mockOnAssign).not.toHaveBeenCalled();
+    });
+
+    it('passes handleCloseHubPreview as onSubmitCallback to Search', () => {
+      const mockHandleCloseHubPreview = jest.fn();
+
+      (ComplexLookupHooks.useModalWithHubPreview as jest.Mock).mockReturnValue({
+        hubPreviewProps: {
+          handleHubAssign: mockHandleHubAssign,
+          isAssigning: false,
+          isHubPreviewOpen: false,
+          isPreviewLoading: false,
+          previewData: null,
+          previewMeta: null,
+          handleHubTitleClick: jest.fn(),
+          handleCloseHubPreview: mockHandleCloseHubPreview,
+          handleHubPreviewAssign: jest.fn(),
+        },
+        handleModalClose: mockHandleModalClose,
+      });
+
+      renderWithProviders(<HubsModal isOpen={true} onClose={mockOnClose} onAssign={mockOnAssign} />);
+
+      expect(capturedSearchOnSubmitCallback).toBe(mockHandleCloseHubPreview);
     });
   });
 

--- a/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
+++ b/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
@@ -46,6 +46,7 @@ export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, assignedValue, 
         defaultSource={defaultSource}
         flow="value"
         mode="custom"
+        onSubmitCallback={hubPreviewProps.handleCloseHubPreview}
       >
         <Search.Controls>
           <Search.Controls.InputsWrapper />

--- a/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.test.tsx
+++ b/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.test.tsx
@@ -34,9 +34,14 @@ jest.mock('@/components/Modal', () => ({
     ) : null,
 }));
 
+let capturedSearchOnSubmitCallback: (() => void) | undefined;
+
 jest.mock('@/features/search/ui/components/Search', () => {
   const MockSearch = Object.assign(
-    ({ children }: { children: React.ReactNode }) => <div data-testid="search">{children}</div>,
+    ({ children, onSubmitCallback }: { children: React.ReactNode; onSubmitCallback?: () => void }) => {
+      capturedSearchOnSubmitCallback = onSubmitCallback;
+      return <div data-testid="search">{children}</div>;
+    },
     {
       Controls: Object.assign(({ children }: { children: React.ReactNode }) => <div>{children}</div>, {
         SegmentGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -357,6 +362,15 @@ describe('SubjectModal', () => {
       render(<SubjectModal isOpen={true} onClose={mockOnClose} onAssign={mockOnAssign} />);
 
       expect(screen.getByTestId('search')).toBeInTheDocument();
+    });
+
+    it('closes both MARC and Hub previews when onSubmitCallback is invoked', () => {
+      render(<SubjectModal isOpen={true} onClose={mockOnClose} onAssign={mockOnAssign} />);
+
+      capturedSearchOnSubmitCallback?.();
+
+      expect(mockHandleCloseMarcPreview).toHaveBeenCalledTimes(1);
+      expect(mockHandleCloseHubPreview).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
+++ b/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
@@ -87,6 +87,10 @@ export const SubjectModal: FC<SubjectModalProps> = ({
         defaultSegment={defaultSegment}
         flow="value"
         mode="custom"
+        onSubmitCallback={() => {
+          handleCloseMarcPreview();
+          hubPreviewProps.handleCloseHubPreview();
+        }}
       >
         <Search.Controls>
           <Search.Controls.SegmentGroup>

--- a/src/features/search/ui/hooks/useSearchControlsHandlers.test.ts
+++ b/src/features/search/ui/hooks/useSearchControlsHandlers.test.ts
@@ -440,6 +440,24 @@ describe('useSearchControlsHandlers', () => {
       expect(resetFullDisplayComponentType).toHaveBeenCalled();
       expect(resetCurrentlyPreviewedEntityBfid).toHaveBeenCalled();
     });
+
+    it('calls onSubmitCallback on submit when provided', () => {
+      const mockOnSubmitCallback = jest.fn();
+      const { result } = renderHook(() =>
+        useSearchControlsHandlers({
+          coreConfig: mockConfig,
+          uiConfig: mockUIConfig,
+          flow: 'url',
+          onSubmitCallback: mockOnSubmitCallback,
+        }),
+      );
+
+      act(() => {
+        result.current.onSubmit();
+      });
+
+      expect(mockOnSubmitCallback).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('onReset', () => {

--- a/src/features/search/ui/hooks/useSearchControlsHandlers.ts
+++ b/src/features/search/ui/hooks/useSearchControlsHandlers.ts
@@ -30,6 +30,7 @@ interface UseSearchControlsHandlersParams {
     };
   };
   refetch?: () => Promise<void>;
+  onSubmitCallback?: () => void;
 }
 
 interface SearchControlsHandlers {
@@ -113,6 +114,7 @@ export const useSearchControlsHandlers = ({
   flow,
   results,
   refetch,
+  onSubmitCallback,
 }: UseSearchControlsHandlersParams): SearchControlsHandlers => {
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -123,6 +125,7 @@ export const useSearchControlsHandlers = ({
   const resultsRef = useRef(results);
   const refetchRef = useRef(refetch);
   const searchParamsRef = useRef(searchParams);
+  const onSubmitCallbackRef = useRef(onSubmitCallback);
 
   useEffect(() => {
     coreConfigRef.current = coreConfig;
@@ -131,7 +134,8 @@ export const useSearchControlsHandlers = ({
     resultsRef.current = results;
     refetchRef.current = refetch;
     searchParamsRef.current = searchParams;
-  }, [coreConfig, uiConfig, flow, results, refetch, searchParams]);
+    onSubmitCallbackRef.current = onSubmitCallback;
+  }, [coreConfig, uiConfig, flow, results, refetch, searchParams, onSubmitCallback]);
 
   const {
     setNavigationState,
@@ -373,6 +377,7 @@ export const useSearchControlsHandlers = ({
           );
 
     resetPreview();
+    onSubmitCallbackRef.current?.();
 
     if (flowRef.current === 'url') {
       // URL flow: update URL params

--- a/src/features/search/ui/providers/SearchProvider.tsx
+++ b/src/features/search/ui/providers/SearchProvider.tsx
@@ -16,7 +16,7 @@ function isDynamicMode(props: SearchProviderProps): props is SearchProviderProps
 }
 
 export const SearchProvider: FC<SearchProviderProps> = props => {
-  const { flow, mode = 'custom', children } = props;
+  const { flow, mode = 'custom', children, onSubmitCallback } = props;
   const { isLoading: isGlobalLoading } = useLoadingState(['isLoading']);
 
   // Extract dynamic/static mode params
@@ -66,7 +66,14 @@ export const SearchProvider: FC<SearchProviderProps> = props => {
   });
 
   // Handlers for search controls (after results so we can pass pageMetadata for browse pagination and refetch)
-  const handlers = useSearchControlsHandlers({ coreConfig, uiConfig: activeUIConfig, flow, results, refetch });
+  const handlers = useSearchControlsHandlers({
+    coreConfig,
+    uiConfig: activeUIConfig,
+    flow,
+    results,
+    refetch,
+    onSubmitCallback,
+  });
 
   // Sync URL to store (URL flow only)
   useUrlSync({ flow, coreConfig, uiConfig: activeUIConfig });

--- a/src/features/search/ui/types/provider.types.ts
+++ b/src/features/search/ui/types/provider.types.ts
@@ -103,6 +103,7 @@ interface BaseProviderProps {
   flow: SearchFlow;
   mode?: RenderMode;
   children: React.ReactNode;
+  onSubmitCallback?: () => void;
 }
 
 export type SearchProviderProps = BaseProviderProps & (StaticModeProps | DynamicModeProps);


### PR DESCRIPTION
Fix a bug where the MARC/Hub preview panel remains visible when the user initiates a new search while an open preview is displayed in Authorities, Hubs, Subject Modal.

[https://folio-org.atlassian.net/browse/UILD-709](https://folio-org.atlassian.net/browse/UILD-709)

**Technical details:**
- Propagated `onSubmitCallback` through `SearchProvider` to `useSearchControlsHandlers` via a ref, so the callback is always up-to-date without destabilizing memoized handlers
- The callback is invoked in `handleSubmit` immediately after the existing `resetPreview()` call, covering all submit code paths (new query, same query re-submitted, value flow, URL flow)
- `AuthoritiesModal`, `SubjectModal` and `HubsModal` passes `handleCloseMarcPreview` as `onSubmitCallback` - this hides the MARC or Hub preview and preview state when a new search starts
- Extended the existing unit tests with a test verifying `onSubmitCallback` is called on submit