### PR TITLE
UILD-744: Refactor record control hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change history for ui-linked-data
 
 ## 3.0.0 (IN PROGRESS)
+* Refactor record control hooks. Refs [UILD-744].
+
+[UILD-744]:https://folio-org.atlassian.net/browse/UILD-744
 
 ## 2.0.3 (2026-05-19)
 * Fix Reset search option is missing after using Advanced Search. Fixes [UILD-812].

--- a/src/common/hooks/useConfig.hook.ts
+++ b/src/common/hooks/useConfig.hook.ts
@@ -3,15 +3,14 @@ import { useSearchParams } from 'react-router-dom';
 
 import { v4 as uuidv4 } from 'uuid';
 
-import { BibframeEntitiesMap } from '@/common/constants/bibframe.constants';
 import { QueryParams } from '@/common/constants/routes.constants';
 import { getProfileConfig } from '@/common/helpers/profile.helper';
 import { getEditingRecordBlocks, getPrimaryEntitiesFromRecord, getRecordTitle } from '@/common/helpers/record.helper';
 import { getReferenceIdsRaw } from '@/common/helpers/recordFormatting.helper';
-import { getUri, mapToResourceType } from '@/configs/resourceTypes';
+import { getUri } from '@/configs/resourceTypes';
 
 import { useLoadProfile, useLoadProfileSettings } from '@/features/profiles';
-import { useProcessedRecordAndSchema } from '@/features/resources';
+import { extractProfileParams, useProcessedRecordAndSchema } from '@/features/resources';
 
 import { useInputsState, useProfileState } from '@/store';
 
@@ -39,13 +38,6 @@ type IGetProfiles = {
     ids: number[];
     rootEntry?: ProfileNode;
   };
