### PR TITLE
UILD-816: Fix - Preserve state on leaving the Edit page

### DIFF
--- a/src/views/Edit/Edit.test.tsx
+++ b/src/views/Edit/Edit.test.tsx
@@ -9,7 +9,6 @@ import * as Router from 'react-router-dom';
 import { act, render, screen } from '@testing-library/react';
 
 import * as BibframeConstants from '@/common/constants/bibframe.constants';
-import * as NavigationHelper from '@/common/helpers/navigation.helper';
 import { Edit } from '@/views';
 
 import { useProfileStore } from '@/store';
@@ -66,7 +65,6 @@ describe('Edit', () => {
 
   test('renders EditSection component if a profile is selected and calls loadResource', async () => {
     jest.spyOn(Router, 'useParams').mockReturnValue({ resourceId: 'testResourceId' });
-    jest.spyOn(NavigationHelper, 'getResourceIdFromUri').mockReturnValue('testResourceId');
 
     await renderComponent(monograph as unknown as ProfileEntry);
 
@@ -76,7 +74,6 @@ describe('Edit', () => {
 
   test("calls initNewResource and doesn't call loadResource when no resourceId", async () => {
     jest.spyOn(Router, 'useParams').mockReturnValue({ resourceId: undefined });
-    jest.spyOn(NavigationHelper, 'getResourceIdFromUri').mockReturnValue(undefined);
 
     await renderComponent(null);
 
@@ -99,7 +96,6 @@ describe('Edit', () => {
 
   test('skips initNewResource when resourceId or cloneOfParam exists', async () => {
     jest.spyOn(Router, 'useParams').mockReturnValue({ resourceId: 'testId' });
-    jest.spyOn(NavigationHelper, 'getResourceIdFromUri').mockReturnValue('testId');
 
     await renderComponent(null);
 

--- a/src/views/Edit/Edit.tsx
+++ b/src/views/Edit/Edit.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useLayoutEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 
 import { QueryParams } from '@/common/constants/routes.constants';
-import { getResourceIdFromUri } from '@/common/helpers/navigation.helper';
 import { scrollEntity } from '@/common/helpers/pageScrolling.helper';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { hasSplitLayout, mapToResourceType } from '@/configs/resourceTypes';
@@ -17,7 +16,7 @@ import './Edit.scss';
 export const Edit = () => {
   const { initNewResource, loadResource } = useEditPage();
   const { clearRecordState } = useRecordNavigation();
-  const resourceId = getResourceIdFromUri();
+  const resourceId = useParams().resourceId;
   const { basicValue: marcPreviewData, resetBasicValue: resetMarcPreviewData } = useMarcPreviewState([
     'basicValue',
     'resetBasicValue',
@@ -52,11 +51,16 @@ export const Edit = () => {
 
     return () => {
       cancelled = true;
-      clearRecordState();
       setIsLoading(false);
       setIsPreviewLoading(false);
     };
   }, [resourceId, cloneOfParam, refParam, resourceType]);
+
+  useEffect(() => {
+    return () => {
+      clearRecordState();
+    };
+  }, []);
 
   useEffect(() => {
     resetHasShownAuthorityWarning();

--- a/src/views/Edit/EditWrapper.tsx
+++ b/src/views/Edit/EditWrapper.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { QueryParams } from '@/common/constants/routes.constants';
@@ -6,13 +6,12 @@ import { Edit } from '@/views';
 
 export const EditWrapper = () => {
   const [queryParams] = useSearchParams();
-  const lastTypeRef = useRef<string | null>(null);
-
   const typeParam = queryParams.get(QueryParams.Type);
+  const [stableType, setStableType] = useState<string | null>(typeParam);
 
-  if (typeParam !== null) {
-    lastTypeRef.current = typeParam;
+  if (typeParam !== null && typeParam !== stableType) {
+    setStableType(typeParam);
   }
 
-  return <Edit key={typeParam ?? lastTypeRef.current} />;
+  return <Edit key={stableType} />;
 };

--- a/src/views/Edit/EditWrapper.tsx
+++ b/src/views/Edit/EditWrapper.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { QueryParams } from '@/common/constants/routes.constants';
@@ -5,6 +6,13 @@ import { Edit } from '@/views';
 
 export const EditWrapper = () => {
   const [queryParams] = useSearchParams();
+  const lastTypeRef = useRef<string | null>(null);
 
-  return <Edit key={queryParams.get(QueryParams.Type)} />;
+  const typeParam = queryParams.get(QueryParams.Type);
+
+  if (typeParam !== null) {
+    lastTypeRef.current = typeParam;
+  }
+
+  return <Edit key={typeParam ?? lastTypeRef.current} />;
 };


### PR DESCRIPTION
Fix a bug (regression) where pressing the browser Back button on the Edit Work page and clicking "No" in the "Close Resource" modal discarded all unsaved changes and reloaded the record from the server.

[https://folio-org.atlassian.net/browse/UILD-816?focusedCommentId=309266](https://folio-org.atlassian.net/browse/UILD-816?focusedCommentId=309266)

**Technical details:**
- Root cause: `getResourceIdFromUri()` read `window.location.pathname` directly. During a blocked Back navigation (React Router v7 fires `go(+1)` to cancel it), the browser URL transiently points to the search page before `go(+1)` completes. This caused `getResourceIdFromUri()` to return `undefined`, changing the `resourceId` dependency and triggering `initNewResource()` - which overwrote all unsaved user input with an empty record.
- Fix: Replaced `getResourceIdFromUri()` with `useParams().resourceId` in `Edit.tsx`. `useParams()` reads from `router.state.matches`, which React Router v7 never updates during a blocked navigation, so `resourceId` stays stable throughout the popstate cycle.
- Effect cleanup fix: Moved `clearRecordState()` from the dep-change cleanup of the main load effect into a separate unmount-only effect ([]). Previously, every `resourceId` dependency change triggered a store wipe before the new load, which was an unintended side effect of a prior refactoring.
- `EditWrapper` stabilization: Introduced a stableType state in `EditWrapper` that only updates when `typeParam` is non-null. This prevents Edit from unmounting and losing state when `typeParam` transiently becomes `null` during navigation.

