### PR TITLE
UILD-563: Show a toast notification after saving a resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
 * Fix editor save button being incorrectly enabled. Fixes [UILD-586].
 * Fix missing preview field label. Fixes [UILD-541].
 * Hide preview in complex lookups. Fixes [UILD-709].
+* Show a toast after saving a resource. Fixes [UILD-563].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -235,6 +236,7 @@
 [UILD-586]:https://folio-org.atlassian.net/browse/UILD-586
 [UILD-541]:https://folio-org.atlassian.net/browse/UILD-541
 [UILD-709]:https://folio-org.atlassian.net/browse/UILD-709
+[UILD-563]:https://folio-org.atlassian.net/browse/UILD-563
 
 ## 1.0.5 (2025-04-30)
 * Browser Back button navigates to Edit without duplicated title when navigated from Duplicate screen. Fixes [UILD-554].

--- a/src/common/hooks/useRecordControls.ts
+++ b/src/common/hooks/useRecordControls.ts
@@ -152,7 +152,7 @@ export const useRecordControls = () => {
   ) => {
     navigate(generateEditResourceUrl(updatedRecordId), {
       replace: true,
-      state: location.state,
+      state: { ...(location.state as NavigationState), preserveStatusMessages: true },
     });
 
     if (isProfileChange) {
@@ -192,7 +192,9 @@ export const useRecordControls = () => {
 
       return updatedRecordId;
     } else {
-      navigate(ensureSegmentInUri(searchResultsUri));
+      navigate(ensureSegmentInUri(searchResultsUri), {
+        state: { preserveStatusMessages: true } satisfies NavigationState,
+      });
     }
 
     return updatedRecordId;

--- a/src/types/navigation.d.ts
+++ b/src/types/navigation.d.ts
@@ -1,0 +1,5 @@
+type NavigationState = {
+  preserveStatusMessages?: boolean;
+  isNavigatedFromLDE?: boolean;
+  [key: string]: unknown;
+};

--- a/src/views/Root/components/CommonStatus.test.tsx
+++ b/src/views/Root/components/CommonStatus.test.tsx
@@ -88,7 +88,7 @@ describe('CommonStatus', () => {
     expect(screen.getByTestId('common-status')).toBeInTheDocument();
     expect(getStatusMessagesCount(container)).toBe(2);
 
-    mockUseLocation.mockReturnValue({ pathname: '/different' });
+    mockUseLocation.mockReturnValue({ pathname: '/different', state: null });
 
     rerender(
       <MemoryRouter initialEntries={[{ pathname: '/different' }]}>
@@ -97,5 +97,27 @@ describe('CommonStatus', () => {
     );
 
     expect(screen.queryByTestId('common-status')).not.toBeInTheDocument();
+  });
+
+  test('preserves messages when navigating with preserveStatusMessages flag', async () => {
+    const statusMessages = [{ id: '01', type: StatusType.success, message: 'ld.rdUpdateSuccess' }];
+
+    const { container, rerender } = renderComponent(statusMessages, '/edit');
+
+    expect(getStatusMessagesCount(container)).toBe(1);
+
+    mockUseLocation.mockReturnValue({
+      pathname: '/search',
+      state: { preserveStatusMessages: true },
+    });
+
+    rerender(
+      <MemoryRouter initialEntries={[{ pathname: '/search' }]}>
+        <CommonStatus />
+      </MemoryRouter>,
+    );
+
+    expect(getStatusMessagesCount(container)).toBe(1);
+    expect(screen.getByText('ld.rdUpdateSuccess')).toBeInTheDocument();
   });
 });

--- a/src/views/Root/components/CommonStatus.tsx
+++ b/src/views/Root/components/CommonStatus.tsx
@@ -42,7 +42,10 @@ export const CommonStatus: FC = () => {
   const { statusMessages, setStatusMessages } = useStatusState(['statusMessages', 'setStatusMessages']);
 
   useEffect(() => {
-    if (previousPath.current !== location.pathname) {
+    const shouldClearMessages =
+      previousPath.current !== location.pathname && !(location.state as NavigationState)?.preserveStatusMessages;
+
+    if (shouldClearMessages) {
       setStatusMessages([]);
     }
     previousPath.current = location.pathname;


### PR DESCRIPTION
Display a toast notification after saving a resource and persist status messages during navigation to the Search page.
Fixed a regression that occurred after changes to the toasts behavior: `CommonStatus` was clearing all status messages on every pathname change, including navigations triggered by save actions where the success toast should persist.

[https://folio-org.atlassian.net/browse/UILD-563](https://folio-org.atlassian.net/browse/UILD-563)

**Technical details:**
- Added `preserveStatusMessages` flag to `navigate()` state in `handleBackNavigation` and `handleProfileOrNoNavigationChange`
- CommonStatus now checks `location.state.preserveStatusMessages` and skips clearing messages when the flag is set
- Introduced `NavigationState` global type for typed navigation state usage
- Added test for the new preserve-messages-on-navigation behavior
