### PR TITLE
UILD-826: Authority Edit page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@
 * Refactor services providers and simple lookup data loading. Refs [UILD-816].
 * Refactor imports and add import boundary rules. Refs [UILD-816].
 * Fix regression issues that appeared after refactoring. Refs [UILD-816], [UILD-827].
+* Add Authority edit page. Refs [UILD-826].
 
 [UILD-744]:https://folio-org.atlassian.net/browse/UILD-744
 [UILD-816]:https://folio-org.atlassian.net/browse/UILD-816
 [UILD-821]:https://folio-org.atlassian.net/browse/UILD-821
 [UILD-827]:https://folio-org.atlassian.net/browse/UILD-827
+[UILD-826]:https://folio-org.atlassian.net/browse/UILD-826
 
 ## 2.0.4 (2026-06-03)
 * Fix default profile type persistence across edit form and profile settings. Fixes [UILD-820].

--- a/src/common/constants/bibframe.constants.ts
+++ b/src/common/constants/bibframe.constants.ts
@@ -4,30 +4,35 @@ export const RESOURCE_TEMPLATE_IDS: Record<string, string> = {
   'lde:Profile:Work': 'Work',
   'lde:Profile:Instance': 'Instance',
   'lde:Profile:Hub': 'Hub',
+  'lde:Profile:Authority': 'Authority',
 };
 
 export enum BibframeEntitiesMap {
   'http://bibfra.me/vocab/lite/Work' = 'work',
   'http://bibfra.me/vocab/lite/Instance' = 'instance',
   'http://bibfra.me/vocab/lite/Hub' = 'hub',
+  '_authority' = 'authority',
 }
 
 export const PROFILE_BFIDS = {
   WORK: 'lde:Profile:Work',
   INSTANCE: 'lde:Profile:Instance',
   HUB: 'lde:Profile:Hub',
+  AUTHORITY: 'lde:Profile:Authority',
 };
 
 export enum BibframeEntities {
   INSTANCE = 'INSTANCE',
   WORK = 'WORK',
   HUB = 'HUB',
+  AUTHORITY = 'AUTHORITY',
 }
 
 export const TYPE_URIS = {
   INSTANCE: BFLITE_URIS.INSTANCE,
   WORK: BFLITE_URIS.WORK,
   HUB: BFLITE_URIS.HUB,
+  AUTHORITY: BFLITE_URIS.AUTHORITY,
 };
 
 export const CONSTRAINTS: Constraints = {

--- a/src/common/constants/bibframeMapping.constants.ts
+++ b/src/common/constants/bibframeMapping.constants.ts
@@ -4,6 +4,7 @@ export const BFLITE_URIS = {
   INSTANCE: 'http://bibfra.me/vocab/lite/Instance',
   WORK: 'http://bibfra.me/vocab/lite/Work',
   HUB: 'http://bibfra.me/vocab/lite/Hub',
+  AUTHORITY: '_authority',
   NAME: 'http://bibfra.me/vocab/lite/name',
   LABEL: 'http://bibfra.me/vocab/lite/label',
   LINK: 'http://bibfra.me/vocab/lite/link',
@@ -143,6 +144,12 @@ export const BLOCKS_BFLITE = {
     uri: BFLITE_URIS.HUB,
     referenceKey: '',
     resourceType: ResourceType.hub,
+    reference: undefined,
+  },
+  AUTHORITY: {
+    uri: BFLITE_URIS.AUTHORITY,
+    referenceKey: '',
+    resourceType: ResourceType.authority,
     reference: undefined,
   },
 };

--- a/src/common/constants/bibframeMapping.constants.ts
+++ b/src/common/constants/bibframeMapping.constants.ts
@@ -98,6 +98,7 @@ export const BFLITE_URIS = {
   SUBORDINATE_UNIT: 'http://bibfra.me/vocab/library/subordinateUnit',
   PLACE: 'http://bibfra.me/vocab/library/place',
   GEOGRAPHIC_COVERAGE: 'http://bibfra.me/vocab/library/geographicCoverage',
+  QUALIFIER: 'http://bibfra.me/vocab/library/qualifier',
 };
 
 export const NON_BF_RECORD_ELEMENTS = {

--- a/src/common/constants/bibframeMapping.constants.ts
+++ b/src/common/constants/bibframeMapping.constants.ts
@@ -90,6 +90,14 @@ export const BFLITE_URIS = {
   DISSERTATION_ID: 'http://bibfra.me/vocab/library/dissertationID',
   BOOKS: 'http://bibfra.me/vocab/library/Books',
   CONTINUING_RESOURCES: 'http://bibfra.me/vocab/library/ContinuingResources',
+  NUMERATION: 'http://bibfra.me/vocab/library/numeration',
+  TITLES: 'http://bibfra.me/vocab/library/titles',
+  ATTRIBUTION: 'http://bibfra.me/vocab/library/attribution',
+  NAME_ALTERNATIVE: 'http://bibfra.me/vocab/lite/nameAlternative',
+  AFFILIATION: 'http://bibfra.me/vocab/scholar/affiliation',
+  SUBORDINATE_UNIT: 'http://bibfra.me/vocab/library/subordinateUnit',
+  PLACE: 'http://bibfra.me/vocab/library/place',
+  GEOGRAPHIC_COVERAGE: 'http://bibfra.me/vocab/library/geographicCoverage',
 };
 
 export const NON_BF_RECORD_ELEMENTS = {

--- a/src/common/constants/record.constants.ts
+++ b/src/common/constants/record.constants.ts
@@ -2,6 +2,7 @@ export enum ResourceType {
   work = 'work',
   instance = 'instance',
   hub = 'hub',
+  authority = 'authority',
 }
 
 export enum RecordStatus {

--- a/src/common/constants/resourceTemplates.constants.ts
+++ b/src/common/constants/resourceTemplates.constants.ts
@@ -25,4 +25,12 @@ export const DUPLICATE_RESOURCE_TEMPLATE: Record<string, ResourceTemplateMetadat
       },
     },
   ],
+  [BFLITE_URIS.AUTHORITY]: [
+    {
+      path: [BFLITE_URIS.AUTHORITY, BFLITE_URIS.NAME],
+      template: {
+        prefix: 'ld.duplicateAuthorityInBrackets',
+      },
+    },
+  ],
 };

