### PR TITLE
UILD-821: Fix duplicate Work cannot be saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 * Refactor resource processing and preview loading. Refs [UILD-744].
 * Refactor resource loading. Refs [UILD-816].
 * Fix default profile type persistence across edit form and profile settings. Fixes [UILD-820].
+* Fix duplicate Work cannot be saved. Fixes [UILD-821].
 
 [UILD-744]:https://folio-org.atlassian.net/browse/UILD-744
 [UILD-816]:https://folio-org.atlassian.net/browse/UILD-816
 [UILD-820]:https://folio-org.atlassian.net/browse/UILD-820
+[UILD-821]:https://folio-org.atlassian.net/browse/UILD-821
 
 ## 2.0.3 (2026-05-19)
 * Fix Reset search option is missing after using Advanced Search. Fixes [UILD-812].

--- a/src/features/edit/hooks/useEditPage.test.ts
+++ b/src/features/edit/hooks/useEditPage.test.ts
@@ -5,7 +5,13 @@ import { act, renderHook } from '@testing-library/react';
 import { StatusType } from '@/common/constants/status.constants';
 import * as recordHelper from '@/common/helpers/record.helper';
 import { UserNotificationFactory } from '@/common/services/userNotification';
-import { getProfileBfid, getReference, hasReference, mapToResourceType } from '@/configs/resourceTypes';
+import {
+  getProfileBfid,
+  getReference,
+  hasReference,
+  mapToResourceType,
+  resolveResourceType,
+} from '@/configs/resourceTypes';
 
 import { useInputsStore, useLoadingStateStore, useProfileStore, useStatusStore, useUIStore } from '@/store';
 
