### PR TITLE
UILD-816: Fix regression issues that appeared after refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@
 * Fix duplicate Work cannot be saved. Fixes [UILD-821].
 * Refactor services providers and simple lookup data loading. Refs [UILD-816].
 * Refactor imports and add import boundary rules. Refs [UILD-816].
+* Fix regression issues that appeared after refactoring. Refs [UILD-816], [UILD-827].
 
 [UILD-744]:https://folio-org.atlassian.net/browse/UILD-744
 [UILD-816]:https://folio-org.atlassian.net/browse/UILD-816
 [UILD-821]:https://folio-org.atlassian.net/browse/UILD-821
+[UILD-827]:https://folio-org.atlassian.net/browse/UILD-827
 
 ## 2.0.4 (2026-06-03)
 * Fix default profile type persistence across edit form and profile settings. Fixes [UILD-820].

--- a/src/features/edit/components/modals/Prompt/Prompt.test.tsx
+++ b/src/features/edit/components/modals/Prompt/Prompt.test.tsx
@@ -4,9 +4,9 @@ import { setInitialGlobalState } from '@/test/__mocks__/store';
 
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-import { useConfigStore } from '@/store';
+import { useConfigStore, useLoadingStateStore } from '@/store';
 
 import { Prompt } from './Prompt';
 
@@ -15,6 +15,7 @@ const mockedUseBlocker = {
   proceed: jest.fn(),
 };
 
+const mockResetIsLoading = jest.fn();
 const setIsModalOpen = jest.fn();
 const openModal = jest.fn();
 const dispatchEvent = jest.fn();
@@ -60,6 +61,10 @@ const renderPrompt = (isBlocking = true) => {
       store: useConfigStore,
       state: { customEvents: { TRIGGER_MODAL: 'triggermodal' } },
     },
+    {
+      store: useLoadingStateStore,
+      state: { resetIsLoading: mockResetIsLoading },
+    },
   ]);
 
   return render(
@@ -101,5 +106,17 @@ describe('Prompt', () => {
     mockedContainer.dispatchEvent(new CustomEvent('triggermodal'));
 
     expect(addEventListener).toHaveBeenCalled();
+  });
+
+  test('calls resetIsLoading when navigation is blocked', () => {
+    expect(mockResetIsLoading).toHaveBeenCalled();
+  });
+
+  test('does not call resetIsLoading when "when" prop is false', () => {
+    cleanup();
+    mockResetIsLoading.mockClear();
+    renderPrompt(false);
+
+    expect(mockResetIsLoading).not.toHaveBeenCalled();
   });
 });

--- a/src/features/edit/components/modals/Prompt/Prompt.tsx
+++ b/src/features/edit/components/modals/Prompt/Prompt.tsx
@@ -10,7 +10,7 @@ import { useNavigateToEditPage } from '@/common/hooks/useNavigateToEditPage';
 
 import { useRecordMutations } from '@/features/resources';
 
-import { useStatusState } from '@/store';
+import { useLoadingState, useStatusState } from '@/store';
 
 import { ModalCloseRecord } from '../ModalCloseRecord';
 import { ModalSwitchToNewRecord } from '../ModalSwitchToNewRecord';