--- a/src/common/services/recordGenerator/schemas/profiles/authority.schema.ts
+++ b/src/common/services/recordGenerator/schemas/profiles/authority.schema.ts
@@ -1,0 +1,1 @@
+export const authorityRecordSchema: RecordSchema = {};

--- a/src/common/services/recordGenerator/schemas/profiles/authority.schema.ts
+++ b/src/common/services/recordGenerator/schemas/profiles/authority.schema.ts
@@ -1,7 +1,8 @@
 import { BFLITE_URIS } from '@/common/constants/bibframeMapping.constants';
 import { RecordSchemaEntryType } from '@/common/constants/recordSchema.constants';
 
-import { stringArrayProperty } from '../common/propertyDefinitions';
+import { linkAndLabelProperties, stringArrayProperty } from '../common/propertyDefinitions';
+import { createArrayObjectProperty, createObjectProperty, createStatusProperty } from '../common/schemaBuilders';
 
 export const authorityRecordSchema: RecordSchema = {
   [BFLITE_URIS.AUTHORITY]: {
@@ -21,6 +22,18 @@ export const authorityRecordSchema: RecordSchema = {
       [BFLITE_URIS.SUBORDINATE_UNIT]: stringArrayProperty,
       [BFLITE_URIS.PLACE]: stringArrayProperty,
       [BFLITE_URIS.GEOGRAPHIC_COVERAGE]: stringArrayProperty,
+      [BFLITE_URIS.MAP]: createArrayObjectProperty({
+        [BFLITE_URIS.IDENTIFIER_LCCN]: createObjectProperty({
+          [BFLITE_URIS.NAME]: stringArrayProperty,
+          [BFLITE_URIS.QUALIFIER]: stringArrayProperty,
+          [BFLITE_URIS.LIBRARY_STATUS]: createStatusProperty(linkAndLabelProperties),
+        }),
+        [BFLITE_URIS.IDENTIFIER_OTHER]: createObjectProperty({
+          [BFLITE_URIS.NAME]: stringArrayProperty,
+          [BFLITE_URIS.QUALIFIER]: stringArrayProperty,
+          [BFLITE_URIS.LIBRARY_STATUS]: createStatusProperty(linkAndLabelProperties),
+        }),
+      }),
     },
   },
 };

