### PR TITLE
UILD-807: Authority assignment removes data from Instance panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 * Fix Sonar issues. Refs [UILD-792].
 * Fix for hidden menu bar. Refs [UILD-805].
 * Fix for tooltip position. Refs [UILD-806].
+* Fix for blank preview in editor while searching for complex values. Refs [UILD-807].
 
 [UILD-792]:https://folio-org.atlassian.net/browse/UILD-792
 [UILD-805]:https://folio-org.atlassian.net/browse/UILD-805
 [UILD-806]:https://folio-org.atlassian.net/browse/UILD-806
+[UILD-807]:https://folio-org.atlassian.net/browse/UILD-807
 
 ## 2.0.1 (2026-04-23)
 * Fix for the case when changes to profile settings are not applied immediately. Fixes [UILD-798].

--- a/src/features/complexLookup/components/modals/AuthoritiesModal/AuthoritiesModal.tsx
+++ b/src/features/complexLookup/components/modals/AuthoritiesModal/AuthoritiesModal.tsx
@@ -81,6 +81,7 @@ export const AuthoritiesModal: FC<AuthoritiesModalProps> = ({
         flow="value"
         mode="custom"
         onSubmitCallback={handleCloseMarcPreview}
+        managePreview={false}
       >
         <Search.Controls>
           {/* Segment tabs - clicking triggers onSegmentChange, auto-resolves new config */}

--- a/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
+++ b/src/features/complexLookup/components/modals/HubsModal/HubsModal.tsx
@@ -47,6 +47,7 @@ export const HubsModal: FC<HubsModalProps> = ({ isOpen, onClose, assignedValue, 
         flow="value"
         mode="custom"
         onSubmitCallback={hubPreviewProps.handleCloseHubPreview}
+        managePreview={false}
       >
         <Search.Controls>
           <Search.Controls.InputsWrapper />

--- a/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
+++ b/src/features/complexLookup/components/modals/SubjectModal/SubjectModal.tsx
@@ -91,6 +91,7 @@ export const SubjectModal: FC<SubjectModalProps> = ({
           handleCloseMarcPreview();
           hubPreviewProps.handleCloseHubPreview();
         }}
+        managePreview={false}
       >
         <Search.Controls>
           <Search.Controls.SegmentGroup>

--- a/src/features/search/ui/hooks/useSearchControlsHandlers.test.ts
+++ b/src/features/search/ui/hooks/useSearchControlsHandlers.test.ts
@@ -189,6 +189,25 @@ describe('useSearchControlsHandlers', () => {
       expect(resetFullDisplayComponentType).toHaveBeenCalled();
       expect(resetCurrentlyPreviewedEntityBfid).toHaveBeenCalled();
     });
+
+    it('skips preview management while configured not to when changing segment', () => {
+      const { result } = renderHook(() =>
+        useSearchControlsHandlers({
+          coreConfig: mockConfig,
+          uiConfig: mockUIConfig,
+          flow: 'url',
+          managePreview: false,
+        }),
+      );
+
+      act(() => {
+        result.current.onSegmentChange('browse');
+      });
+
+      expect(resetPreviewContent).not.toHaveBeenCalled();
+      expect(resetFullDisplayComponentType).not.toHaveBeenCalled();
+      expect(resetCurrentlyPreviewedEntityBfid).not.toHaveBeenCalled();
+    });
   });
 
   describe('onSourceChange', () => {
@@ -441,6 +460,25 @@ describe('useSearchControlsHandlers', () => {
       expect(resetCurrentlyPreviewedEntityBfid).toHaveBeenCalled();
     });
 
+    it('skips preview management while configured not to on submit', () => {
+      const { result } = renderHook(() =>
+        useSearchControlsHandlers({
+          coreConfig: mockConfig,
+          uiConfig: mockUIConfig,
+          flow: 'url',
+          managePreview: false,
+        }),
+      );
+
+      act(() => {
+        result.current.onSubmit();
+      });
+
+      expect(resetPreviewContent).not.toHaveBeenCalled();
+      expect(resetFullDisplayComponentType).not.toHaveBeenCalled();
+      expect(resetCurrentlyPreviewedEntityBfid).not.toHaveBeenCalled();
+    });
+
     it('calls onSubmitCallback on submit when provided', () => {
       const mockOnSubmitCallback = jest.fn();
       const { result } = renderHook(() =>
@@ -549,6 +587,25 @@ describe('useSearchControlsHandlers', () => {
       expect(resetPreviewContent).toHaveBeenCalled();
       expect(resetFullDisplayComponentType).toHaveBeenCalled();
       expect(resetCurrentlyPreviewedEntityBfid).toHaveBeenCalled();
+    });
+
+    it('skips preview management while configured not to on reset', () => {
+      const { result } = renderHook(() =>
+        useSearchControlsHandlers({
+          coreConfig: mockConfig,
+          uiConfig: mockUIConfig,
+          flow: 'url',
+          managePreview: false,
+        }),
+      );
+
+      act(() => {
+        result.current.onReset();
+      });
+
+      expect(resetPreviewContent).not.toHaveBeenCalled();
+      expect(resetFullDisplayComponentType).not.toHaveBeenCalled();
+      expect(resetCurrentlyPreviewedEntityBfid).not.toHaveBeenCalled();
     });
 
     it('sets default source in navigation state when segment has a default source', () => {

--- a/src/features/search/ui/hooks/useSearchControlsHandlers.ts
+++ b/src/features/search/ui/hooks/useSearchControlsHandlers.ts
@@ -31,6 +31,7 @@ interface UseSearchControlsHandlersParams {
   };
   refetch?: () => Promise<void>;
   onSubmitCallback?: () => void;
+  managePreview?: boolean;
 }
 
 interface SearchControlsHandlers {
@@ -115,6 +116,7 @@ export const useSearchControlsHandlers = ({
   results,
   refetch,
   onSubmitCallback,
+  managePreview = true,
 }: UseSearchControlsHandlersParams): SearchControlsHandlers => {
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -222,9 +224,7 @@ export const useSearchControlsHandlers = ({
       saveCurrentDraft();
 
       // Reset preview
-      resetPreviewContent();
-      resetFullDisplayComponentType();
-      resetCurrentlyPreviewedEntityBfid();
+      resetPreview();
 
       // Resolve configs for the new segment using centralized resolvers
       const newSegmentConfig = resolveCoreConfig(newSegment);
@@ -313,9 +313,11 @@ export const useSearchControlsHandlers = ({
   );
 
   const resetPreview = () => {
-    resetPreviewContent();
-    resetFullDisplayComponentType();
-    resetCurrentlyPreviewedEntityBfid();
+    if (managePreview) {
+      resetPreviewContent();
+      resetFullDisplayComponentType();
+      resetCurrentlyPreviewedEntityBfid();
+    }
   };
 
   const handleSubmit = useCallback(() => {

--- a/src/features/search/ui/providers/SearchProvider.tsx
+++ b/src/features/search/ui/providers/SearchProvider.tsx
@@ -16,7 +16,7 @@ function isDynamicMode(props: SearchProviderProps): props is SearchProviderProps
 }
 
 export const SearchProvider: FC<SearchProviderProps> = props => {
-  const { flow, mode = 'custom', children, onSubmitCallback } = props;
+  const { flow, mode = 'custom', children, onSubmitCallback, managePreview } = props;
   const { isLoading: isGlobalLoading } = useLoadingState(['isLoading']);
 
   // Extract dynamic/static mode params
@@ -73,6 +73,7 @@ export const SearchProvider: FC<SearchProviderProps> = props => {
     results,
     refetch,
     onSubmitCallback,
+    managePreview,
   });
 
   // Sync URL to store (URL flow only)

--- a/src/features/search/ui/types/provider.types.ts
+++ b/src/features/search/ui/types/provider.types.ts
@@ -104,6 +104,7 @@ interface BaseProviderProps {
   mode?: RenderMode;
   children: React.ReactNode;
   onSubmitCallback?: () => void;
+  managePreview?: boolean;
 }
 
 export type SearchProviderProps = BaseProviderProps & (StaticModeProps | DynamicModeProps);


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-807

Adds a property to determine whether this Search should manage the view's preview screen, defaulting to true. For complex searches, like creator, subject, hub, etc., the preview section of the view is not related and should not be managed by Search.