### PR TITLE
UILD-788: Fix the broken search results table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@
 * Fix missing preview field label. Fixes [UILD-541].
 * Hide preview in complex lookups. Fixes [UILD-709].
 * Show a toast after saving a resource. Fixes [UILD-563].
+* Fix the broken search results table. Fixes [UILD-788].
 
 [UILD-552]:https://folio-org.atlassian.net/browse/UILD-552
 [UILD-544]:https://folio-org.atlassian.net/browse/UILD-544
@@ -237,6 +238,7 @@
 [UILD-541]:https://folio-org.atlassian.net/browse/UILD-541
 [UILD-709]:https://folio-org.atlassian.net/browse/UILD-709
 [UILD-563]:https://folio-org.atlassian.net/browse/UILD-563
+[UILD-788]:https://folio-org.atlassian.net/browse/UILD-788
 
 ## 1.0.5 (2025-04-30)
 * Browser Back button navigates to Edit without duplicated title when navigated from Duplicate screen. Fixes [UILD-554].

--- a/src/features/search/core/strategies/resultFormatters/authorities.test.ts
+++ b/src/features/search/core/strategies/resultFormatters/authorities.test.ts
@@ -31,7 +31,7 @@ describe('AuthoritiesResultFormatter', () => {
       {
         __meta: {
           id: '1',
-          key: expect.any(String),
+          key: '1',
           isAnchor: true,
         },
         authorized: {
@@ -72,7 +72,7 @@ describe('AuthoritiesResultFormatter', () => {
       {
         __meta: {
           id: '2',
-          key: expect.any(String),
+          key: '2',
           isAnchor: false,
         },
         authorized: {
@@ -104,7 +104,7 @@ describe('AuthoritiesResultFormatter', () => {
       {
         __meta: {
           id: '1',
-          key: expect.any(String),
+          key: '1',
           isAnchor: true,
         },
         authorized: {
@@ -151,7 +151,7 @@ describe('AuthoritiesResultFormatter', () => {
       {
         __meta: {
           id: '3',
-          key: expect.any(String),
+          key: '3',
           isAnchor: false,
         },
         authorized: {
@@ -198,7 +198,7 @@ describe('AuthoritiesResultFormatter', () => {
       {
         __meta: {
           id: 'id_3',
-          key: expect.any(String),
+          key: 'id_3',
           isAnchor: false,
         },
         authorized: {
@@ -245,7 +245,7 @@ describe('AuthoritiesResultFormatter', () => {
       {
         __meta: {
           id: '4',
-          key: expect.any(String),
+          key: '4',
           isAnchor: false,
         },
         authorized: {
@@ -271,5 +271,28 @@ describe('AuthoritiesResultFormatter', () => {
     });
 
     expect(result).toEqual(testResult);
+  });
+
+  it('uses a deterministic fallback key when id is missing', () => {
+    const authoritiesListWithoutId = [
+      {
+        authority: {
+          id: '',
+          authRefType: 'testType_fallback',
+          headingRef: 'testHeading_fallback',
+          headingType: 'testHeadingType_fallback',
+          sourceFileId: 'testSource_fallback',
+        },
+        isAnchor: false,
+      },
+    ];
+
+    const firstResult = formatter.format(authoritiesListWithoutId as unknown as AuthorityAsBrowseResultDTO[]);
+    const secondResult = formatter.format(authoritiesListWithoutId as unknown as AuthorityAsBrowseResultDTO[]);
+
+    expect(firstResult[0].__meta.key).toBe(secondResult[0].__meta.key);
+    expect(firstResult[0].__meta.key).toContain('authority:');
+    expect(firstResult[0].__meta.key).toContain('testheading_fallback');
+    expect(firstResult[0].__meta.key).not.toBe('authority-0');
   });
 });

--- a/src/features/search/core/strategies/resultFormatters/authorities.ts
+++ b/src/features/search/core/strategies/resultFormatters/authorities.ts
@@ -1,6 +1,5 @@
-import { v4 as uuidv4 } from 'uuid';
-
 import { IResultFormatter, ResultFormatterOptions } from '../../types';
+import { createCompositeKeyBuilder } from '../../utils';
 
 /**
  * Formats Authority data for search/browse results
@@ -19,6 +18,8 @@ export class AuthoritiesResultFormatter implements IResultFormatter<SearchResult
     sourceData?: SourceDataDTO,
     notSpecifiedLabel?: string,
   ): SearchResultsTableRow[] {
+    const buildFallbackKey = createCompositeKeyBuilder();
+
     return authoritiesList?.map(authorityEntry => {
       const selectedEntry = (authorityEntry.authority ?? authorityEntry) as AuthorityAsSearchResultDTO;
       const { id = '', authRefType = '', headingRef = '', headingType = '', sourceFileId = '' } = selectedEntry;
@@ -28,7 +29,7 @@ export class AuthoritiesResultFormatter implements IResultFormatter<SearchResult
       return {
         __meta: {
           id,
-          key: uuidv4(),
+          key: id || buildFallbackKey('authority', [headingRef, headingType, authRefType, sourceFileId, isAnchor]),
           isAnchor,
         },
         authorized: {

--- a/src/features/search/core/strategies/resultFormatters/hub.test.ts
+++ b/src/features/search/core/strategies/resultFormatters/hub.test.ts
@@ -27,7 +27,7 @@ describe('HubsResultFormatter', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].__meta.id).toBe('token_123');
-      expect(result[0].__meta.key).toBeDefined();
+      expect(result[0].__meta.key).toBe('token_123');
       expect(result[0].__meta.isAnchor).toBe(false);
       expect(result[0].__meta.isLocal).toBe(false);
       expect(result[0].hub.label).toBe('Test Hub');
@@ -68,6 +68,7 @@ describe('HubsResultFormatter', () => {
       const result = formatter.format(mockHubData);
 
       expect(result[0].__meta.id).toBe('id_456');
+      expect(result[0].__meta.key).toBe('id_456');
       expect(result[0].__meta.isLocal).toBe(true);
       expect(result[0].source.label).toBe('ld.source.libraryOfCongress.local');
     });
@@ -105,6 +106,8 @@ describe('HubsResultFormatter', () => {
       expect(result[0].hub.label).toBe('');
       expect(result[0].hub.uri).toBe('');
       expect(result[0].__meta.id).toBe('');
+      expect(result[0].__meta.key).toContain('hub:');
+      expect(result[0].__meta.key).not.toBe('hub-0');
     });
 
     it('formats multiple hub entries correctly', () => {
@@ -134,7 +137,7 @@ describe('HubsResultFormatter', () => {
       expect(result[2].__meta.id).toBe('token_3');
     });
 
-    it('generates unique keys for each entry', () => {
+    it('uses stable keys for each entry', () => {
       const mockHubData = [
         {
           suggestLabel: 'Hub 1',
@@ -150,7 +153,8 @@ describe('HubsResultFormatter', () => {
 
       const result = formatter.format(mockHubData);
 
-      expect(result[0].__meta.key).not.toBe(result[1].__meta.key);
+      expect(result[0].__meta.key).toBe('token_1');
+      expect(result[1].__meta.key).toBe('token_2');
     });
   });
 });

--- a/src/features/search/core/strategies/resultFormatters/hub.ts
+++ b/src/features/search/core/strategies/resultFormatters/hub.ts
@@ -1,7 +1,5 @@
-import { v4 as uuidv4 } from 'uuid';
-
 import { IResultFormatter } from '../../types';
-import { getIsLocalFlag, getSourceLabel } from '../../utils';
+import { createCompositeKeyBuilder, getIsLocalFlag, getSourceLabel } from '../../utils';
 
 /**
  * Formats Hub data for Search page results
@@ -13,16 +11,19 @@ export class HubsResultFormatter implements IResultFormatter<SearchResultsTableR
   }
 
   private formatHubs(hubList: HubSearchResultDTO[]): SearchResultsTableRow[] {
+    const buildFallbackKey = createCompositeKeyBuilder();
+
     return hubList?.map(hubEntry => {
       const { suggestLabel = '', uri = '', token = '' } = hubEntry;
       const isLocal = getIsLocalFlag(hubEntry);
       const localId = (hubEntry as HubSearchResultDTO & { localId?: string }).localId;
       const sourceLabel = getSourceLabel(isLocal);
+      const stableId = isLocal && localId ? localId : token;
 
       return {
         __meta: {
-          id: isLocal && localId ? localId : token,
-          key: uuidv4(),
+          id: stableId,
+          key: stableId || buildFallbackKey('hub', [suggestLabel, uri, isLocal]),
           isAnchor: false,
           isLocal,
         },

--- a/src/features/search/core/strategies/resultFormatters/hubLocal.test.ts
+++ b/src/features/search/core/strategies/resultFormatters/hubLocal.test.ts
@@ -25,6 +25,7 @@ describe('HubsLocalResultFormatter', () => {
       expect(result[0]).toMatchObject({
         __meta: {
           id: 'hub_1',
+          key: 'hub_1',
           isAnchor: false,
           isLocal: true,
         },
@@ -38,7 +39,6 @@ describe('HubsLocalResultFormatter', () => {
           className: 'hub-source',
         },
       });
-      expect(result[0].__meta.key).toBeDefined();
     });
 
     it('Formats local hub without originalId as "Local"', () => {
@@ -56,6 +56,7 @@ describe('HubsLocalResultFormatter', () => {
       expect(result[0]).toMatchObject({
         __meta: {
           id: 'hub_2',
+          key: 'hub_2',
           isAnchor: false,
           isLocal: true,
         },
@@ -134,6 +135,9 @@ describe('HubsLocalResultFormatter', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].__meta.id).toBe('');
+      expect(result[0].__meta.key).toContain('hub-local:');
+      expect(result[0].__meta.key).toContain('test hub');
+      expect(result[0].__meta.key).not.toBe('hub-local-0');
     });
 
     it('Sets isLocal to true for all results', () => {
@@ -158,7 +162,7 @@ describe('HubsLocalResultFormatter', () => {
       });
     });
 
-    it('Generates unique keys for each result', () => {
+    it('Uses stable keys for each result', () => {
       const mockData: LocalHubSearchResultDTO[] = [
         {
           id: 'hub_1',
@@ -174,10 +178,8 @@ describe('HubsLocalResultFormatter', () => {
 
       const result = formatter.format(mockData);
 
-      const keys = result.map(r => r.__meta.key);
-      const uniqueKeys = new Set(keys);
-
-      expect(uniqueKeys.size).toBe(keys.length);
+      expect(result[0].__meta.key).toBe('hub_1');
+      expect(result[1].__meta.key).toBe('hub_2');
     });
 
     it('Handles originalId with empty string as "Local"', () => {

--- a/src/features/search/core/strategies/resultFormatters/hubLocal.ts
+++ b/src/features/search/core/strategies/resultFormatters/hubLocal.ts
@@ -1,6 +1,5 @@
-import { v4 as uuidv4 } from 'uuid';
-
 import { IResultFormatter, LocalHubSearchResultDTO } from '../../types';
+import { createCompositeKeyBuilder } from '../../utils';
 
 /**
  * Formats local Hub data for Search page results
@@ -13,6 +12,8 @@ export class HubsLocalResultFormatter implements IResultFormatter<SearchResultsT
   }
 
   private formatHubs(hubList: LocalHubSearchResultDTO[]): SearchResultsTableRow[] {
+    const buildFallbackKey = createCompositeKeyBuilder();
+
     return hubList?.map(hubEntry => {
       const { label = '', id = '', originalId } = hubEntry;
 
@@ -22,7 +23,7 @@ export class HubsLocalResultFormatter implements IResultFormatter<SearchResultsT
       return {
         __meta: {
           id,
-          key: uuidv4(),
+          key: id || buildFallbackKey('hub-local', [label, originalId]),
           isAnchor: false,
           isLocal: true,
           originalId,

--- a/src/features/search/core/strategies/resultFormatters/hubLookup.test.ts
+++ b/src/features/search/core/strategies/resultFormatters/hubLookup.test.ts
@@ -69,6 +69,7 @@ describe('HubsLookupResultFormatter', () => {
     // Test first item with Auth and RDA notes
     const firstItem = result[0];
     expect(firstItem.__meta.id).toBe('test_token');
+    expect(firstItem.__meta.key).toBe('test_token');
     expect(firstItem.hub.label).toBe('Beta (Computer file) suggest');
     expect(firstItem.hub.uri).toBe('test_uri/test_token');
     expect(firstItem.auth.label).toBe('ld.yes');
@@ -77,9 +78,21 @@ describe('HubsLookupResultFormatter', () => {
     // Test second item without Auth and RDA notes
     const secondItem = result[1];
     expect(secondItem.__meta.id).toBe('test-hub-id');
+    expect(secondItem.__meta.key).toBe('test-hub-id');
     expect(secondItem.hub.label).toBe('Alpha Test suggest');
     expect(secondItem.auth.label).toBe(undefined);
     expect(secondItem.rda.label).toBe(undefined);
+  });
+
+  test('uses a deterministic fallback key when token is missing', () => {
+    const firstResult = formatter.format([{ ...mockHubData[0], token: '' }]);
+    const secondResult = formatter.format([{ ...mockHubData[0], token: '' }]);
+
+    expect(firstResult[0].__meta.id).toBe('');
+    expect(firstResult[0].__meta.key).toBe(secondResult[0].__meta.key);
+    expect(firstResult[0].__meta.key).toContain('hub-lookup:');
+    expect(firstResult[0].__meta.key).toContain('beta (computer file) suggest');
+    expect(firstResult[0].__meta.key).not.toBe('hub-lookup-0');
   });
 
   test('handles empty hub list', () => {

--- a/src/features/search/core/strategies/resultFormatters/hubLookup.ts
+++ b/src/features/search/core/strategies/resultFormatters/hubLookup.ts
@@ -1,7 +1,5 @@
-import { v4 as uuidv4 } from 'uuid';
-
 import { IResultFormatter } from '../../types';
-import { getIsLocalFlag, getSourceLabel } from '../../utils';
+import { createCompositeKeyBuilder, getIsLocalFlag, getSourceLabel } from '../../utils';
 
 const checkAuthNote = (notes: string[]) => notes.some(note => note.includes('Created from auth.'));
 
@@ -21,17 +19,20 @@ export class HubsLookupResultFormatter implements IResultFormatter<SearchResults
   }
 
   private formatHubs(hubList: HubSearchResultDTO[]): SearchResultsTableRow[] {
+    const buildFallbackKey = createCompositeKeyBuilder();
+
     return hubList?.map(hubEntry => {
-      const { suggestLabel = '', uri = '', token = '', more } = hubEntry;
+      const { suggestLabel = '', uri = '', token = '', more, aLabel = '', vLabel = '', sLabel = '' } = hubEntry;
       const { notes = [] } = more || {};
       const isLocal = getIsLocalFlag(hubEntry);
       const localId = (hubEntry as HubSearchResultDTO & { localId?: string }).localId;
       const sourceLabel = getSourceLabel(isLocal);
+      const stableId = isLocal && localId ? localId : token;
 
       return {
         __meta: {
-          id: isLocal && localId ? localId : token,
-          key: uuidv4(),
+          id: stableId,
+          key: stableId || buildFallbackKey('hub-lookup', [suggestLabel, uri, aLabel, vLabel, sLabel, isLocal]),
           isAnchor: false,
           isLocal,
         },

--- a/src/features/search/core/utils/search.helper.test.ts
+++ b/src/features/search/core/utils/search.helper.test.ts
@@ -1,9 +1,81 @@
 import { SearchQueryParams } from '@/common/constants/routes.constants';
-import { SearchIdentifiers } from '@/common/constants/search.constants';
+import { SearchIdentifiers, TitleTypes } from '@/common/constants/search.constants';
 
-import { generateSearchParamsState, removeBackslashes } from './search.helper';
+import { formatItemSearchInstanceListData, generateSearchParamsState, removeBackslashes } from './search.helper';
 
 describe('search.helper', () => {
+  describe('formatItemSearchInstanceListData', () => {
+    it('uses stable instance keys based on id', () => {
+      const result = formatItemSearchInstanceListData([
+        {
+          id: 'instance_1',
+          titles: [{ type: TitleTypes.Main, value: 'Primary Title' }],
+          identifiers: [],
+          publications: [],
+        } as unknown as InstanceAsSearchResultDTO,
+      ]);
+
+      expect(result[0].__meta).toEqual({
+        id: 'instance_1',
+        key: 'instance_1',
+      });
+    });
+
+    it('uses a deterministic fallback key when instance id is missing', () => {
+      const firstResult = formatItemSearchInstanceListData([
+        {
+          id: '',
+          titles: [{ type: TitleTypes.Main, value: 'Fallback Title' }],
+          identifiers: [],
+          publications: [],
+        } as unknown as InstanceAsSearchResultDTO,
+      ]);
+      const secondResult = formatItemSearchInstanceListData([
+        {
+          id: '',
+          titles: [{ type: TitleTypes.Main, value: 'Fallback Title' }],
+          identifiers: [],
+          publications: [],
+        } as unknown as InstanceAsSearchResultDTO,
+      ]);
+      const [firstRow] = firstResult;
+      const [secondRow] = secondResult;
+
+      if (!firstRow || !secondRow || !firstRow.__meta || !secondRow.__meta) {
+        throw new Error('Expected a formatted row');
+      }
+
+      expect(firstResult).toHaveLength(1);
+      expect(secondResult).toHaveLength(1);
+      expect(firstRow.__meta.key).toBe(secondRow.__meta.key);
+      expect(firstRow.__meta.key).toContain('instance:');
+      expect(firstRow.__meta.key).toContain('fallback title');
+      expect(firstRow.__meta.key).not.toBe('instance-0');
+    });
+
+    it('adds an occurrence suffix when fallback signatures repeat', () => {
+      const result = formatItemSearchInstanceListData([
+        {
+          id: '',
+          titles: [{ type: TitleTypes.Main, value: 'Duplicate Title' }],
+          identifiers: [],
+          publications: [],
+        } as unknown as InstanceAsSearchResultDTO,
+        {
+          id: '',
+          titles: [{ type: TitleTypes.Main, value: 'Duplicate Title' }],
+          identifiers: [],
+          publications: [],
+        } as unknown as InstanceAsSearchResultDTO,
+      ]);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.__meta?.key).not.toBe(result[1]?.__meta?.key);
+      expect(result[0]?.__meta?.key).toContain('duplicate title');
+      expect(result[1]?.__meta?.key).toContain('duplicate title');
+    });
+  });
+
   describe('generateSearchParamsState', () => {
     it('generates state with query only', () => {
       const result = generateSearchParamsState('test query');
@@ -108,7 +180,7 @@ describe('search.helper', () => {
 
   describe('removeBackslashes', () => {
     it('removes all backslashes from a string', () => {
-      const query = 'hello\\world\\test';
+      const query = String.raw`hello\world\test`;
       const testResult = 'helloworldtest';
 
       expect(removeBackslashes(query)).toBe(testResult);
@@ -129,42 +201,42 @@ describe('search.helper', () => {
     });
 
     it('handles multiple consecutive backslashes', () => {
-      const query = 'hello\\\\world';
+      const query = String.raw`hello\\world`;
       const testResult = 'helloworld';
 
       expect(removeBackslashes(query)).toBe(testResult);
     });
 
     it('preserves other special characters', () => {
-      const query = 'hello\\world!@#$%^&*()';
+      const query = String.raw`hello\world!@#$%^&*()`;
       const testResult = 'helloworld!@#$%^&*()';
 
       expect(removeBackslashes(query)).toBe(testResult);
     });
 
     it('handles escaped quotes', () => {
-      const query = 'hello\\"world\\"';
+      const query = String.raw`hello\"world\"`;
       const testResult = 'hello"world"';
 
       expect(removeBackslashes(query)).toBe(testResult);
     });
 
     it('handles escaped single quotes', () => {
-      const query = "hello\\'world\\'";
+      const query = String.raw`hello\'world\'`;
       const testResult = "hello'world'";
 
       expect(removeBackslashes(query)).toBe(testResult);
     });
 
     it('handles escaped forward slashes', () => {
-      const query = 'hello\\/world\\/test';
+      const query = String.raw`hello\/world\/test`;
       const testResult = 'hello/world/test';
 
       expect(removeBackslashes(query)).toBe(testResult);
     });
 
     it('handles multiple escaped quotes in sequence', () => {
-      const query = '\\"\\"\\"hello\\"\\"\\"';
+      const query = String.raw`\"\"\"hello\"\"\"`;
       const testResult = '"""hello"""';
 
       expect(removeBackslashes(query)).toBe(testResult);

--- a/src/features/search/core/utils/search.helper.ts
+++ b/src/features/search/core/utils/search.helper.ts
@@ -10,23 +10,21 @@ import { Row } from '@/components/Table';
 type CompositePrimitiveKeyPart = string | number | boolean | null | undefined;
 type CompositeKeyPart = CompositePrimitiveKeyPart | ReadonlyArray<CompositePrimitiveKeyPart>;
 
-export const normalizeKeyPart = (value: CompositeKeyPart): string => {
-  if (Array.isArray(value)) {
-    return JSON.stringify(value.map(item => normalizeKeyPart(item)));
-  }
-
-  return String(value ?? '')
+export const normalizeKeyPart = (value: CompositePrimitiveKeyPart): string =>
+  String(value ?? '')
     .normalize('NFKC')
     .trim()
     .toLowerCase()
     .replaceAll(/\s+/g, ' ');
-};
 
 export const createCompositeKeyBuilder = () => {
   const occurrenceBySignature = new Map<string, number>();
 
   return (prefix: string, parts: CompositeKeyPart[]): string => {
-    const signature = JSON.stringify(parts.map(normalizeKeyPart));
+    const normalizedParts = parts.map(part =>
+      Array.isArray(part) ? part.map(normalizeKeyPart) : normalizeKeyPart(part as CompositePrimitiveKeyPart),
+    );
+    const signature = JSON.stringify(normalizedParts);
     const occurrence = occurrenceBySignature.get(signature) ?? 0;
 
     occurrenceBySignature.set(signature, occurrence + 1);

--- a/src/features/search/core/utils/search.helper.ts
+++ b/src/features/search/core/utils/search.helper.ts
@@ -1,5 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
-
 import { SearchQueryParams } from '@/common/constants/routes.constants';
 import {
   AdvancedSearchQualifiers,
@@ -8,6 +6,34 @@ import {
   TitleTypes,
 } from '@/common/constants/search.constants';
 import { Row } from '@/components/Table';
+
+type CompositePrimitiveKeyPart = string | number | boolean | null | undefined;
+type CompositeKeyPart = CompositePrimitiveKeyPart | ReadonlyArray<CompositePrimitiveKeyPart>;
+
+export const normalizeKeyPart = (value: CompositeKeyPart): string => {
+  if (Array.isArray(value)) {
+    return JSON.stringify(value.map(item => normalizeKeyPart(item)));
+  }
+
+  return String(value ?? '')
+    .normalize('NFKC')
+    .trim()
+    .toLowerCase()
+    .replaceAll(/\s+/g, ' ');
+};
+
+export const createCompositeKeyBuilder = () => {
+  const occurrenceBySignature = new Map<string, number>();
+
+  return (prefix: string, parts: CompositeKeyPart[]): string => {
+    const signature = JSON.stringify(parts.map(normalizeKeyPart));
+    const occurrence = occurrenceBySignature.get(signature) ?? 0;
+
+    occurrenceBySignature.set(signature, occurrence + 1);
+
+    return `${prefix}:${signature}#${occurrence}`;
+  };
+};
 
 export const findIdentifier = (id: SearchIdentifiers, identifiers?: { value?: string; type?: string }[]) =>
   identifiers?.find(({ type }) => type === id.toUpperCase())?.value;
@@ -19,27 +45,32 @@ export const getTitle = (titles: GenericStructDTO<TitleType>[] | undefined) => {
 };
 
 export const formatItemSearchInstanceListData = (instanceList: InstanceAsSearchResultDTO[]): Row[] => {
+  const buildFallbackKey = createCompositeKeyBuilder();
+
   return instanceList.map(({ id, titles, identifiers, publications }) => {
     // at the moment, picking the first match/first item in list for display
     // this might change depending on requirements
 
     const selectedPublisher = publications?.find(({ name, date }) => name ?? date);
+    const title = getTitle(titles);
+    const isbn = findIdentifier(SearchIdentifiers.ISBN, identifiers);
+    const lccn = findIdentifier(SearchIdentifiers.LCCN, identifiers);
 
     return {
       __meta: {
         id,
-        key: uuidv4(),
+        key: id || buildFallbackKey('instance', [title, isbn, lccn, selectedPublisher?.name, selectedPublisher?.date]),
       },
       title: {
-        label: getTitle(titles),
+        label: title,
         className: 'title',
       },
       isbn: {
-        label: findIdentifier(SearchIdentifiers.ISBN, identifiers),
+        label: isbn,
         className: 'identifier',
       },
       lccn: {
-        label: findIdentifier(SearchIdentifiers.LCCN, identifiers),
+        label: lccn,
         className: 'identifier',
       },
       publisher: {
@@ -115,14 +146,14 @@ export const generateSearchParamsState = (
 };
 
 export const normalizeQuery = (query?: string | null) => {
-  return query?.replaceAll(/['"/\\]/g, '\\$&');
+  return query?.replaceAll(/['"/\\]/g, String.raw`\$&`);
 };
 
 export const removeBackslashes = (query?: string | null) => {
   if (!query) return '';
 
   return query
-    .replace(/\\"/g, '"') // replace escaped double quotes with double quotes
-    .replace(/\\\\/g, '\\') // replace double backslashes with single
-    .replace(/([^\\])\\(?!\\)/g, '$1'); // remove single backslashes;
+    .replaceAll(String.raw`\"`, '"') // replace escaped double quotes with double quotes
+    .replaceAll(String.raw`\\`, '\\') // replace double backslashes with single
+    .replaceAll(/([^\\])\\(?!\\)/g, '$1'); // remove single backslashes;
 };

--- a/src/features/search/ui/components/results/authorities/AuthoritiesResultList.test.tsx
+++ b/src/features/search/ui/components/results/authorities/AuthoritiesResultList.test.tsx
@@ -86,6 +86,21 @@ describe('AuthoritiesResultList', () => {
     });
   });
 
+  test('reuses formatter options across rerenders when fallback label does not change', () => {
+    mockUseFormattedResults.mockReturnValue(mockData);
+    mockUseTableFormatter.mockReturnValue({
+      formattedData: mockFormattedData,
+      listHeader: mockListHeader,
+    });
+
+    const { rerender } = render(<AuthoritiesResultList />);
+
+    rerender(<AuthoritiesResultList />);
+
+    expect(mockUseFormattedResults).toHaveBeenCalledTimes(2);
+    expect(mockUseFormattedResults.mock.calls[0][0]).toBe(mockUseFormattedResults.mock.calls[1][0]);
+  });
+
   test('renders with empty data when useFormattedResults returns undefined', () => {
     mockUseFormattedResults.mockReturnValue(undefined);
     mockUseTableFormatter.mockReturnValue({

--- a/src/features/search/ui/components/results/authorities/AuthoritiesResultList.tsx
+++ b/src/features/search/ui/components/results/authorities/AuthoritiesResultList.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
 import { TableFlex } from '@/components/Table';
@@ -24,7 +24,8 @@ export const AuthoritiesResultList: FC<AuthoritiesResultListProps> = ({
 }) => {
   const { formatMessage } = useIntl();
   const fallbackLabel = notSpecifiedLabel ?? formatMessage({ id: 'ld.notSpecified' });
-  const data = useFormattedResults<SearchResultsTableRow>({ notSpecifiedLabel: fallbackLabel }) || [];
+  const formatterOptions = useMemo(() => ({ notSpecifiedLabel: fallbackLabel }), [fallbackLabel]);
+  const data = useFormattedResults<SearchResultsTableRow>(formatterOptions) || [];
   const { formattedData, listHeader } = useTableFormatter({
     data,
     tableConfig: authoritiesTableConfig,

--- a/src/features/search/ui/hooks/useSearchControlsHandlers.ts
+++ b/src/features/search/ui/hooks/useSearchControlsHandlers.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useCallback, useEffect, useRef } from 'react';
+import { type RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
 import { type SetURLSearchParams, useSearchParams } from 'react-router-dom';
 
 import { DEFAULT_SEARCH_BY, SEARCH_RESULTS_LIMIT } from '@/common/constants/search.constants';
@@ -471,11 +471,14 @@ export const useSearchControlsHandlers = ({
     resetCurrentlyPreviewedEntityBfid,
   ]);
 
-  return {
-    onSegmentChange: handleSegmentChange,
-    onSourceChange: handleSourceChange,
-    onPageChange: handlePageChange,
-    onSubmit: handleSubmit,
-    onReset: handleReset,
-  };
+  return useMemo(
+    () => ({
+      onSegmentChange: handleSegmentChange,
+      onSourceChange: handleSourceChange,
+      onPageChange: handlePageChange,
+      onSubmit: handleSubmit,
+      onReset: handleReset,
+    }),
+    [handleSegmentChange, handleSourceChange, handlePageChange, handleSubmit, handleReset],
+  );
 };

--- a/src/features/search/ui/hooks/useUrlSync.ts
+++ b/src/features/search/ui/hooks/useUrlSync.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { SearchIdentifiers } from '@/common/constants/search.constants';
@@ -19,13 +19,26 @@ interface UseUrlSyncParams {
 
 export const useUrlSync = ({ flow, coreConfig, uiConfig }: UseUrlSyncParams): void => {
   const [searchParams] = useSearchParams();
-  const { query, setQuery, searchBy, setSearchBy, setNavigationState } = useSearchState([
-    'query',
+  const { setQuery, setSearchBy, setNavigationState } = useSearchState([
     'setQuery',
-    'searchBy',
     'setSearchBy',
     'setNavigationState',
   ]);
+
+  // Use refs for query/searchBy to avoid subscribing to their changes.
+  // Reactive subscriptions would cause SearchProvider to re-render on every keystroke,
+  // even in value flow where useUrlSync is a complete no-op.
+  const queryRef = useRef(useSearchState.getState().query);
+  const searchByRef = useRef(useSearchState.getState().searchBy);
+
+  useEffect(() => {
+    const unsubscribe = useSearchState.subscribe(state => {
+      queryRef.current = state.query;
+      searchByRef.current = state.searchBy;
+    });
+
+    return unsubscribe;
+  }, []);
 
   useEffect(() => {
     // Only sync for URL flow
@@ -39,7 +52,7 @@ export const useUrlSync = ({ flow, coreConfig, uiConfig }: UseUrlSyncParams): vo
     const isAdvancedSearch = queryFromUrl !== null && searchByFromUrl === null;
 
     // Only sync query to store if it's NOT an advanced search
-    if (!isAdvancedSearch && queryFromUrl !== null && queryFromUrl !== query) {
+    if (!isAdvancedSearch && queryFromUrl !== null && queryFromUrl !== queryRef.current) {
       const unescapedQuery = removeBackslashes(queryFromUrl);
       setQuery(unescapedQuery);
     }
@@ -48,7 +61,7 @@ export const useUrlSync = ({ flow, coreConfig, uiConfig }: UseUrlSyncParams): vo
     if (searchByFromUrl !== null) {
       const validSearchBy = getValidSearchBy(searchByFromUrl, uiConfig, coreConfig);
 
-      if (validSearchBy !== searchBy) {
+      if (validSearchBy !== searchByRef.current) {
         setSearchBy(validSearchBy as SearchIdentifiers);
       }
     }
@@ -61,7 +74,7 @@ export const useUrlSync = ({ flow, coreConfig, uiConfig }: UseUrlSyncParams): vo
 
     // If URL has no query but store does, clear store (only for simple search)
     // Don't clear if it's transitioning from advanced search
-    if (queryFromUrl === null && query && searchByFromUrl !== null) {
+    if (queryFromUrl === null && queryRef.current && searchByFromUrl !== null) {
       setQuery('');
     }
   }, [flow, searchParams, setQuery, setSearchBy, setNavigationState, coreConfig, uiConfig]);


### PR DESCRIPTION
Fix search results table layout breaking when query input or search-by changes in complex lookup modals (Authorities, Subject, Dissertation, etc.).

[https://folio-org.atlassian.net/browse/UILD-788](https://folio-org.atlassian.net/browse/UILD-788)

**Technical details:**
- Replaced `uuidv4()` row keys in all result formatters with stable, deterministic keys derived from data identifiers. A new `createCompositeKeyBuilder` utility generates collision-safe fallback keys from field content when no id is present, preventing React from unmounting and re-mounting DOM rows on re-render
- Memoized `formatterOptions` in `AuthoritiesResultList` with `useMemo` so `useFormattedResults's` `useMemo` does not recompute when the parent re-renders with the same label value
- Replaced reactive query/searchBy Zustand subscriptions in `useUrlSync` with `useRef` + `useSearchState.subscribe()` - eliminating unnecessary `SearchProvider` re-renders on every keystroke in value-flow modals where `useUrlSync` is a complete no-op
- Wrapped the return value of `useSearchControlsHandlers` in `useMemo` to produce a stable object reference, preventing `contextValue` in `SearchProvider` from recomputing and cascading re-renders to all context consumers when handlers haven't changed
