### PR TITLE
UILD-798: Fix - Changes in profile settings are not applied immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change history for ui-linked-data
 
 ## 3.0.0 (IN PROGRESS)
+* Fix for the case when changes to profile settings are not applied immediately. Fixes [UILD-798].
+
+[UILD-798]:https://folio-org.atlassian.net/browse/UILD-798
 
 ## 2.0.0 (2026-04-17)
 * Remove unnecessary child subcomponents when copying a whole field when the record is loaded. Fixes [UILD-544].

--- a/src/common/hooks/useLoadProfileSettings.ts
+++ b/src/common/hooks/useLoadProfileSettings.ts
@@ -19,23 +19,23 @@ export const useLoadProfileSettings = () => {
     profile: Profile,
     resourceTypeURL?: string,
   ) => {
-    const queryKey = ['profileSettings', profileId];
-    const queryFn = async () => {
-      if (profileId === undefined) {
-        return DEFAULT_INACTIVE_SETTINGS;
-      }
-      const settings = await fetchProfileSettings(profileId);
-      sortProfileSettingsChildren(settings);
-      return detectDrift(profile, settings, resourceTypeURL);
-    };
+    if (profileId === undefined) {
+      return DEFAULT_INACTIVE_SETTINGS;
+    }
 
     try {
       const settings = await queryClient.ensureQueryData({
-        queryKey,
-        queryFn,
+        queryKey: ['profileSettings', String(profileId)],
+        queryFn: async () => {
+          const loadedSettings = await fetchProfileSettings(profileId);
+          sortProfileSettingsChildren(loadedSettings);
+
+          return loadedSettings;
+        },
         staleTime: Infinity,
       });
-      return settings;
+
+      return detectDrift(profile, settings, resourceTypeURL);
     } catch (error) {
       logger.error('Error fetching profile settings:', error);
       addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, 'ld.cantLoadProfileSettings'));

--- a/src/features/manageProfileSettings/components/ProfileSettings/ProfileSettings.test.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettings/ProfileSettings.test.tsx
@@ -5,8 +5,9 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 
-import { fetchProfile, fetchProfileSettings } from '@/common/api/profiles.api';
+import { fetchProfile } from '@/common/api/profiles.api';
 import { StatusType } from '@/common/constants/status.constants';
+import { useLoadProfileSettings } from '@/common/hooks/useLoadProfileSettings';
 
 import { useLoadingState, useManageProfileSettingsState, useStatusStore } from '@/store';
 
@@ -17,10 +18,25 @@ jest.mock('@/common/api/profiles.api', () => ({
   fetchProfile: jest.fn(),
   fetchProfileSettings: jest.fn(),
 }));