-};
-
-type IExtractProfileParams = {
-  recordData: RecordData;
-  profileIdParam: string | null;
-  typeParam: string | null;
-  editingRecordBlocks?: SelectedRecordBlocks;
 };
 
 type IBuildSchema = {
@@ -94,7 +86,7 @@ export const useConfig = () => {
     userValuesService.set(userValues);
     selectedEntriesService.set([]);
 
-    schemaGeneratorService.init(profile as unknown as Profile, settings);
+    schemaGeneratorService.init(profile, settings);
     schemaGeneratorService.generate(initKey);
 
     const { updatedSchema, updatedUserValues, selectedRecordBlocks } = await getProcessedRecordAndSchema({
@@ -119,38 +111,6 @@ export const useConfig = () => {
       initKey,
       updatedUserValues: updatedUserValues ?? userValues,
       selectedEntries: selectedEntriesService.get(),
-    };
-  };
-
-  const extractProfileParams = ({
-    recordData,
-    profileIdParam,
-    typeParam,
-    editingRecordBlocks,
-  }: IExtractProfileParams) => {
-    if (recordData && Object.keys(recordData).length) {
-      const block = editingRecordBlocks?.block as keyof typeof BibframeEntitiesMap;
-      const reference = editingRecordBlocks?.reference?.key;
-      const recordProfileId = recordData[block]?.profileId as string | number | null | undefined;
-
-      // Use record's profileId if present;
-      // only fall back to URL param if there is no profileId (valid for the Create resource page)
-      const profileId = recordProfileId ?? profileIdParam;
-      const referenceProfileId = (recordData[block]?.[reference as string] as unknown as RecursiveRecordSchema[])?.[0]
-        ?.profileId as string;
-      const resourceTypeValue = BibframeEntitiesMap[block];
-      const mappedResourceType = mapToResourceType(resourceTypeValue);
-
-      return {
-        profileId,
-        referenceProfileId,
-        resourceType: mappedResourceType,
-      };
-    }
-
-    return {
-      profileId: profileIdParam,
-      resourceType: mapToResourceType(typeParam),
     };
   };
 

--- a/src/common/hooks/useRecordControls.ts
+++ b/src/common/hooks/useRecordControls.ts
@@ -1,39 +1,17 @@
-import { flushSync } from 'react-dom';
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { ExternalResourceIdType } from '@/common/constants/api.constants';
 import { BibframeEntities } from '@/common/constants/bibframe.constants';
 import { BLOCKS_BFLITE } from '@/common/constants/bibframeMapping.constants';
-import { RecordStatus, ResourceType } from '@/common/constants/record.constants';
-import { QueryParams, ROUTES, SearchQueryParams } from '@/common/constants/routes.constants';
+import { QueryParams, ROUTES } from '@/common/constants/routes.constants';
 import { StatusType } from '@/common/constants/status.constants';
-import { getFriendlyErrorMessage } from '@/common/helpers/api.helper';
-import { generateEditResourceUrl } from '@/common/helpers/navigation.helper';
-import { getPrimaryEntitiesFromRecord, getRecordId, getSelectedRecordBlocks } from '@/common/helpers/record.helper';
+import { getPrimaryEntitiesFromRecord } from '@/common/helpers/record.helper';
 import { PreviewParams, useConfig } from '@/common/hooks/useConfig.hook';
 import { UserNotificationFactory } from '@/common/services/userNotification';
-import { getSearchSegment, mapToResourceType } from '@/configs/resourceTypes';
 
-import {
-  deleteRecord as deleteRecordRequest,
-  getGraphIdByExternalId,
-  getRecord,
-  postRecord,
-  putRecord,
-  useRecordGeneration,
-} from '@/features/resources';
+import { getRecord } from '@/features/resources';
 
-import { useInputsState, useLoadingState, useProfileState, useStatusState, useUIState } from '@/store';
-
-import { useBackToSearchUri } from './useBackToSearchUri';
-import { useContainerEvents } from './useContainerEvents';
-
-type SaveRecordProps = {
-  asRefToNewRecord?: boolean;
-  shouldSetSearchParams?: boolean;
-  isNavigatingBack?: boolean;
-  profileId?: string;
-};
+import { useInputsState, useLoadingState, useStatusState, useUIState } from '@/store';
 
 type IBaseFetchRecord = {
   recordId?: string;
@@ -45,58 +23,51 @@ type IBaseFetchRecord = {
   skipProfileProcessing?: boolean;
 };
 
-type HandleRecordUpdateProps = {
-  generatedRecord?: RecordEntry;
-  recordId: string;
-  updatedSelectedRecordBlocks: SelectedRecordBlocks;
-  isNavigatingBack?: boolean;
-  asRefToNewRecord?: boolean;
-  shouldSetSearchParams?: boolean;
-  isProfileChange?: boolean;
-};
-
 export const useRecordControls = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const { setIsLoading } = useLoadingState(['setIsLoading']);
-  const { resetUserValues, selectedRecordBlocks, setSelectedRecordBlocks, record, setRecord } = useInputsState([
-    'resetUserValues',
-    'selectedRecordBlocks',
-    'setSelectedRecordBlocks',
-    'record',
-    'setRecord',
-  ]);
-  const { setSelectedProfile } = useProfileState(['setSelectedProfile']);
+  const [queryParams] = useSearchParams();
+  const { setRecord } = useInputsState(['setRecord']);
   const { setCurrentlyEditedEntityBfid, setCurrentlyPreviewedEntityBfid } = useUIState([
     'setCurrentlyEditedEntityBfid',
     'setCurrentlyPreviewedEntityBfid',
   ]);
-  const {
-    setRecordStatus,
-    setLastSavedRecordId,
-    setIsRecordEdited: setIsEdited,
-    addStatusMessagesItem,
-  } = useStatusState(['setRecordStatus', 'setLastSavedRecordId', 'setIsRecordEdited', 'addStatusMessagesItem']);
-  const currentRecordId = getRecordId(record);
+  const { setIsRecordEdited: setIsEdited, addStatusMessagesItem } = useStatusState([
+    'setIsRecordEdited',
+    'addStatusMessagesItem',
+  ]);
   const { getProfiles } = useConfig();
   const navigate = useNavigate();
-  const location = useLocation();
-  const searchResultsUri = useBackToSearchUri();
-  const { dispatchUnblockEvent, dispatchNavigateToOriginEventWithFallback } = useContainerEvents();
-  const [queryParams] = useSearchParams();
+  const { setIsLoading } = useLoadingState(['setIsLoading']);
   const isClone = queryParams.get(QueryParams.CloneOf);
-  const { generateRecord } = useRecordGeneration();
 
-  const ensureSegmentInUri = (uri: string) => {
-    if (uri.includes(`${SearchQueryParams.Segment}=`)) {
-      return uri;
+  const getRecordAndInitializeParsing = async ({
+    recordId,
+    cachedRecord,
+    idType,
+    previewParams,
+    errorMessage,
+    signal,
+    skipProfileProcessing = false,
+  }: IBaseFetchRecord) => {
+    if (!recordId && !cachedRecord) return;
+
+    try {
+      const recordData: RecordEntry = cachedRecord ?? (recordId && (await getRecord({ recordId, idType, signal })));
+
+      if (!skipProfileProcessing) {
+        await getProfiles({
+          record: recordData,
+          recordId,
+          previewParams,
+        });
+      }
+
+      return recordData;
+    } catch (err) {
+      console.error('Error initializing record parsing:', err);
+      addStatusMessagesItem?.(
+        UserNotificationFactory.createMessage(StatusType.error, errorMessage ?? 'ld.errorFetching'),
+      );
     }
-
-    const typeParam = searchParams.get(QueryParams.Type);
-    const resourceType = mapToResourceType(typeParam);
-    const segment = getSearchSegment(resourceType);
-    const separator = uri.includes('?') ? '&' : '?';
-
-    return `${uri}${separator}${SearchQueryParams.Segment}=${segment}`;
   };
 
   const fetchRecord = async (recordId: string, previewParams?: PreviewParams, signal?: AbortSignal) => {
@@ -121,175 +92,18 @@ export const useRecordControls = () => {
     setIsEdited(false);
   };
 
-  // Helper functions to reduce cognitive complexity in handleRecordUpdate
-  const saveRecordToApi = async (recordId: string, generatedRecord: RecordEntry) => {
-    const shouldPostRecord = !recordId || isClone;
-
-    return shouldPostRecord ? await postRecord(generatedRecord) : await putRecord(recordId, generatedRecord);
-  };
-
-  const updateStateAfterSave = (parsedResponse: RecordEntry, asRefToNewRecord: boolean, recordId: string) => {
-    dispatchUnblockEvent();
-
-    if (!asRefToNewRecord) {
-      setRecord(parsedResponse);
-    }
-
-    // Show success message
-    addStatusMessagesItem?.(
-      UserNotificationFactory.createMessage(StatusType.success, recordId ? 'ld.rdUpdateSuccess' : 'ld.rdSaveSuccess'),
-    );
-
-    // isEdited state update is not immediately reflected in the <Prompt />
-    // blocker component, forcing <Prompt /> to block the navigation call below
-    // right before isEdited is set to false, disabling <Prompt />
-    flushSync(() => setIsEdited(false));
-  };
-
-  const handleProfileOrNoNavigationChange = async (
-    updatedRecordId: string,
-    parsedResponse: RecordEntry,
-    isProfileChange: boolean,
-  ) => {
-    navigate(generateEditResourceUrl(updatedRecordId), {
-      replace: true,
-      state: { ...(location.state as NavigationState), preserveStatusMessages: true },
-    });
-
-    if (isProfileChange) {
-      await getProfiles({
-        record: parsedResponse,
-      });
-    } else {
-      setRecordStatus({ type: RecordStatus.saveAndKeepEditing });
-    }
-
-    return updatedRecordId;
-  };
-
-  const handleBackNavigation = (
-    updatedRecordId: string,
-    parsedResponse: RecordEntry,
-    asRefToNewRecord: boolean,
-    shouldSetSearchParams: boolean,
-  ) => {
-    setRecordStatus({ type: RecordStatus.saveAndClose });
-
-    if (asRefToNewRecord) {
-      const blocksBfliteKey = (
-        searchParams.get(QueryParams.Type) ?? ResourceType.instance
-      )?.toUpperCase() as BibframeEntities;
-
-      const blockConfig = BLOCKS_BFLITE[blocksBfliteKey];
-      const selectedBlock = blockConfig?.uri;
-
-      // Only set search params if this resource type has a reference (e.g., Work/Instance)
-      if (shouldSetSearchParams && blockConfig?.reference) {
-        setSearchParams({
-          type: blockConfig.reference.name,
-          ref: String(getRecordId(parsedResponse, selectedBlock)),
-        });
-      }
-
-      return updatedRecordId;
-    } else {
-      navigate(ensureSegmentInUri(searchResultsUri), {
-        state: { preserveStatusMessages: true } satisfies NavigationState,
-      });
-    }
-
-    return updatedRecordId;
-  };
-
-  const handleRecordUpdate = async ({
-    generatedRecord,
-    recordId,
-    updatedSelectedRecordBlocks,
-    isNavigatingBack = true,
-    asRefToNewRecord = false,
-    shouldSetSearchParams = true,
-    isProfileChange = false,
-  }: HandleRecordUpdateProps) => {
-    if (!generatedRecord) return;
+  const fetchExternalRecordForPreview = async (recordId?: string, idType = ExternalResourceIdType.Inventory) => {
+    if (!recordId) return;
 
     setIsLoading(true);
 
-    try {
-      const response = await saveRecordToApi(recordId, generatedRecord);
-      const parsedResponse = await response.json();
-
-      updateStateAfterSave(parsedResponse, asRefToNewRecord, recordId);
-
-      const updatedRecordId = getRecordId(parsedResponse, updatedSelectedRecordBlocks?.block);
-      setLastSavedRecordId(updatedRecordId);
-
-      // Handle different navigation scenarios
-      if (isProfileChange || !isNavigatingBack) {
-        return await handleProfileOrNoNavigationChange(updatedRecordId, parsedResponse, isProfileChange);
-      }
-
-      if (isNavigatingBack) {
-        return handleBackNavigation(updatedRecordId, parsedResponse, asRefToNewRecord, shouldSetSearchParams);
-      }
-
-      return updatedRecordId;
-    } catch (error) {
-      console.error('Cannot update the resource description', error);
-      addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, getFriendlyErrorMessage(error)));
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const saveRecord = async ({
-    asRefToNewRecord = false,
-    isNavigatingBack = true,
-    shouldSetSearchParams = true,
-    profileId,
-  }: SaveRecordProps = {}) => {
-    const generatedRecord = generateRecord({ profileId });
-    const updatedSelectedRecordBlocks = selectedRecordBlocks || getSelectedRecordBlocks(searchParams);
-    const recordId = getRecordId(record, updatedSelectedRecordBlocks?.block);
-
-    return await handleRecordUpdate({
-      generatedRecord,
+    await getRecordAndInitializeParsing({
       recordId,
-      updatedSelectedRecordBlocks,
-      isNavigatingBack,
-      asRefToNewRecord,
-      shouldSetSearchParams,
+      idType,
+      errorMessage: 'ld.errorFetchingExternalResourceForPreview',
     });
-  };
 
-  const clearRecordState = () => {
-    resetUserValues();
-    setRecord(null);
-    setSelectedRecordBlocks(undefined);
-    setSelectedProfile(null);
-    setRecordStatus({ type: RecordStatus.close });
-    dispatchUnblockEvent();
-  };
-
-  const discardRecord = (clearState = true) => {
-    if (clearState) clearRecordState();
-
-    dispatchNavigateToOriginEventWithFallback(ensureSegmentInUri(searchResultsUri));
-  };
-
-  const deleteRecord = async () => {
-    try {
-      if (!currentRecordId) return;
-
-      await deleteRecordRequest(currentRecordId as unknown as string);
-      discardRecord();
-      addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.success, 'ld.rdDeleted'));
-
-      navigate(ROUTES.SEARCH.uri);
-    } catch (error) {
-      console.error('Cannot delete the resource description', error);
-
-      addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, 'ld.cantDeleteRd'));
-    }
+    setIsLoading(false);
   };
 
   const fetchRecordAndSelectEntityValues = async (recordId: string, entityId: BibframeEntities) => {
@@ -332,93 +146,10 @@ export const useRecordControls = () => {
     }
   };
 
-  const getRecordAndInitializeParsing = async ({
-    recordId,
-    cachedRecord,
-    idType,
-    previewParams,
-    errorMessage,
-    signal,
-    skipProfileProcessing = false,
-  }: IBaseFetchRecord) => {
-    if (!recordId && !cachedRecord) return;
-
-    try {
-      const recordData: RecordEntry = cachedRecord ?? (recordId && (await getRecord({ recordId, idType, signal })));
-
-      if (!skipProfileProcessing) {
-        await getProfiles({
-          record: recordData,
-          recordId,
-          previewParams,
-        });
-      }
-
-      return recordData;
-    } catch (err) {
-      console.error('Error initializing record parsing:', err);
-      addStatusMessagesItem?.(
-        UserNotificationFactory.createMessage(StatusType.error, errorMessage ?? 'ld.errorFetching'),
-      );
-    }
-  };
-
-  const fetchExternalRecordForPreview = async (recordId?: string, idType = ExternalResourceIdType.Inventory) => {
-    if (!recordId) return;
-
-    setIsLoading(true);
-
-    await getRecordAndInitializeParsing({
-      recordId,
-      idType,
-      errorMessage: 'ld.errorFetchingExternalResourceForPreview',
-    });
-
-    setIsLoading(false);
-  };
-
-  const tryFetchExternalRecordForEdit = async (recordId?: string) => {
-    try {
-      if (!recordId) return;
-
-      setIsLoading(true);
-
-      const { id } = await getGraphIdByExternalId({ recordId });
-
-      if (id) {
-        navigate(generateEditResourceUrl(id), { replace: true });
-      }
-    } catch (err: unknown) {
-      addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, getFriendlyErrorMessage(err)));
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const changeRecordProfile = ({ profileId }: { profileId: string | number }) => {
-    const generatedRecord = generateRecord({ profileId: `${profileId}` });
-    const updatedSelectedRecordBlocks = selectedRecordBlocks || getSelectedRecordBlocks(searchParams);
-    const recordId = getRecordId(record, updatedSelectedRecordBlocks?.block);
-
-    return handleRecordUpdate({
-      generatedRecord,
-      recordId,
-      updatedSelectedRecordBlocks,
-      isNavigatingBack: false,
-      isProfileChange: true,
-    });
-  };
-
   return {
     fetchRecord,
-    saveRecord,
-    deleteRecord,
-    discardRecord,
-    clearRecordState,
-    fetchRecordAndSelectEntityValues,
-    fetchExternalRecordForPreview,
-    tryFetchExternalRecordForEdit,
     getRecordAndInitializeParsing,
-    changeRecordProfile,
+    fetchExternalRecordForPreview,
+    fetchRecordAndSelectEntityValues,
   };
 };

--- a/src/features/edit/components/CloseRecord/CloseRecord.test.tsx
+++ b/src/features/edit/components/CloseRecord/CloseRecord.test.tsx
@@ -1,5 +1,5 @@
-import { discardRecord } from '@/test/__mocks__/common/hooks/useRecordControls.mock';
 import '@/test/__mocks__/components/Modal.mock';
+import { discardRecord } from '@/test/__mocks__/features/resources/hooks/useRecordNavigation.mock';
 
 import { fireEvent, render, screen } from '@testing-library/react';
 

--- a/src/features/edit/components/CloseRecord/CloseRecord.tsx
+++ b/src/features/edit/components/CloseRecord/CloseRecord.tsx
@@ -1,11 +1,12 @@
 import { FC, memo } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { useRecordControls } from '@/common/hooks/useRecordControls';
 import { Button, ButtonType } from '@/components/Button';
 
+import { useRecordNavigation } from '@/features/resources';
+
 const CloseRecord: FC = () => {
-  const { discardRecord } = useRecordControls();
+  const { discardRecord } = useRecordNavigation();
 
   return (
     <Button data-testid="close-record-button" type={ButtonType.Primary} onClick={() => discardRecord(false)}>

--- a/src/features/edit/components/DeleteRecord/DeleteRecord.test.tsx
+++ b/src/features/edit/components/DeleteRecord/DeleteRecord.test.tsx
@@ -1,8 +1,8 @@
 import { checkButtonDisabledState } from '@/test/__mocks__/common/helpers/recordControls.helper.mock';
 import { openModal } from '@/test/__mocks__/common/hooks/useModalControls.mock';
-import '@/test/__mocks__/common/hooks/useRecordControls.mock';
 import '@/test/__mocks__/common/hooks/useRoutePathPattern.mock';
 import '@/test/__mocks__/components/Modal.mock';
+import '@/test/__mocks__/features/resources/hooks/useRecordMutations.mock';
 import { setInitialGlobalState } from '@/test/__mocks__/store';
 
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/src/features/edit/components/DeleteRecord/DeleteRecord.tsx
+++ b/src/features/edit/components/DeleteRecord/DeleteRecord.tsx
@@ -4,9 +4,10 @@ import { FormattedMessage } from 'react-intl';
 import { RESOURCE_URLS } from '@/common/constants/routes.constants';
 import { checkButtonDisabledState } from '@/common/helpers/recordControls.helper';
 import { useModalControls } from '@/common/hooks/useModalControls';
-import { useRecordControls } from '@/common/hooks/useRecordControls';
 import { useRoutePathPattern } from '@/common/hooks/useRoutePathPattern';
 import { Button, ButtonType } from '@/components/Button';
+
+import { useRecordMutations } from '@/features/resources';
 
 import { useInputsState, useStatusState } from '@/store';
 
@@ -17,7 +18,7 @@ const DeleteRecord: FC = () => {
   const { record } = useInputsState(['record']);
   const { isRecordEdited: isEdited } = useStatusState(['isRecordEdited']);
   const resourceRoutePattern = useRoutePathPattern(RESOURCE_URLS);
-  const { deleteRecord } = useRecordControls();
+  const { deleteRecord } = useRecordMutations();
   const { isModalOpen, setIsModalOpen, openModal } = useModalControls();
   const { hasBeenSaved } = useRecordStatus();
   const isDisabledForEditPage =

--- a/src/features/edit/components/SaveRecord/SaveRecord.test.tsx
+++ b/src/features/edit/components/SaveRecord/SaveRecord.test.tsx
@@ -1,4 +1,4 @@
-import { saveRecord } from '@/test/__mocks__/common/hooks/useRecordControls.mock';
+import { saveRecord } from '@/test/__mocks__/features/resources/hooks/useRecordMutations.mock';
 import { setInitialGlobalState } from '@/test/__mocks__/store';
 
 import { BrowserRouter } from 'react-router-dom';

--- a/src/features/edit/components/modals/Prompt/Prompt.tsx
+++ b/src/features/edit/components/modals/Prompt/Prompt.tsx
@@ -7,7 +7,8 @@ import { getForceNavigateToDest } from '@/common/helpers/navigation.helper';
 import { useContainerEvents } from '@/common/hooks/useContainerEvents';
 import { useModalControls } from '@/common/hooks/useModalControls';
 import { useNavigateToEditPage } from '@/common/hooks/useNavigateToEditPage';
-import { useRecordControls } from '@/common/hooks/useRecordControls';
+
+import { useRecordMutations } from '@/features/resources';
 
 import { useStatusState } from '@/store';
 
@@ -21,7 +22,7 @@ interface Props {
 }
 
 export const Prompt: FC<Props> = ({ when: shouldPrompt }) => {
-  const { saveRecord } = useRecordControls();
+  const { saveRecord } = useRecordMutations();
   const {
     isModalOpen: isCloseRecordModalOpen,
     setIsModalOpen: setIsCloseRecordModalOpen,

--- a/src/features/edit/hooks/useSaveRecord.test.ts
+++ b/src/features/edit/hooks/useSaveRecord.test.ts
@@ -16,8 +16,8 @@ jest.mock('react-router-dom', () => ({
   useSearchParams: jest.fn(),
 }));
 
-jest.mock('@/common/hooks/useRecordControls', () => ({
-  useRecordControls: () => ({
+jest.mock('@/features/resources', () => ({
+  useRecordMutations: () => ({
     saveRecord: mockSaveRecord,
   }),
 }));

--- a/src/features/edit/hooks/useSaveRecord.ts
+++ b/src/features/edit/hooks/useSaveRecord.ts
@@ -2,13 +2,14 @@ import { useSearchParams } from 'react-router-dom';
 
 import { QueryParams } from '@/common/constants/routes.constants';
 import { useModalControls } from '@/common/hooks/useModalControls';
-import { useRecordControls } from '@/common/hooks/useRecordControls';
+
+import { useRecordMutations } from '@/features/resources';
 
 import { useStatusState } from '@/store';
 
 export const useSaveRecord = (primary: boolean) => {
   const { isRecordEdited } = useStatusState(['isRecordEdited']);
-  const { saveRecord } = useRecordControls();
+  const { saveRecord } = useRecordMutations();
   const { isModalOpen, openModal, closeModal } = useModalControls();
   const [searchParams] = useSearchParams();
 

--- a/src/features/profiles/components/ProfileSelectionManager/ProfileSelectionManager.test.tsx
+++ b/src/features/profiles/components/ProfileSelectionManager/ProfileSelectionManager.test.tsx
@@ -20,8 +20,8 @@ jest.mock('@/common/hooks/useNavigateToEditPage', () => ({
     navigateToEditPage: mockNavigateToEditPage,
   }),
 }));
-jest.mock('@/common/hooks/useRecordControls', () => ({
-  useRecordControls: () => ({
+jest.mock('@/features/resources', () => ({
+  useRecordMutations: () => ({
     changeRecordProfile: mockChangeRecordProfile,
   }),
 }));

--- a/src/features/profiles/hooks/useProfileSelectionActions.test.ts
+++ b/src/features/profiles/hooks/useProfileSelectionActions.test.ts
@@ -8,8 +8,9 @@ import { StatusType } from '@/common/constants/status.constants';
 import { generatePageURL } from '@/common/helpers/navigation.helper';
 import { createUpdatedPreferredProfiles, getProfileNameById } from '@/common/helpers/profileActions.helper';
 import { useNavigateToEditPage } from '@/common/hooks/useNavigateToEditPage';
-import { useRecordControls } from '@/common/hooks/useRecordControls';
 import { UserNotificationFactory } from '@/common/services/userNotification';
+
+import { useRecordMutations } from '@/features/resources';
 
 import { useLoadingState, useNavigationState, useProfileState, useStatusState } from '@/store';
 
@@ -28,8 +29,8 @@ jest.mock('@/common/hooks/useNavigateToEditPage', () => ({
   useNavigateToEditPage: jest.fn(),
 }));
 
-jest.mock('@/common/hooks/useRecordControls', () => ({
-  useRecordControls: jest.fn(),
+jest.mock('@/features/resources', () => ({
+  useRecordMutations: jest.fn(),
 }));
 
 jest.mock('@/common/services/userNotification', () => ({
@@ -107,7 +108,7 @@ describe('useProfileSelectionActions', () => {
       navigateToEditPage: mockNavigateToEditPage,
     });
 
-    (useRecordControls as jest.Mock).mockReturnValue({
+    (useRecordMutations as jest.Mock).mockReturnValue({
       changeRecordProfile: mockChangeRecordProfile,
     });
 

--- a/src/features/profiles/hooks/useProfileSelectionActions.ts
+++ b/src/features/profiles/hooks/useProfileSelectionActions.ts
@@ -5,8 +5,9 @@ import { generatePageURL } from '@/common/helpers/navigation.helper';
 import { createUpdatedPreferredProfiles, getProfileNameById } from '@/common/helpers/profileActions.helper';
 import { isProfilePreferred } from '@/common/helpers/profileSelection.helper';
 import { useNavigateToEditPage } from '@/common/hooks/useNavigateToEditPage';
-import { useRecordControls } from '@/common/hooks/useRecordControls';
 import { UserNotificationFactory } from '@/common/services/userNotification';
+
+import { useRecordMutations } from '@/features/resources';
 
 import { useLoadingState, useNavigationState, useProfileState, useStatusState } from '@/store';
 
@@ -30,7 +31,7 @@ export const useProfileSelectionActions = ({
     'setPreferredProfiles',
   ]);
   const { navigateToEditPage } = useNavigateToEditPage();
-  const { changeRecordProfile } = useRecordControls();
+  const { changeRecordProfile } = useRecordMutations();
 
   const updatePreferredProfiles = (profileId: string | number) => {
     if (!resourceTypeURL) return;

--- a/src/features/resources/helpers/index.ts
+++ b/src/features/resources/helpers/index.ts
@@ -1,0 +1,1 @@
+export { extractProfileParams } from './resourceParams';

--- a/src/features/resources/helpers/resourceParams.ts
+++ b/src/features/resources/helpers/resourceParams.ts
@@ -1,0 +1,41 @@
+import { BibframeEntitiesMap } from '@/common/constants/bibframe.constants';
+import { mapToResourceType } from '@/configs/resourceTypes';
+
+type ExtractProfileParams = {
+  recordData: RecordData;
+  profileIdParam: string | null;
+  typeParam: string | null;
+  editingRecordBlocks?: SelectedRecordBlocks;
+};
+
+export const extractProfileParams = ({
+  recordData,
+  profileIdParam,
+  typeParam,
+  editingRecordBlocks,
+}: ExtractProfileParams) => {
+  if (recordData && Object.keys(recordData).length) {
+    const block = editingRecordBlocks?.block as keyof typeof BibframeEntitiesMap;
+    const reference = editingRecordBlocks?.reference?.key;
+    const recordProfileId = recordData[block]?.profileId as string | number | null | undefined;
+
+    // Use record's profileId if present;
+    // only fall back to URL param if there is no profileId (valid for the Create resource page)
+    const profileId = recordProfileId ?? profileIdParam;
+    const referenceProfileId = (recordData[block]?.[reference as string] as unknown as RecursiveRecordSchema[])?.[0]
+      ?.profileId as string;
+    const resourceTypeValue = BibframeEntitiesMap[block];
+    const mappedResourceType = mapToResourceType(resourceTypeValue);
+
+    return {
+      profileId,
+      referenceProfileId,
+      resourceType: mappedResourceType,
+    };
+  }
+
+  return {
+    profileId: profileIdParam,
+    resourceType: mapToResourceType(typeParam),
+  };
+};

--- a/src/features/resources/hooks/index.ts
+++ b/src/features/resources/hooks/index.ts
@@ -1,3 +1,5 @@
 export { useRecordGeneration } from './useRecordGeneration';
 export { useProcessedRecordAndSchema } from './useProcessedRecordAndSchema';
 export { useMarcData } from './useMarcData';
+export { useRecordMutations } from './useRecordMutations';
+export { useRecordNavigation } from './useRecordNavigation';

--- a/src/features/resources/hooks/useRecordMutations.test.ts
+++ b/src/features/resources/hooks/useRecordMutations.test.ts
@@ -11,7 +11,6 @@ import * as recordsApi from '@/features/resources';
 
 import { useInputsStore, useStatusStore } from '@/store';
 
-import { useRecordGeneration } from './useRecordGeneration';
 import { useRecordMutations } from './useRecordMutations';
 
 jest.mock('@/common/constants/build.constants', () => ({ IS_EMBEDDED_MODE: false }));
@@ -143,7 +142,7 @@ describe('useRecordMutations', () => {
     });
 
     it('does not save if generateRecord returns null', async () => {
-      jest.spyOn(useRecordGeneration(), 'generateRecord').mockReturnValue(undefined);
+      mockGenerateRecord.mockReturnValue(undefined);
 
       const { result } = renderHook(() => useRecordMutations());
       await result.current.saveRecord();

--- a/src/features/resources/hooks/useRecordMutations.test.ts
+++ b/src/features/resources/hooks/useRecordMutations.test.ts
@@ -1,0 +1,212 @@
+import { setInitialGlobalState } from '@/test/__mocks__/store';
+
+import { renderHook } from '@testing-library/react';
+
+import { RecordStatus } from '@/common/constants/record.constants';
+import { StatusType } from '@/common/constants/status.constants';
+import * as recordHelper from '@/common/helpers/record.helper';
+import { UserNotificationFactory } from '@/common/services/userNotification';
+
+import * as recordsApi from '@/features/resources';
+
+import { useInputsStore, useStatusStore } from '@/store';
+
+import { useRecordGeneration } from './useRecordGeneration';
+import { useRecordMutations } from './useRecordMutations';
+
+jest.mock('@/common/constants/build.constants', () => ({ IS_EMBEDDED_MODE: false }));
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ state: {} }),
+  useSearchParams: () => [new URLSearchParams('type=hub'), jest.fn()],
+}));
+
+const mockGenerateRecord = jest.fn();
+jest.mock('@/features/resources', () => ({
+  getRecord: jest.fn(),
+  postRecord: jest.fn(),
+  putRecord: jest.fn(),
+  deleteRecord: jest.fn(),
+  useRecordGeneration: () => ({
+    generateRecord: mockGenerateRecord,
+  }),
+}));
+
+const mockDiscardRecord = jest.fn();
+jest.mock('@/features/resources/hooks/useRecordNavigation', () => ({
+  useRecordNavigation: () => ({ discardRecord: mockDiscardRecord }),
+}));
+
+jest.mock('@/common/hooks/useContainerEvents', () => ({
+  useContainerEvents: () => ({
+    dispatchUnblockEvent: jest.fn(),
+    dispatchNavigateToOriginEventWithFallback: jest.fn(),
+  }),
+}));
+
+const mockGetProfiles = jest.fn();
+jest.mock('@/common/hooks/useConfig.hook', () => ({
+  useConfig: () => ({
+    getProfiles: mockGetProfiles,
+  }),
+}));
+
+jest.mock('@/common/services/userNotification', () => ({
+  UserNotificationFactory: {
+    createMessage: jest.fn(),
+  },
+}));
+
+describe('useRecordMutations', () => {
+  const mockSetRecordStatus = jest.fn();
+  const mockApiResponse = { id: 'test-id' };
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockReturnValue();
+  });
+
+  describe('saveRecord', () => {
+    beforeEach(() => {
+      setInitialGlobalState([
+        {
+          store: useStatusStore,
+          state: {
+            setRecordStatus: mockSetRecordStatus,
+          },
+        },
+        {
+          store: useInputsStore,
+          state: {
+            selectedRecordBlocks: null,
+            record: {},
+          },
+        },
+      ]);
+
+      mockGenerateRecord.mockReturnValue({});
+    });
+
+    it('saves record with default props', async () => {
+      const mockResponse = { json: () => Promise.resolve(mockApiResponse) };
+      (recordsApi.postRecord as jest.Mock).mockResolvedValue(mockResponse);
+
+      const { result } = renderHook(() => useRecordMutations());
+      await result.current.saveRecord();
+
+      expect(recordsApi.postRecord).toHaveBeenCalled();
+    });
+
+    it('handles save with asRefToNewRecord=true', async () => {
+      const mockResponse = { json: () => Promise.resolve(mockApiResponse) };
+      (recordsApi.postRecord as jest.Mock).mockResolvedValue(mockResponse);
+
+      const { result } = renderHook(() => useRecordMutations());
+      await result.current.saveRecord({ asRefToNewRecord: true });
+
+      expect(recordsApi.postRecord).toHaveBeenCalled();
+    });
+
+    it('handles save with isNavigatingBack=false', async () => {
+      const mockResponse = { json: () => Promise.resolve(mockApiResponse) };
+      (recordsApi.putRecord as jest.Mock).mockResolvedValue(mockResponse);
+
+      jest.spyOn(recordHelper, 'getRecordId').mockReturnValue('existing-id');
+
+      const { result } = renderHook(() => useRecordMutations());
+      await result.current.saveRecord({ isNavigatingBack: false });
+
+      expect(recordsApi.putRecord).toHaveBeenCalled();
+    });
+
+    it('handles save errors', async () => {
+      (recordsApi.postRecord as jest.Mock).mockRejectedValue(new Error('Save failed'));
+
+      const { result } = renderHook(() => useRecordMutations());
+      await result.current.saveRecord();
+
+      expect(UserNotificationFactory.createMessage).toHaveBeenCalledWith(StatusType.error, 'ld.cantSaveRd');
+    });
+
+    it('updates record status on successful save', async () => {
+      const mockResponse = { json: () => Promise.resolve(mockApiResponse) };
+      (recordsApi.postRecord as jest.Mock).mockResolvedValue(mockResponse);
+
+      const { result } = renderHook(() => useRecordMutations());
+      await result.current.saveRecord();
+
+      expect(mockSetRecordStatus).toHaveBeenCalledWith({
+        type: RecordStatus.saveAndClose,
+      });
+    });
+
+    it('does not save if generateRecord returns null', async () => {
+      jest.spyOn(useRecordGeneration(), 'generateRecord').mockReturnValue(undefined);
+
+      const { result } = renderHook(() => useRecordMutations());
+      await result.current.saveRecord();
+
+      expect(recordsApi.postRecord).not.toHaveBeenCalled();
+      expect(recordsApi.putRecord).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('changeRecordProfile', () => {
+    const mockSetRecord = jest.fn();
+    const mockSetIsEdited = jest.fn();
+    const mockSetLastSavedRecordId = jest.fn();
+    const mockSelectedRecordBlocks = { block: 'test-block' };
+    const mockRecord = { id: 'record-id', data: 'test data' };
+    const mockNewProfileId = '456';
+    const mockResponseData = { id: 'updated-record-id', data: 'updated data' };
+
+    beforeEach(() => {
+      setInitialGlobalState([
+        {
+          store: useStatusStore,
+          state: {
+            setIsRecordEdited: mockSetIsEdited,
+            setLastSavedRecordId: mockSetLastSavedRecordId,
+          },
+        },
+        {
+          store: useInputsStore,
+          state: {
+            record: mockRecord,
+            setRecord: mockSetRecord,
+            selectedRecordBlocks: mockSelectedRecordBlocks,
+          },
+        },
+      ]);
+
+      mockGenerateRecord.mockReturnValue({ generated: 'record' });
+      jest
+        .spyOn(recordHelper, 'getRecordId')
+        .mockReturnValueOnce('record-id')
+        .mockReturnValueOnce('record-id')
+        .mockReturnValueOnce('updated-record-id')
+        .mockReturnValueOnce('updated-record-id');
+    });
+
+    it('successfully changes record profile', async () => {
+      mockGenerateRecord.mockReturnValue(mockResponseData);
+
+      const { result } = renderHook(() => useRecordMutations());
+      await result.current.changeRecordProfile({ profileId: mockNewProfileId });
+
+      expect(mockGenerateRecord).toHaveBeenCalledWith({ profileId: mockNewProfileId });
+    });
+
+    it('does not proceed if generateRecord returns nothing', async () => {
+      mockGenerateRecord.mockReturnValue(undefined);
+
+      const { result } = renderHook(() => useRecordMutations());
+      await result.current.changeRecordProfile({ profileId: mockNewProfileId });
+
+      expect(recordsApi.putRecord).not.toHaveBeenCalled();
+      expect(mockSetRecord).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/features/resources/hooks/useRecordMutations.ts
+++ b/src/features/resources/hooks/useRecordMutations.ts
@@ -1,0 +1,245 @@
+import { flushSync } from 'react-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+
+import { BibframeEntities } from '@/common/constants/bibframe.constants';
+import { BLOCKS_BFLITE } from '@/common/constants/bibframeMapping.constants';
+import { RecordStatus, ResourceType } from '@/common/constants/record.constants';
+import { QueryParams, ROUTES, SearchQueryParams } from '@/common/constants/routes.constants';
+import { StatusType } from '@/common/constants/status.constants';
+import { getFriendlyErrorMessage } from '@/common/helpers/api.helper';
+import { generateEditResourceUrl } from '@/common/helpers/navigation.helper';
+import { getRecordId, getSelectedRecordBlocks } from '@/common/helpers/record.helper';
+import { useBackToSearchUri } from '@/common/hooks/useBackToSearchUri';
+import { useConfig } from '@/common/hooks/useConfig.hook';
+import { useContainerEvents } from '@/common/hooks/useContainerEvents';
+import { logger } from '@/common/services/logger';
+import { UserNotificationFactory } from '@/common/services/userNotification';
+import { getSearchSegment, mapToResourceType } from '@/configs/resourceTypes';
+
+import { deleteRecord as deleteRecordRequest, postRecord, putRecord, useRecordGeneration } from '@/features/resources';
+
+import { useInputsState, useLoadingState, useStatusState } from '@/store';
+
+import { useRecordNavigation } from './useRecordNavigation';
+
+type SaveRecordProps = {
+  asRefToNewRecord?: boolean;
+  shouldSetSearchParams?: boolean;
+  isNavigatingBack?: boolean;
+  profileId?: string;
+};
+
+type HandleRecordUpdateProps = {
+  generatedRecord?: RecordEntry;
+  recordId: string;
+  updatedSelectedRecordBlocks: SelectedRecordBlocks;
+  isNavigatingBack?: boolean;
+  asRefToNewRecord?: boolean;
+  shouldSetSearchParams?: boolean;
+  isProfileChange?: boolean;
+};
+
+export const useRecordMutations = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { setIsLoading } = useLoadingState(['setIsLoading']);
+  const { selectedRecordBlocks, record, setRecord } = useInputsState(['selectedRecordBlocks', 'record', 'setRecord']);
+  const {
+    setRecordStatus,
+    setLastSavedRecordId,
+    setIsRecordEdited: setIsEdited,
+    addStatusMessagesItem,
+  } = useStatusState(['setRecordStatus', 'setLastSavedRecordId', 'setIsRecordEdited', 'addStatusMessagesItem']);
+  const currentRecordId = getRecordId(record);
+  const { getProfiles } = useConfig(); // TEMPORARY — will be replaced after "useConfig" refactoring
+  const navigate = useNavigate();
+  const location = useLocation();
+  const searchResultsUri = useBackToSearchUri();
+  const { dispatchUnblockEvent } = useContainerEvents();
+  const [queryParams] = useSearchParams();
+  const isClone = queryParams.get(QueryParams.CloneOf);
+  const { generateRecord } = useRecordGeneration();
+  const { discardRecord } = useRecordNavigation();
+
+  const ensureSegmentInUri = (uri: string) => {
+    if (uri.includes(`${SearchQueryParams.Segment}=`)) {
+      return uri;
+    }
+
+    const typeParam = searchParams.get(QueryParams.Type);
+    const resourceType = mapToResourceType(typeParam);
+    const segment = getSearchSegment(resourceType);
+    const separator = uri.includes('?') ? '&' : '?';
+
+    return `${uri}${separator}${SearchQueryParams.Segment}=${segment}`;
+  };
+
+  const saveRecordToApi = async (recordId: string, generatedRecord: RecordEntry) => {
+    const shouldPostRecord = !recordId || isClone;
+
+    return shouldPostRecord ? await postRecord(generatedRecord) : await putRecord(recordId, generatedRecord);
+  };
+
+  const updateStateAfterSave = (parsedResponse: RecordEntry, asRefToNewRecord: boolean, recordId: string) => {
+    dispatchUnblockEvent();
+
+    if (!asRefToNewRecord) {
+      setRecord(parsedResponse);
+    }
+
+    // Show success message
+    addStatusMessagesItem?.(
+      UserNotificationFactory.createMessage(StatusType.success, recordId ? 'ld.rdUpdateSuccess' : 'ld.rdSaveSuccess'),
+    );
+
+    // isEdited state update is not immediately reflected in the <Prompt />
+    // blocker component, forcing <Prompt /> to block the navigation call below
+    // right before isEdited is set to false, disabling <Prompt />
+    flushSync(() => setIsEdited(false));
+  };
+
+  const handleProfileOrNoNavigationChange = async (
+    updatedRecordId: string,
+    parsedResponse: RecordEntry,
+    isProfileChange: boolean,
+  ) => {
+    navigate(generateEditResourceUrl(updatedRecordId), {
+      replace: true,
+      state: { ...(location.state as NavigationState), preserveStatusMessages: true },
+    });
+
+    if (isProfileChange) {
+      await getProfiles({
+        record: parsedResponse,
+      });
+    } else {
+      setRecordStatus({ type: RecordStatus.saveAndKeepEditing });
+    }
+
+    return updatedRecordId;
+  };
+
+  const handleBackNavigation = (
+    updatedRecordId: string,
+    parsedResponse: RecordEntry,
+    asRefToNewRecord: boolean,
+    shouldSetSearchParams: boolean,
+  ) => {
+    setRecordStatus({ type: RecordStatus.saveAndClose });
+
+    if (asRefToNewRecord) {
+      const blocksBfliteKey = (
+        searchParams.get(QueryParams.Type) ?? ResourceType.instance
+      )?.toUpperCase() as BibframeEntities;
+
+      const blockConfig = BLOCKS_BFLITE[blocksBfliteKey];
+      const selectedBlock = blockConfig?.uri;
+
+      // Only set search params if this resource type has a reference (e.g., Work/Instance)
+      if (shouldSetSearchParams && blockConfig?.reference) {
+        setSearchParams({
+          type: blockConfig.reference.name,
+          ref: String(getRecordId(parsedResponse, selectedBlock)),
+        });
+      }
+
+      return updatedRecordId;
+    } else {
+      navigate(ensureSegmentInUri(searchResultsUri), {
+        state: { preserveStatusMessages: true } satisfies NavigationState,
+      });
+    }
+
+    return updatedRecordId;
+  };
+
+  const handleRecordUpdate = async ({
+    generatedRecord,
+    recordId,
+    updatedSelectedRecordBlocks,
+    isNavigatingBack = true,
+    asRefToNewRecord = false,
+    shouldSetSearchParams = true,
+    isProfileChange = false,
+  }: HandleRecordUpdateProps) => {
+    if (!generatedRecord) return;
+
+    setIsLoading(true);
+
+    try {
+      const response = await saveRecordToApi(recordId, generatedRecord);
+      const parsedResponse = await response.json();
+
+      updateStateAfterSave(parsedResponse, asRefToNewRecord, recordId);
+
+      const updatedRecordId = getRecordId(parsedResponse, updatedSelectedRecordBlocks?.block);
+      setLastSavedRecordId(updatedRecordId);
+
+      // Handle different navigation scenarios
+      if (isProfileChange || !isNavigatingBack) {
+        return await handleProfileOrNoNavigationChange(updatedRecordId, parsedResponse, isProfileChange);
+      }
+
+      if (isNavigatingBack) {
+        return handleBackNavigation(updatedRecordId, parsedResponse, asRefToNewRecord, shouldSetSearchParams);
+      }
+
+      return updatedRecordId;
+    } catch (error) {
+      logger.error('Cannot update the resource description', error);
+      addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, getFriendlyErrorMessage(error)));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const saveRecord = async ({
+    asRefToNewRecord = false,
+    isNavigatingBack = true,
+    shouldSetSearchParams = true,
+    profileId,
+  }: SaveRecordProps = {}) => {
+    const generatedRecord = generateRecord({ profileId });
+    const updatedSelectedRecordBlocks = selectedRecordBlocks || getSelectedRecordBlocks(searchParams);
+    const recordId = getRecordId(record, updatedSelectedRecordBlocks?.block);
+
+    return await handleRecordUpdate({
+      generatedRecord,
+      recordId,
+      updatedSelectedRecordBlocks,
+      isNavigatingBack,
+      asRefToNewRecord,
+      shouldSetSearchParams,
+    });
+  };
+
+  const deleteRecord = async () => {
+    try {
+      if (!currentRecordId) return;
+
+      await deleteRecordRequest(currentRecordId);
+      discardRecord();
+      addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.success, 'ld.rdDeleted'));
+
+      navigate(ROUTES.SEARCH.uri);
+    } catch (error) {
+      logger.error('Cannot delete the resource description', error);
+      addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, 'ld.cantDeleteRd'));
+    }
+  };
+
+  const changeRecordProfile = ({ profileId }: { profileId: string | number }) => {
+    const generatedRecord = generateRecord({ profileId: `${profileId}` });
+    const updatedSelectedRecordBlocks = selectedRecordBlocks || getSelectedRecordBlocks(searchParams);
+    const recordId = getRecordId(record, updatedSelectedRecordBlocks?.block);
+
+    return handleRecordUpdate({
+      generatedRecord,
+      recordId,
+      updatedSelectedRecordBlocks,
+      isNavigatingBack: false,
+      isProfileChange: true,
+    });
+  };
+
+  return { saveRecord, deleteRecord, changeRecordProfile };
+};

--- a/src/features/resources/hooks/useRecordNavigation.test.ts
+++ b/src/features/resources/hooks/useRecordNavigation.test.ts
@@ -1,0 +1,57 @@
+import { setInitialGlobalState } from '@/test/__mocks__/store';
+
+import { renderHook } from '@testing-library/react';
+
+import { useInputsStore } from '@/store';
+
+import { useRecordNavigation } from './useRecordNavigation';
+
+jest.mock('@/common/constants/build.constants', () => ({ IS_EMBEDDED_MODE: false }));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => jest.fn(),
+  useLocation: () => ({ state: {} }),
+  useSearchParams: () => [new URLSearchParams('type=hub'), jest.fn()],
+}));
+
+jest.mock('@/features/resources', () => ({
+  getGraphIdByExternalId: jest.fn(),
+}));
+
+const mockDispatchUnblockEvent = jest.fn();
+const mockDispatchNavigateToOriginEventWithFallback = jest.fn();
+
+jest.mock('@/common/hooks/useContainerEvents', () => ({
+  useContainerEvents: () => ({
+    dispatchUnblockEvent: mockDispatchUnblockEvent,
+    dispatchNavigateToOriginEventWithFallback: mockDispatchNavigateToOriginEventWithFallback,
+  }),
+}));
+
+describe('useRecordNavigation', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockReturnValue();
+  });
+
+  describe('discardRecord', () => {
+    it('discards record and navigates away with segment parameter', () => {
+      setInitialGlobalState([
+        {
+          store: useInputsStore,
+          state: {
+            record: null,
+            selectedRecordBlocks: null,
+          },
+        },
+      ]);
+
+      const { result } = renderHook(() => useRecordNavigation());
+      result.current.discardRecord();
+
+      expect(mockDispatchUnblockEvent).toHaveBeenCalled();
+      expect(mockDispatchNavigateToOriginEventWithFallback).toHaveBeenCalledWith(
+        expect.stringContaining('segment=hubs'),
+      );
+    });
+  });
+});

--- a/src/features/resources/hooks/useRecordNavigation.ts
+++ b/src/features/resources/hooks/useRecordNavigation.ts
@@ -1,0 +1,78 @@
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import { RecordStatus } from '@/common/constants/record.constants';
+import { QueryParams, SearchQueryParams } from '@/common/constants/routes.constants';
+import { StatusType } from '@/common/constants/status.constants';
+import { getFriendlyErrorMessage } from '@/common/helpers/api.helper';
+import { generateEditResourceUrl } from '@/common/helpers/navigation.helper';
+import { useBackToSearchUri } from '@/common/hooks/useBackToSearchUri';
+import { useContainerEvents } from '@/common/hooks/useContainerEvents';
+import { UserNotificationFactory } from '@/common/services/userNotification';
+import { getSearchSegment, mapToResourceType } from '@/configs/resourceTypes';
+
+import { getGraphIdByExternalId } from '@/features/resources';
+
+import { useInputsState, useLoadingState, useProfileState, useStatusState } from '@/store';
+
+export const useRecordNavigation = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const searchResultsUri = useBackToSearchUri();
+  const { resetUserValues, setRecord, setSelectedRecordBlocks } = useInputsState([
+    'resetUserValues',
+    'setRecord',
+    'setSelectedRecordBlocks',
+  ]);
+  const { setSelectedProfile } = useProfileState(['setSelectedProfile']);
+  const { setRecordStatus, addStatusMessagesItem } = useStatusState(['setRecordStatus', 'addStatusMessagesItem']);
+  const { setIsLoading } = useLoadingState(['setIsLoading']);
+  const { dispatchUnblockEvent, dispatchNavigateToOriginEventWithFallback } = useContainerEvents();
+
+  const ensureSegmentInUri = (uri: string) => {
+    if (uri.includes(`${SearchQueryParams.Segment}=`)) {
+      return uri;
+    }
+
+    const typeParam = searchParams.get(QueryParams.Type);
+    const resourceType = mapToResourceType(typeParam);
+    const segment = getSearchSegment(resourceType);
+    const separator = uri.includes('?') ? '&' : '?';
+
+    return `${uri}${separator}${SearchQueryParams.Segment}=${segment}`;
+  };
+
+  const clearRecordState = () => {
+    resetUserValues();
+    setRecord(null);
+    setSelectedRecordBlocks(undefined);
+    setSelectedProfile(null);
+    setRecordStatus({ type: RecordStatus.close });
+    dispatchUnblockEvent();
+  };
+
+  const discardRecord = (clearState = true) => {
+    if (clearState) clearRecordState();
+
+    dispatchNavigateToOriginEventWithFallback(ensureSegmentInUri(searchResultsUri));
+  };
+
+  const tryFetchExternalRecordForEdit = async (recordId?: string) => {
+    try {
+      if (!recordId) return;
+
+      setIsLoading(true);
+
+      const { id } = await getGraphIdByExternalId({ recordId });
+
+      if (id) {
+        navigate(generateEditResourceUrl(id), { replace: true });
+      }
+    } catch (err: unknown) {
+      addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, getFriendlyErrorMessage(err)));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { clearRecordState, discardRecord, tryFetchExternalRecordForEdit };
+};

--- a/src/features/resources/index.ts
+++ b/src/features/resources/index.ts
@@ -1,2 +1,3 @@
 export * from './api';
+export * from './helpers';
 export * from './hooks';

--- a/src/test/__mocks__/common/hooks/useRecordControls.mock.ts
+++ b/src/test/__mocks__/common/hooks/useRecordControls.mock.ts
@@ -1,17 +1,11 @@
-export const saveRecord = jest.fn();
-export const discardRecord = jest.fn();
 export const fetchRecord = jest.fn();
-export const clearRecordState = jest.fn();
 export const fetchRecordAndSelectEntityValues = jest.fn();
 export const fetchExternalRecordForPreview = jest.fn();
 export const getRecordAndInitializeParsing = jest.fn();
 
 jest.mock('@/common/hooks/useRecordControls', () => ({
   useRecordControls: () => ({
-    saveRecord,
-    discardRecord,
     fetchRecord,
-    clearRecordState,
     fetchRecordAndSelectEntityValues,
     fetchExternalRecordForPreview,
     getRecordAndInitializeParsing,

--- a/src/test/__mocks__/features/resources/hooks/useRecordMutations.mock.ts
+++ b/src/test/__mocks__/features/resources/hooks/useRecordMutations.mock.ts
@@ -1,0 +1,7 @@
+export const saveRecord = jest.fn();
+export const deleteRecord = jest.fn();
+export const changeRecordProfile = jest.fn();
+
+jest.mock('@/features/resources/hooks/useRecordMutations', () => ({
+  useRecordMutations: () => ({ saveRecord, deleteRecord, changeRecordProfile }),
+}));

--- a/src/test/__mocks__/features/resources/hooks/useRecordNavigation.mock.ts
+++ b/src/test/__mocks__/features/resources/hooks/useRecordNavigation.mock.ts
@@ -1,0 +1,7 @@
+export const discardRecord = jest.fn();
+export const tryFetchExternalRecordForEdit = jest.fn();
+export const clearRecordState = jest.fn();
+
+jest.mock('@/features/resources/hooks/useRecordNavigation', () => ({
+  useRecordNavigation: () => ({ discardRecord, tryFetchExternalRecordForEdit, clearRecordState }),
+}));

--- a/src/test/__tests__/common/hooks/useRecordControls.test.ts
+++ b/src/test/__tests__/common/hooks/useRecordControls.test.ts
@@ -1,26 +1,18 @@
-import { setInitialGlobalState } from '@/test/__mocks__/store';
-
 import { renderHook } from '@testing-library/react';
 
 import { ExternalResourceIdType } from '@/common/constants/api.constants';
 import { BibframeEntities } from '@/common/constants/bibframe.constants';
-import { RecordStatus } from '@/common/constants/record.constants';
 import { ROUTES } from '@/common/constants/routes.constants';
 import { StatusType } from '@/common/constants/status.constants';
-import * as recordHelper from '@/common/helpers/record.helper';
 import { PreviewParams } from '@/common/hooks/useConfig.hook';
 import { useRecordControls } from '@/common/hooks/useRecordControls';
 import { UserNotificationFactory } from '@/common/services/userNotification';
 
 import * as recordsApi from '@/features/resources';
-import { useRecordGeneration } from '@/features/resources';
-
-import { useInputsStore, useStatusStore } from '@/store';
 
 jest.mock('@/common/constants/build.constants', () => ({ IS_EMBEDDED_MODE: false }));
 
 const mockNavigate = jest.fn();
-const mockDispatchNavigateToOriginEventWithFallback = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
@@ -28,21 +20,14 @@ jest.mock('react-router-dom', () => ({
   useSearchParams: () => [new URLSearchParams('type=hub'), jest.fn()],
 }));
 
-const mockGenerateRecord = jest.fn();
 jest.mock('@/features/resources', () => ({
   getRecord: jest.fn(),
-  postRecord: jest.fn(),
-  putRecord: jest.fn(),
-  useRecordGeneration: () => ({
-    generateRecord: mockGenerateRecord,
-  }),
 }));
 
-const mockDispatchUnblockEvent = jest.fn();
 jest.mock('@/common/hooks/useContainerEvents', () => ({
   useContainerEvents: () => ({
-    dispatchUnblockEvent: mockDispatchUnblockEvent,
-    dispatchNavigateToOriginEventWithFallback: mockDispatchNavigateToOriginEventWithFallback,
+    dispatchUnblockEvent: jest.fn(),
+    dispatchNavigateToOriginEventWithFallback: jest.fn(),
   }),
 }));
 
@@ -60,96 +45,8 @@ jest.mock('@/common/services/userNotification', () => ({
 }));
 
 describe('useRecordControls', () => {
-  const mockSetRecordStatus = jest.fn();
-  const mockApiResponse = { id: 'test-id' };
-
   beforeEach(() => {
     jest.spyOn(console, 'error').mockReturnValue();
-  });
-
-  describe('saveRecord', () => {
-    beforeEach(() => {
-      setInitialGlobalState([
-        {
-          store: useStatusStore,
-          state: {
-            setRecordStatus: mockSetRecordStatus,
-          },
-        },
-        {
-          store: useInputsStore,
-          state: {
-            selectedRecordBlocks: null,
-            record: {},
-          },
-        },
-      ]);
-
-      mockGenerateRecord.mockReturnValue({});
-    });
-
-    it('saves record with default props', async () => {
-      const mockResponse = { json: () => Promise.resolve(mockApiResponse) };
-      (recordsApi.postRecord as jest.Mock).mockResolvedValue(mockResponse);
-
-      const { result } = renderHook(() => useRecordControls());
-      await result.current.saveRecord();
-
-      expect(recordsApi.postRecord).toHaveBeenCalled();
-    });
-
-    it('handles save with asRefToNewRecord=true', async () => {
-      const mockResponse = { json: () => Promise.resolve(mockApiResponse) };
-      (recordsApi.postRecord as jest.Mock).mockResolvedValue(mockResponse);
-
-      const { result } = renderHook(() => useRecordControls());
-      await result.current.saveRecord({ asRefToNewRecord: true });
-
-      expect(recordsApi.postRecord).toHaveBeenCalled();
-    });
-
-    it('handles save with isNavigatingBack=false', async () => {
-      const mockResponse = { json: () => Promise.resolve(mockApiResponse) };
-      (recordsApi.putRecord as jest.Mock).mockResolvedValue(mockResponse);
-
-      jest.spyOn(recordHelper, 'getRecordId').mockReturnValue('existing-id');
-
-      const { result } = renderHook(() => useRecordControls());
-      await result.current.saveRecord({ isNavigatingBack: false });
-
-      expect(recordsApi.putRecord).toHaveBeenCalled();
-    });
-
-    it('handles save errors', async () => {
-      (recordsApi.postRecord as jest.Mock).mockRejectedValue(new Error('Save failed'));
-
-      const { result } = renderHook(() => useRecordControls());
-      await result.current.saveRecord();
-
-      expect(UserNotificationFactory.createMessage).toHaveBeenCalledWith(StatusType.error, 'ld.cantSaveRd');
-    });
-
-    it('updates record status on successful save', async () => {
-      const mockResponse = { json: () => Promise.resolve(mockApiResponse) };
-      (recordsApi.postRecord as jest.Mock).mockResolvedValue(mockResponse);
-
-      const { result } = renderHook(() => useRecordControls());
-      await result.current.saveRecord();
-
-      expect(mockSetRecordStatus).toHaveBeenCalledWith({
-        type: RecordStatus.saveAndClose,
-      });
-    });
-
-    it('does not save if generateRecord returns null', async () => {
-      jest.spyOn(useRecordGeneration(), 'generateRecord').mockReturnValue(undefined);
-
-      const { result } = renderHook(() => useRecordControls());
-      await result.current.saveRecord();
-
-      expect(recordsApi.postRecord).not.toHaveBeenCalled();
-      expect(recordsApi.putRecord).not.toHaveBeenCalled();
-    });
   });
 
   describe('fetchRecordAndSelectEntityValues', () => {
@@ -287,85 +184,6 @@ describe('useRecordControls', () => {
         recordId: 'test-id',
         previewParams,
       });
-    });
-  });
-
-  describe('changeRecordProfile', () => {
-    const mockSetRecord = jest.fn();
-    const mockSetIsEdited = jest.fn();
-    const mockSetLastSavedRecordId = jest.fn();
-    const mockSelectedRecordBlocks = { block: 'test-block' };
-    const mockRecord = { id: 'record-id', data: 'test data' };
-    const mockNewProfileId = '456';
-    const mockResponseData = { id: 'updated-record-id', data: 'updated data' };
-
-    beforeEach(() => {
-      setInitialGlobalState([
-        {
-          store: useStatusStore,
-          state: {
-            setIsRecordEdited: mockSetIsEdited,
-            setLastSavedRecordId: mockSetLastSavedRecordId,
-          },
-        },
-        {
-          store: useInputsStore,
-          state: {
-            record: mockRecord,
-            setRecord: mockSetRecord,
-            selectedRecordBlocks: mockSelectedRecordBlocks,
-          },
-        },
-      ]);
-
-      mockGenerateRecord.mockReturnValue({ generated: 'record' });
-      jest
-        .spyOn(recordHelper, 'getRecordId')
-        .mockReturnValueOnce('record-id')
-        .mockReturnValueOnce('record-id')
-        .mockReturnValueOnce('updated-record-id')
-        .mockReturnValueOnce('updated-record-id');
-    });
-
-    it('successfully changes record profile', async () => {
-      mockGenerateRecord.mockReturnValue(mockResponseData);
-
-      const { result } = renderHook(() => useRecordControls());
-      await result.current.changeRecordProfile({ profileId: mockNewProfileId });
-
-      expect(mockGenerateRecord).toHaveBeenCalledWith({ profileId: mockNewProfileId });
-    });
-
-    it('does not proceed if generateRecord returns nothing', async () => {
-      mockGenerateRecord.mockReturnValue(undefined);
-
-      const { result } = renderHook(() => useRecordControls());
-      await result.current.changeRecordProfile({ profileId: mockNewProfileId });
-
-      expect(recordsApi.putRecord).not.toHaveBeenCalled();
-      expect(mockSetRecord).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('discardRecord', () => {
-    it('discards record and navigates away with segment parameter', () => {
-      setInitialGlobalState([
-        {
-          store: useInputsStore,
-          state: {
-            record: null,
-            selectedRecordBlocks: null,
-          },
-        },
-      ]);
-
-      const { result } = renderHook(() => useRecordControls());
-      result.current.discardRecord();
-
-      expect(mockDispatchUnblockEvent).toHaveBeenCalled();
-      expect(mockDispatchNavigateToOriginEventWithFallback).toHaveBeenCalledWith(
-        expect.stringContaining('segment=hubs'),
-      );
     });
   });
 });

--- a/src/views/Edit/Edit.test.tsx
+++ b/src/views/Edit/Edit.test.tsx
@@ -1,7 +1,8 @@
 import { getMockedImportedConstant } from '@/test/__mocks__/common/constants/constants.mock';
 import '@/test/__mocks__/common/helpers/pageScrolling.helper.mock';
 import { getProfiles } from '@/test/__mocks__/common/hooks/useConfig.mock';
-import { clearRecordState, fetchRecord } from '@/test/__mocks__/common/hooks/useRecordControls.mock';
+import { fetchRecord } from '@/test/__mocks__/common/hooks/useRecordControls.mock';
+import { clearRecordState } from '@/test/__mocks__/features/resources/hooks/useRecordNavigation.mock';
 import { setInitialGlobalState } from '@/test/__mocks__/store';
 
 import * as Router from 'react-router-dom';
@@ -13,8 +14,7 @@ import { PROFILE_BFIDS } from '@/common/constants/bibframe.constants';
 import * as NavigationHelper from '@/common/helpers/navigation.helper';
 import { Edit } from '@/views';
 
-import { useUIStore } from '@/store';
-import { useProfileStore } from '@/store/stores/profile';
+import { useProfileStore, useUIStore } from '@/store';
 
 const monograph = {
   id: 'id',

--- a/src/views/Edit/Edit.tsx
+++ b/src/views/Edit/Edit.tsx
@@ -13,6 +13,7 @@ import { UserNotificationFactory } from '@/common/services/userNotification';
 import { getProfileBfid, getReference, hasReference, hasSplitLayout, mapToResourceType } from '@/configs/resourceTypes';
 
 import { EditPreview, EditSection, ModalViewMarc, useResetRecordStatus } from '@/features/edit';
+import { useRecordNavigation } from '@/features/resources';
 
 import { useInputsState, useLoadingState, useMarcPreviewState, useStatusState, useUIState } from '@/store';
 
@@ -22,7 +23,8 @@ const ignoreLoadingStatuses = new Set([RecordStatus.saveAndClose, RecordStatus.s
 
 export const Edit = () => {
   const { getProfiles } = useConfig();
-  const { fetchRecord, clearRecordState, fetchRecordAndSelectEntityValues } = useRecordControls();
+  const { fetchRecord, fetchRecordAndSelectEntityValues } = useRecordControls();
+  const { clearRecordState } = useRecordNavigation();
   const resourceId = getResourceIdFromUri();
   const { resetRecord, resetUserValues, resetSelectedEntries } = useInputsState([
     'resetRecord',

--- a/src/views/ExternalResource/components/PreviewExternalResourceControls/PreviewExternalResourceControls.tsx
+++ b/src/views/ExternalResource/components/PreviewExternalResourceControls/PreviewExternalResourceControls.tsx
@@ -2,13 +2,14 @@ import { FormattedMessage } from 'react-intl';
 import { useParams } from 'react-router-dom';
 
 import { useContainerEvents } from '@/common/hooks/useContainerEvents';
-import { useRecordControls } from '@/common/hooks/useRecordControls';
 import { Button, ButtonType } from '@/components/Button';
+
+import { useRecordNavigation } from '@/features/resources';
 
 import './PreviewExternalResourceControls.scss';
 
 export const PreviewExternalResourceControls = () => {
-  const { tryFetchExternalRecordForEdit } = useRecordControls();
+  const { tryFetchExternalRecordForEdit } = useRecordNavigation();
   const { dispatchNavigateToOriginEventWithFallback } = useContainerEvents();
   const { externalId } = useParams();
 


### PR DESCRIPTION
Decouples write-side and navigation operations out of the `useRecordControls` monolith into two focused hooks: `useRecordMutations` and `useRecordNavigation`. Updates all consumers and tests accordingly.
**Note:** The remaining fetch/read logic in `useRecordControls` and the related `useConfig` refactoring (dependency inversion, profile loading deduplication) are planned for the next PR.

[https://folio-org.atlassian.net/browse/UILD-744](https://folio-org.atlassian.net/browse/UILD-744)

**Technical details:**
- Extracted `saveRecord`, `deleteRecord`, and `changeRecordProfile` into the new `useRecordMutations` hook
- Extracted `clearRecordState`, `discardRecord`, and `tryFetchExternalRecordForEdit` into the new `useRecordNavigation` hook
- Extracted `extractProfileParams` into a pure helper shared by `useRecordMutations` and `useConfig`
- Updated all consumers
- Added unit tests for both new hooks; slimmed `useRecordControls.test.ts` to cover only remaining functionality

