### PR TITLE
UILD-812: Fix Reset button functionality for Advanced search scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change history for ui-linked-data
 
 ## 3.0.0 (IN PROGRESS)
+* Fix Reset search option is missing after using Advanced Search. Fixes [UILD-812].
+
+[UILD-792]:https://folio-org.atlassian.net/browse/UILD-812
 
 ## 2.0.2 (2026-05-07)
 * Fix Sonar issues. Refs [UILD-792].

--- a/src/features/search/ui/components/SearchControls/ResetButton.test.tsx
+++ b/src/features/search/ui/components/SearchControls/ResetButton.test.tsx
@@ -1,5 +1,7 @@
 import { setInitialGlobalState } from '@/test/__mocks__/store';
 
+import { MemoryRouter } from 'react-router-dom';
+
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { useSearchStore } from '@/store';
@@ -30,7 +32,11 @@ describe('ResetButton', () => {
       },
     ]);
 
-    render(<ResetButton />);
+    render(
+      <MemoryRouter>
+        <ResetButton />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByTestId('id-search-reset-button')).toBeInTheDocument();
     expect(screen.getByText('ld.reset')).toBeInTheDocument();
@@ -46,7 +52,11 @@ describe('ResetButton', () => {
       },
     ]);
 
-    render(<ResetButton />);
+    render(
+      <MemoryRouter>
+        <ResetButton />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByTestId('x-in-circle-icon')).toBeInTheDocument();
   });
@@ -61,7 +71,11 @@ describe('ResetButton', () => {
       },
     ]);
 
-    render(<ResetButton />);
+    render(
+      <MemoryRouter>
+        <ResetButton />
+      </MemoryRouter>,
+    );
 
     const button = screen.getByTestId('id-search-reset-button');
     expect(button).not.toBeDisabled();
@@ -77,7 +91,51 @@ describe('ResetButton', () => {
       },
     ]);
 
-    render(<ResetButton />);
+    render(
+      <MemoryRouter>
+        <ResetButton />
+      </MemoryRouter>,
+    );
+
+    const button = screen.getByTestId('id-search-reset-button');
+    expect(button).toBeDisabled();
+  });
+
+  test('button is enabled when advanced search is active', () => {
+    setInitialGlobalState([
+      {
+        store: useSearchStore,
+        state: {
+          query: '',
+        },
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={['/?query=title+adj+value']}>
+        <ResetButton />
+      </MemoryRouter>,
+    );
+
+    const button = screen.getByTestId('id-search-reset-button');
+    expect(button).not.toBeDisabled();
+  });
+
+  test('button is disabled when query is empty and no advanced search is active', () => {
+    setInitialGlobalState([
+      {
+        store: useSearchStore,
+        state: {
+          query: '',
+        },
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={['/?query=some+query&searchBy=title']}>
+        <ResetButton />
+      </MemoryRouter>,
+    );
 
     const button = screen.getByTestId('id-search-reset-button');
     expect(button).toBeDisabled();
@@ -93,7 +151,11 @@ describe('ResetButton', () => {
       },
     ]);
 
-    render(<ResetButton />);
+    render(
+      <MemoryRouter>
+        <ResetButton />
+      </MemoryRouter>,
+    );
 
     const button = screen.getByTestId('id-search-reset-button');
     fireEvent.click(button);
@@ -111,7 +173,11 @@ describe('ResetButton', () => {
       },
     ]);
 
-    render(<ResetButton />);
+    render(
+      <MemoryRouter>
+        <ResetButton />
+      </MemoryRouter>,
+    );
 
     const button = screen.getByTestId('id-search-reset-button');
     fireEvent.click(button);
@@ -129,7 +195,11 @@ describe('ResetButton', () => {
       },
     ]);
 
-    render(<ResetButton />);
+    render(
+      <MemoryRouter>
+        <ResetButton />
+      </MemoryRouter>,
+    );
 
     const button = screen.getByTestId('id-search-reset-button');
     expect(button).toHaveClass('search-button');
@@ -145,7 +215,11 @@ describe('ResetButton', () => {
       },
     ]);
 
-    render(<ResetButton />);
+    render(
+      <MemoryRouter>
+        <ResetButton />
+      </MemoryRouter>,
+    );
 
     const button = screen.getByTestId('id-search-reset-button');
     expect(button).toHaveAttribute('aria-label');

--- a/src/features/search/ui/components/SearchControls/ResetButton.tsx
+++ b/src/features/search/ui/components/SearchControls/ResetButton.tsx
@@ -1,7 +1,10 @@
 import { FC } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useSearchParams } from 'react-router-dom';
 
 import { Button, ButtonType } from '@/components/Button';
+
+import { SearchParam } from '@/features/search/core';
 
 import { useSearchState } from '@/store';
 
@@ -11,10 +14,12 @@ import { useSearchContext } from '../../providers/SearchProvider';
 
 export const ResetButton: FC = () => {
   const { formatMessage } = useIntl();
+  const [searchParams] = useSearchParams();
   const { onReset } = useSearchContext();
   const { query } = useSearchState(['query']);
 
-  const isDisabled = !query;
+  const isAdvancedSearch = !!searchParams.get(SearchParam.QUERY) && !searchParams.get(SearchParam.SEARCH_BY);
+  const isDisabled = !query && !isAdvancedSearch;
 
   return (
     <Button


### PR DESCRIPTION
Fixes the Reset button being incorrectly disabled after the Advanced search is submitted.

When Advanced search runs, the store `query` is intentionally cleared (the CQL query is not synced back to the store), leaving the Reset button disabled even though active search results are displayed. The button now also checks the URL for an active Advanced search state.

[https://folio-org.atlassian.net/browse/UILD-812](https://folio-org.atlassian.net/browse/UILD-812)