@@ -43,6 +43,7 @@ export const Prompt: FC<Props> = ({ when: shouldPrompt }) => {
   const { dispatchProceedNavigationEvent, dispatchUnblockEvent } = useContainerEvents({
     onTriggerModal: () => setIsCloseRecordModalOpen(true),
   });
+  const { resetIsLoading } = useLoadingState(['resetIsLoading']);
 
   const closeAllModals = () => {
     setIsCloseRecordModalOpen(false);
@@ -59,6 +60,8 @@ export const Prompt: FC<Props> = ({ when: shouldPrompt }) => {
     // ID we receive from the update operation
 
     if (shouldPrompt) {
+      resetIsLoading();
+
       const forceNavigateToDest = getForceNavigateToDest(pathname, search);
 
       if (forceNavigateToDest) {

--- a/src/features/edit/hooks/useEditPage.test.ts
+++ b/src/features/edit/hooks/useEditPage.test.ts
@@ -53,6 +53,14 @@ jest.mock('@/configs/resourceTypes', () => ({
   getReference: jest.fn(),
 }));
 
+const mockSelectedEntriesServiceSet = jest.fn();
+
+jest.mock('@/common/hooks/useSchemaPipeline', () => ({
+  useSchemaPipeline: () => ({
+    selectedEntriesService: { set: mockSelectedEntriesServiceSet },
+  }),
+}));
+
 const mockSetIsLoading = jest.fn();
 const mockSetSelectedProfile = jest.fn();
 const mockSetInitialSchemaKey = jest.fn();
@@ -121,6 +129,20 @@ describe('useEditPage', () => {
     (getProfileBfid as jest.Mock).mockReturnValue('lde:Profile:Instance');
     (hasReference as jest.Mock).mockReturnValue(false);
     setupStores();
+  });
+
+  describe('applyToStores', () => {
+    it('calls selectedEntriesService.set with selectedEntries from the processed resource', async () => {
+      mockProcessResource.mockResolvedValue(mockProcessedResource);
+
+      const { result } = renderHook(() => useEditPage());
+
+      await act(async () => {
+        await result.current.initNewResource();
+      });
+
+      expect(mockSelectedEntriesServiceSet).toHaveBeenCalledWith(mockProcessedResource.selectedEntries);
+    });
   });
 
   describe('initNewResource', () => {

--- a/src/features/edit/hooks/useEditPage.ts
+++ b/src/features/edit/hooks/useEditPage.ts
@@ -14,6 +14,7 @@ import {
   unwrapRecordValuesFromCommonContainer,
   wrapRecordValuesWithCommonContainer,
 } from '@/common/helpers/record.helper';
+import { useSchemaPipeline } from '@/common/hooks/useSchemaPipeline';
 import { logger } from '@/common/services/logger';
 import { UserNotificationFactory } from '@/common/services/userNotification';
 import {
@@ -47,6 +48,7 @@ export const useEditPage = () => {
   const { processResource } = useResourceProcessing();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const { selectedEntriesService } = useSchemaPipeline();
 
   const { setIsLoading } = useLoadingState(['setIsLoading']);
   const { setSelectedProfile, setInitialSchemaKey, setSchema } = useProfileState([
@@ -99,6 +101,7 @@ export const useEditPage = () => {
       setUserValues(result.userValues);
       setSelectedEntries(result.selectedEntries);
       setSelectedRecordBlocks(result.selectedRecordBlocks);
+      selectedEntriesService.set(result.selectedEntries);
 
       if (record !== undefined) setRecord(record);
 


### PR DESCRIPTION
Fix the navigation Prompt being hidden behind the loader, and prevent dropdown collapse when another dropdown's option changes.

[https://folio-org.atlassian.net/browse/UILD-827](https://folio-org.atlassian.net/browse/UILD-827)
[https://folio-org.atlassian.net/browse/UILD-816?focusedCommentId=310390](https://folio-org.atlassian.net/browse/UILD-816?focusedCommentId=310390)
[https://folio-org.atlassian.net/browse/UILD-816?focusedCommentId=310389](https://folio-org.atlassian.net/browse/UILD-816?focusedCommentId=310389)

**Technical details:**
- Prompt: call `resetIsLoading()` at the start of the blocker callback so the loading overlay is dismissed before the navigation modal is shown, making the prompt visible to the user
- `useEditPage` / `applyToStores`: sync `selectedEntries` into `selectedEntriesService` (the schema pipeline service) in addition to the Zustand store, so the service state stays consistent with the store and dropdowns no longer collapse when an unrelated dropdown's selection changes
- Added unit tests for both fixes