--- a/src/common/services/recordGenerator/schemas/profiles/authority.schema.ts
+++ b/src/common/services/recordGenerator/schemas/profiles/authority.schema.ts
@@ -1,1 +1,26 @@
-export const authorityRecordSchema: RecordSchema = {};
+import { BFLITE_URIS } from '@/common/constants/bibframeMapping.constants';
+import { RecordSchemaEntryType } from '@/common/constants/recordSchema.constants';
+
+import { stringArrayProperty } from '../common/propertyDefinitions';
+
+export const authorityRecordSchema: RecordSchema = {
+  [BFLITE_URIS.AUTHORITY]: {
+    type: RecordSchemaEntryType.object,
+    options: {
+      isRootEntry: true,
+    },
+    properties: {
+      [BFLITE_URIS.NAME]: stringArrayProperty,
+      [BFLITE_URIS.NUMERATION]: stringArrayProperty,
+      [BFLITE_URIS.TITLES]: stringArrayProperty,
+      [BFLITE_URIS.DATE]: stringArrayProperty,
+      [BFLITE_URIS.MISC_INFO]: stringArrayProperty,
+      [BFLITE_URIS.ATTRIBUTION]: stringArrayProperty,
+      [BFLITE_URIS.NAME_ALTERNATIVE]: stringArrayProperty,
+      [BFLITE_URIS.AFFILIATION]: stringArrayProperty,
+      [BFLITE_URIS.SUBORDINATE_UNIT]: stringArrayProperty,
+      [BFLITE_URIS.PLACE]: stringArrayProperty,
+      [BFLITE_URIS.GEOGRAPHIC_COVERAGE]: stringArrayProperty,
+    },
+  },
+};

--- a/src/common/services/recordGenerator/schemas/profiles/index.ts
+++ b/src/common/services/recordGenerator/schemas/profiles/index.ts
@@ -1,3 +1,4 @@
+import { authorityRecordSchema } from './authority.schema';
 import { hubRecordSchema } from './hub.schema';
 import { instanceRecordSchema } from './instance.schema';
 import { workRecordSchema } from './work.schema';
@@ -6,4 +7,5 @@ export const profileRecordSchemas = {
   instance: instanceRecordSchema,
   work: workRecordSchema,
   hub: hubRecordSchema,
+  authority: authorityRecordSchema,
 };

--- a/src/configs/resourceTypes/resourceType.config.ts
+++ b/src/configs/resourceTypes/resourceType.config.ts
@@ -1,3 +1,4 @@
+import { PROFILE_BFIDS } from '@/common/constants/bibframe.constants';
 import { BFLITE_URIS } from '@/common/constants/bibframeMapping.constants';
 import { ResourceType } from '@/common/constants/record.constants';
 
