### PR TITLE
UILD-805: Menu bar in search view hidden after saving profile settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## 3.0.0 (IN PROGRESS)
 * Fix Sonar issues. Refs [UILD-792].
+* Fix for hidden menu bar. Refs [UILD-805].
 
 [UILD-792]:https://folio-org.atlassian.net/browse/UILD-792
+[UILD-805]:https://folio-org.atlassian.net/browse/UILD-805
 
 ## 2.0.1 (2026-04-23)
 * Fix for the case when changes to profile settings are not applied immediately. Fixes [UILD-798].

--- a/src/App.scss
+++ b/src/App.scss
@@ -24,20 +24,6 @@ h6 {
   margin: 0;
 }
 
-#app-root {
-  display: flex;
-  flex-direction: column;
-}
-
-.main-content {
-  flex: 1;
-  overflow: auto;
-}
-
-.no-overflow {
-  overflow: hidden;
-}
-
 #editor-root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -52,6 +38,20 @@ h6 {
 
   #root {
     width: 100%;
+  }
+
+  #app-root {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .main-content {
+    flex: 1;
+    overflow: auto;
+  }
+
+  .no-overflow {
+    overflow: hidden;
   }
 
   h1 {

--- a/src/common/constants/routes.constants.ts
+++ b/src/common/constants/routes.constants.ts
@@ -48,7 +48,7 @@ export const RESOURCE_CREATE_URLS = [ROUTES.RESOURCE_CREATE.uri];
 
 export const MANAGE_PROFILE_SETTINGS_URLS = [ROUTES.MANAGE_PROFILE_SETTINGS.uri];
 
-export const FIXED_HEIGHT_VIEWS = [ROUTES.SEARCH.uri];
+export const FIXED_HEIGHT_VIEWS = [ROUTES.SEARCH.uri, ROUTES.MANAGE_PROFILE_SETTINGS.uri];
 
 export enum QueryParams {
   Type = 'type',

--- a/src/views/ManageProfileSettings/ManageProfileSettings.scss
+++ b/src/views/ManageProfileSettings/ManageProfileSettings.scss
@@ -2,6 +2,8 @@
 
 .manage-profile-settings {
   min-height: 100%;
+  height: 100%;
+  overflow-y: auto;
   display: flex;
   flex-direction: row;
   font-size: $font-md;


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-805

The issue is caused by having the view use a root parent with `main-content` class for scrolling. After scrolling within the view and returning to the search view, the scroll position stays the same, but the search view has `overflow: hidden`, so the menu bar at the top of the page is no longer in the viewport, and all scrolling is disabled, making it invisible and inaccessible. It can't be directly brought back into view by the user (unless they figure out how to focus one of its children).

The bugfix is to fix the manage profile settings view at 100% height and then scroll its own internal content node instead, as other views do.

A few more classes and IDs were brought in under `#editor-root` to prevent leaking.