### PR TITLE
UILD-806: Fix tooltip position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## 3.0.0 (IN PROGRESS)
 * Fix Sonar issues. Refs [UILD-792].
 * Fix for hidden menu bar. Refs [UILD-805].
+* Fix for tooltip position. Refs [UILD-806].
 
 [UILD-792]:https://folio-org.atlassian.net/browse/UILD-792
 [UILD-805]:https://folio-org.atlassian.net/browse/UILD-805
+[UILD-806]:https://folio-org.atlassian.net/browse/UILD-806
 
 ## 2.0.1 (2026-04-23)
 * Fix for the case when changes to profile settings are not applied immediately. Fixes [UILD-798].

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -14,6 +14,8 @@
     position: absolute;
     top: 100%;
     right: -6px;
+    left: auto;
+    margin: 0;
     margin-top: 2px;
     background-color: $base;
     border: 1px solid $modal-border-color;


### PR DESCRIPTION
Fix tooltip position by adjusting left alignment and margin properties

[https://folio-org.atlassian.net/browse/UILD-806](https://folio-org.atlassian.net/browse/UILD-806)

<img width="858" height="259" alt="image" src="https://github.com/user-attachments/assets/eabb16b0-030c-44b3-ab1c-e17b034c38d0" />