@@ -7,7 +8,7 @@ export const RESOURCE_TYPE_REGISTRY: ResourceTypeRegistry = {
   [ResourceType.instance]: {
     type: ResourceType.instance,
     uri: BFLITE_URIS.INSTANCE,
-    profileBfid: 'lde:Profile:Instance',
+    profileBfid: PROFILE_BFIDS.INSTANCE,
     defaultProfileId: 3,
     profileChildren: ['Profile:Work', 'Profile:Instance'],
     dependencies: [ResourceType.work],
@@ -31,7 +32,7 @@ export const RESOURCE_TYPE_REGISTRY: ResourceTypeRegistry = {
   [ResourceType.work]: {
     type: ResourceType.work,
     uri: BFLITE_URIS.WORK,
-    profileBfid: 'lde:Profile:Work',
+    profileBfid: PROFILE_BFIDS.WORK,
     defaultProfileId: 2,
     profileChildren: ['Profile:Work', 'Profile:Instance'],
     dependencies: [ResourceType.instance],
@@ -55,7 +56,7 @@ export const RESOURCE_TYPE_REGISTRY: ResourceTypeRegistry = {
   [ResourceType.hub]: {
     type: ResourceType.hub,
     uri: BFLITE_URIS.HUB,
-    profileBfid: 'lde:Profile:Hub',
+    profileBfid: PROFILE_BFIDS.HUB,
     defaultProfileId: 7,
     profileChildren: ['Profile:Hub'],
     dependencies: [],
@@ -72,7 +73,7 @@ export const RESOURCE_TYPE_REGISTRY: ResourceTypeRegistry = {
   [ResourceType.authority]: {
     type: ResourceType.authority,
     uri: BFLITE_URIS.AUTHORITY,
-    profileBfid: 'lde:Profile:Authority',
+    profileBfid: PROFILE_BFIDS.AUTHORITY,
     defaultProfileId: 8,
     profileChildren: ['Profile:Authority'],
     dependencies: [],

--- a/src/configs/resourceTypes/resourceType.config.ts
+++ b/src/configs/resourceTypes/resourceType.config.ts
@@ -68,4 +68,21 @@ export const RESOURCE_TYPE_REGISTRY: ResourceTypeRegistry = {
       segment: 'hubs',
     },
   },
+
+  [ResourceType.authority]: {
+    type: ResourceType.authority,
+    uri: BFLITE_URIS.AUTHORITY,
+    profileBfid: 'lde:Profile:Authority',
+    defaultProfileId: 8,
+    profileChildren: ['Profile:Authority'],
+    dependencies: [],
+    ui: {
+      hasPreview: false,
+      editPageLayout: 'single',
+    },
+    labelId: 'ld.hub',
+    search: {
+      segment: 'authorities',
+    },
+  },
 };

--- a/src/features/edit/hooks/useEditPage.ts
+++ b/src/features/edit/hooks/useEditPage.ts
@@ -129,8 +129,9 @@ export const useEditPage = () => {
         if (isCancelled()) return;
 
         if (result) applyToStores({ result, record: null, withReference: true });
-      } catch {
+      } catch (error) {
         if (!isCancelled()) {
+          logger.error('Error occurred while processing a resource', error);
           addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, 'ld.errorFetching'));
         }
       } finally {

--- a/translations/ui-linked-data/en.json
+++ b/translations/ui-linked-data/en.json
@@ -167,6 +167,7 @@
   "ld.duplicateInstanceInBrackets": "(DUPLICATE INSTANCE)",
   "ld.duplicateWorkInBrackets": "(DUPLICATE WORK)",
   "ld.duplicateHubInBrackets": "(DUPLICATE HUB)",
+  "ld.duplicateAuthorityInBrackets": "(DUPLICATE AUTHORITY)",
   "ld.identifierAll": "Identifier (all)",
   "ld.personalName": "Personal name",
   "ld.corporateName": "Corporate/Conference name",

--- a/translations/ui-linked-data/en.json
+++ b/translations/ui-linked-data/en.json
@@ -124,6 +124,7 @@
   "ld.compareSelected": "Compare selected",
   "ld.newInstance": "New instance",
   "ld.newWork": "New work",
+  "ld.newAuthority": "New authority",
   "ld.new": "New",
   "ld.cantSelectReferenceContents": "Can't select reference contents while fetching a reference",
   "ld.addNewInstance": "Add new instance",


### PR DESCRIPTION
[https://folio-org.atlassian.net/browse/UILD-826](https://folio-org.atlassian.net/browse/UILD-826)

**Technical details:**
- Registered `ResourceType.authority` in `RESOURCE_TYPE_REGISTRY` with single-column edit layout, no preview, and authorities search segment
- Added `authority.schema.ts` for record generation and exported it from the profiles index
- Added duplicate authority resource template using `BFLITE_URIS.NAME` as the path
- Refactored `resourceType.config.ts` to use `PROFILE_BFIDS` constants instead of inline string literals
- Added error logging in `useEditPage` catch block when fetching a resource fails