@@ -41,6 +47,7 @@ jest.mock('@/common/services/userNotification', () => ({
 
 jest.mock('@/configs/resourceTypes', () => ({
   mapToResourceType: jest.fn(() => 'instance'),
+  resolveResourceType: jest.fn(() => 'instance'),
   getProfileBfid: jest.fn(() => 'lde:Profile:Instance'),
   hasReference: jest.fn(() => false),
   getReference: jest.fn(),
@@ -329,10 +336,21 @@ describe('useEditPage', () => {
   });
 
   describe('isWorkClone behavior', () => {
-    it('passes null to stores when cloning a work (clears instance preview)', async () => {
-      (mapToResourceType as jest.Mock).mockReturnValue('work');
+    const WORK_URI = 'http://bibfra.me/vocab/lite/Work';
+    const INSTANCE_REF_KEY = '_instanceReference';
 
-      const mockRecord = { resource: { uri: 'test-work' } };
+    it('strips the instance reference from the record when cloning a work', async () => {
+      (mapToResourceType as jest.Mock).mockReturnValue('work');
+      (resolveResourceType as jest.Mock).mockReturnValue('work');
+
+      const mockRecord = {
+        resource: {
+          [WORK_URI]: {
+            someField: ['test value'],
+            [INSTANCE_REF_KEY]: [{ id: 'instance-1' }],
+          },
+        },
+      };
 
       mockFetchQuery.mockResolvedValue(mockRecord);
       mockProcessResource.mockResolvedValue(mockProcessedResource);
@@ -344,12 +362,14 @@ describe('useEditPage', () => {
         await result.current.loadResource('work-id-1', { asClone: true });
       });
 
-      // null is passed so the preview section has no linked instances
-      expect(mockSetRecord).toHaveBeenCalledWith(null);
+      const storedRecord = mockSetRecord.mock.calls[0][0];
+      expect(storedRecord.resource[WORK_URI]).not.toHaveProperty(INSTANCE_REF_KEY);
+      expect(storedRecord.resource[WORK_URI]).toHaveProperty('someField');
     });
 
     it('passes the original record to stores when cloning an instance (preserves work preview)', async () => {
       (mapToResourceType as jest.Mock).mockReturnValue('instance');
+      (resolveResourceType as jest.Mock).mockReturnValue('instance');
 
       const mockRecord = { resource: { uri: 'test-instance' } };
 

--- a/src/features/edit/hooks/useEditPage.ts
+++ b/src/features/edit/hooks/useEditPage.ts
@@ -8,7 +8,12 @@ import { BLOCKS_BFLITE } from '@/common/constants/bibframeMapping.constants';
 import { ResourceType } from '@/common/constants/record.constants';
 import { QueryParams, ROUTES } from '@/common/constants/routes.constants';
 import { StatusType } from '@/common/constants/status.constants';
-import { getPrimaryEntitiesFromRecord } from '@/common/helpers/record.helper';
+import {
+  getAdjustedRecordContents,
+  getPrimaryEntitiesFromRecord,
+  unwrapRecordValuesFromCommonContainer,
+  wrapRecordValuesWithCommonContainer,
+} from '@/common/helpers/record.helper';
 import { logger } from '@/common/services/logger';
 import { UserNotificationFactory } from '@/common/services/userNotification';
 import {
@@ -209,19 +214,16 @@ export const useEditPage = () => {
 
         let recordToStore = record;
         if (isWorkClone && record) {
-          const {
-            uri: workBlockUri,
-            reference: { key: instanceRefKey },
-          } = BLOCKS_BFLITE.WORK;
-          const workBlock = record.resource?.[workBlockUri] as Record<string, unknown>;
+          const { uri, reference } = BLOCKS_BFLITE.WORK;
+          const unwrapped = unwrapRecordValuesFromCommonContainer(record);
+          const { record: adjusted } = getAdjustedRecordContents({
+            record: unwrapped,
+            block: uri,
+            reference,
+            asClone: true,
+          });
 
-          recordToStore = {
-            ...record,
-            resource: {
-              ...record.resource,
-              [workBlockUri]: { ...workBlock, [instanceRefKey]: undefined },
-            },
-          } as RecordEntry;
+          recordToStore = wrapRecordValuesWithCommonContainer(adjusted);
         }
 
         applyToStores({ result, record: recordToStore, withReference: !isWorkClone });

--- a/src/features/edit/hooks/useEditPage.ts
+++ b/src/features/edit/hooks/useEditPage.ts
@@ -125,7 +125,7 @@ export const useEditPage = () => {
 
         if (isCancelled()) return;
 
-        if (result) applyToStores({ result, record: null });
+        if (result) applyToStores({ result, record: null, withReference: true });
       } catch {
         if (!isCancelled()) {
           addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, 'ld.errorFetching'));

--- a/src/features/edit/hooks/useEditPage.ts
+++ b/src/features/edit/hooks/useEditPage.ts
@@ -11,7 +11,13 @@ import { StatusType } from '@/common/constants/status.constants';
 import { getPrimaryEntitiesFromRecord } from '@/common/helpers/record.helper';
 import { logger } from '@/common/services/logger';
 import { UserNotificationFactory } from '@/common/services/userNotification';
-import { getProfileBfid, getReference, hasReference, mapToResourceType } from '@/configs/resourceTypes';
+import {
+  getProfileBfid,
+  getReference,
+  hasReference,
+  mapToResourceType,
+  resolveResourceType,
+} from '@/configs/resourceTypes';
 
 import { type ProcessedResource, generateResourceQueryOptions, useResourceProcessing } from '@/features/resources/';
 
@@ -20,6 +26,12 @@ import { useInputsState, useLoadingState, useProfileState, useStatusState, useUI
 type LoadResourceOptions = {
   asClone?: boolean;
   ref?: string | null;
+};
+
+type ApplyToStoresProps = {
+  result: ProcessedResource;
+  record?: RecordEntry | null;
+  withReference?: boolean;
 };
 
 export const useEditPage = () => {
@@ -53,7 +65,7 @@ export const useEditPage = () => {
   ]);
 
   const applyEntityBfids = useCallback(
-    (record?: RecordEntry | null) => {
+    (record?: RecordEntry | null, withReference?: boolean) => {
       if (record) {
         setCurrentlyEditedEntityBfid(new Set(getPrimaryEntitiesFromRecord(record)));
         setCurrentlyPreviewedEntityBfid(new Set(getPrimaryEntitiesFromRecord(record, false)));
@@ -62,7 +74,7 @@ export const useEditPage = () => {
 
         setCurrentlyEditedEntityBfid(new Set([editedEntityBfId]));
 
-        if (hasReference(resourceType)) {
+        if (withReference && hasReference(resourceType)) {
           const ref = getReference(resourceType);
 
           setCurrentlyPreviewedEntityBfid(new Set([getProfileBfid(ref?.targetType)]));
@@ -75,7 +87,7 @@ export const useEditPage = () => {
   );
 
   const applyToStores = useCallback(
-    (result: ProcessedResource, record?: RecordEntry | null) => {
+    ({ result, record, withReference }: ApplyToStoresProps) => {
       setSelectedProfile(result.selectedProfile ?? null);
       setSchema(result.schema);
       setInitialSchemaKey(result.initKey);
@@ -85,7 +97,7 @@ export const useEditPage = () => {
 
       if (record !== undefined) setRecord(record);
 
-      applyEntityBfids(record);
+      applyEntityBfids(record, withReference);
     },
     [
       setSelectedProfile,
@@ -108,7 +120,7 @@ export const useEditPage = () => {
 
         if (isCancelled()) return;
 
-        if (result) applyToStores(result, null);
+        if (result) applyToStores({ result, record: null });
       } catch {
         if (!isCancelled()) {
           addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, 'ld.errorFetching'));
@@ -189,11 +201,30 @@ export const useEditPage = () => {
 
         if (isCancelled() || !result) return;
 
-        // When cloning a work, pass null so the preview section is empty (the clone has no linked instances yet).
-        // Instance clones retain the original record so the linked work preview remains visible.
-        const isWorkClone = asClone && resourceType === ResourceType.work;
+        // When cloning a work, strip the instance reference from the record so the Instance preview
+        // section is not displayed. Instance clones retain the original record so the linked work preview remains visible.
+        const blockUri = result?.selectedRecordBlocks?.block;
+        const resourceTypeResolved = resolveResourceType(blockUri, typeParam);
+        const isWorkClone = asClone && resourceTypeResolved === ResourceType.work;
 
-        applyToStores(result, isWorkClone ? null : record);
+        let recordToStore = record;
+        if (isWorkClone && record) {
+          const {
+            uri: workBlockUri,
+            reference: { key: instanceRefKey },
+          } = BLOCKS_BFLITE.WORK;
+          const workBlock = record.resource?.[workBlockUri] as Record<string, unknown>;
+
+          recordToStore = {
+            ...record,
+            resource: {
+              ...record.resource,
+              [workBlockUri]: { ...workBlock, [instanceRefKey]: undefined },
+            },
+          } as RecordEntry;
+        }
+
+        applyToStores({ result, record: recordToStore, withReference: !isWorkClone });
 
         if (resourceId && !asClone) setIsEdited(false);
       } catch {


### PR DESCRIPTION
When duplicating a Work, the linked instance reference was included in the stored record, which caused the Instance preview panel to appear - and led to save failures because the duplicate Work appeared to have an existing instance linked to it.

[https://folio-org.atlassian.net/browse/UILD-821](https://folio-org.atlassian.net/browse/UILD-821)

**Technical details:**
- In `loadResource`, when cloning a Work, the stored record is now stripped of its `_instanceReference` key by delegating to the existing `getAdjustedRecordContents` helper (wrapped/unwrapped with `unwrapRecordValuesFromCommonContainer` / `wrapRecordValuesWithCommonContainer`) instead of passing null; this keeps the Work's own field values intact while clearing the instance back-reference
- `initNewResource` now passes `withReference: true` to `applyToStores` so the preview panel bfid is correctly initialised when creating a new resource (e.g. the Work preview slot is set when opening a new Instance form)