+jest.mock('@/common/hooks/useLoadProfileSettings', () => ({
+  useLoadProfileSettings: jest.fn(),
+}));
+jest.mock('../CustomProfileToggle', () => ({
+  CustomProfileToggle: () => <div data-testid="custom-profile-toggle" />,
+}));
+jest.mock('../DefaultProfileOption', () => ({
+  DefaultProfileOption: () => <div data-testid="default-profile-option" />,
+}));
+jest.mock('../ProfileSettingsEditor', () => ({
+  ProfileSettingsEditor: () => <div data-testid="profile-settings-editor" />,
+}));
+
+const mockWorkResourceTypeUrl = 'mock-work-resource-type-url';
 
 describe('ProfileSettings', () => {
   const mockAddStatusMessagesItem = jest.fn();
   const mockSetIsLoading = jest.fn();
+  const mockLoadProfileSettings = jest.fn();
 
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -28,6 +44,19 @@ describe('ProfileSettings', () => {
         retry: false,
       },
     },
+  });
+
+  beforeEach(() => {
+    queryClient.clear();
+    (fetchProfile as jest.Mock).mockResolvedValue([]);
+    (useLoadProfileSettings as jest.Mock).mockReturnValue({
+      loadProfileSettings: mockLoadProfileSettings,
+    });
+    mockLoadProfileSettings.mockResolvedValue({
+      active: true,
+      children: [],
+      missingFromSettings: [],
+    });
   });
 
   const renderComponent = (selected: boolean) => {
@@ -39,7 +68,7 @@ describe('ProfileSettings', () => {
             ? {
                 id: 'one',
                 name: 'One',
-                resourceType: 'test-resource',
+                resourceType: mockWorkResourceTypeUrl,
               }
             : null,
         },
@@ -99,7 +128,7 @@ describe('ProfileSettings', () => {
   it('shows an error when loading profile settings fails', async () => {
     const error = new Error('Failed to load profile settings');
     (fetchProfile as jest.Mock).mockResolvedValue([]);
-    (fetchProfileSettings as jest.Mock).mockRejectedValue(error);
+    mockLoadProfileSettings.mockRejectedValue(error);
 
     renderComponent(true);
 
@@ -111,6 +140,17 @@ describe('ProfileSettings', () => {
         }),
       );
       expect(mockSetIsLoading).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('passes the selected profile resource type URI to load profile settings', async () => {
+    const profile = [] as Profile;
+    (fetchProfile as jest.Mock).mockResolvedValue(profile);
+
+    renderComponent(true);
+
+    await waitFor(() => {
+      expect(mockLoadProfileSettings).toHaveBeenCalledWith('one', profile, mockWorkResourceTypeUrl);
     });
   });
 });

--- a/src/features/manageProfileSettings/components/ProfileSettings/ProfileSettings.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettings/ProfileSettings.tsx
@@ -8,7 +8,7 @@ import { useLoadProfile } from '@/common/hooks/useLoadProfile';
 import { useLoadProfileSettings } from '@/common/hooks/useLoadProfileSettings';
 import { UserNotificationFactory } from '@/common/services/userNotification';
 import { Button, ButtonType } from '@/components/Button';
-import { getProfileLabelId, getResourceTypeFromURL, getUri } from '@/configs/resourceTypes';
+import { getProfileLabelId, getResourceTypeFromURL } from '@/configs/resourceTypes';
 
 import { useLoadingState, useManageProfileSettingsState, useStatusState, useUIState } from '@/store';
 
@@ -55,7 +55,7 @@ export const ProfileSettings = () => {
           const profile = await loadProfile(selectedProfile.id);
           setFullProfile(profile);
           setProfileSettings(
-            await loadProfileSettings(String(selectedProfile.id), profile, getUri(selectedProfile.resourceType)),
+            await loadProfileSettings(String(selectedProfile.id), profile, selectedProfile.resourceType),
           );
         } catch {
           addStatusMessagesItem?.(

--- a/src/test/__tests__/common/hooks/useLoadProfileSettings.test.tsx
+++ b/src/test/__tests__/common/hooks/useLoadProfileSettings.test.tsx
@@ -20,6 +20,9 @@ jest.mock('@/common/helpers/profileSettingsDrift.helper', () => ({
   detectDrift: jest.fn(),
 }));
 
+const mockInstanceResourceTypeUrl = 'mock-instance-resource-type-url';
+const mockWorkResourceTypeUrl = 'mock-work-resource-type-url';
+
 describe('useLoadProfileSettings', () => {
   const addStatusMessagesItem = jest.fn();
   let queryClient: QueryClient;
@@ -84,6 +87,37 @@ describe('useLoadProfileSettings', () => {
 
       expect(settings).toBe(newProfileSettingsWithDrift);
       expect(fetchProfileSettings).toHaveBeenCalledWith(1);
+    });
+
+    test('recomputes drift for each resource type while reusing cached settings', async () => {
+      const newProfileSettings = {
+        active: true,
+        children: [],
+      } as ProfileSettings;
+      const profile = [] as Profile;
+      const instanceSettings = {
+        ...newProfileSettings,
+        resourceTypeURL: mockInstanceResourceTypeUrl,
+        missingFromSettings: [],
+      } as ProfileSettingsWithDrift;
+      const workSettings = {
+        ...newProfileSettings,
+        resourceTypeURL: mockWorkResourceTypeUrl,
+        missingFromSettings: [],
+      } as ProfileSettingsWithDrift;
+
+      (fetchProfileSettings as jest.Mock).mockResolvedValue(newProfileSettings);
+      (detectDrift as jest.Mock).mockReturnValueOnce(instanceSettings).mockReturnValueOnce(workSettings);
+
+      const { result } = renderHook(useLoadProfileSettings, { wrapper: createWrapper() });
+      const first = await result.current.loadProfileSettings(1, profile, mockInstanceResourceTypeUrl);
+      const second = await result.current.loadProfileSettings(1, profile, mockWorkResourceTypeUrl);
+
+      expect(first).toBe(instanceSettings);
+      expect(second).toBe(workSettings);
+      expect(fetchProfileSettings).toHaveBeenCalledTimes(1);
+      expect(detectDrift).toHaveBeenNthCalledWith(1, profile, newProfileSettings, mockInstanceResourceTypeUrl);
+      expect(detectDrift).toHaveBeenNthCalledWith(2, profile, newProfileSettings, mockWorkResourceTypeUrl);
     });
 
     test('error in fetchProfileSettings returns default settings', async () => {


### PR DESCRIPTION
Fixed a regression where profile settings stopped hiding and ordering fields correctly on the Edit screen after the user opened Manage Profile Settings and then navigated back to Edit.

[https://folio-org.atlassian.net/browse/UILD-798](https://folio-org.atlassian.net/browse/UILD-798)

**Root cause:** `useLoadProfileSettings` cached a drifted `ProfileSettingsWithDrift` object by `profileId` only, even though the computed drift also depends on `resourceTypeURL`. Manage Profile Settings also passed `selectedProfile.resourceType` through `getUri()` even though it was already a BIBFRAME URI, which could produce the wrong resource type and store an invalid drifted result in the cache. When Edit later reused that cached settings object, the schema generator no longer matched the active block URI, so block child ordering and visibility rules were skipped.

**Fix:** updated `useLoadProfileSettings` to cache only the raw profile settings response and recompute drift for each caller using the current `resourceTypeURL`, and changed Manage Profile Settings to pass the selected profile’s resource type URI directly instead of re-normalizing it.
