### PR TITLE
UILD-838: Fix field collision in record generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix regression issues that appeared after refactoring. Refs [UILD-816], [UILD-827].
 * Add Authority edit page. Refs [UILD-826].
 * Extend Search page with Authority search and create options. Refs [UILD-825].
+* Fix field collision in the record generation. Fixes [UILD-838].
 
 [UILD-744]:https://folio-org.atlassian.net/browse/UILD-744
 [UILD-816]:https://folio-org.atlassian.net/browse/UILD-816
@@ -17,6 +18,7 @@
 [UILD-827]:https://folio-org.atlassian.net/browse/UILD-827
 [UILD-826]:https://folio-org.atlassian.net/browse/UILD-826
 [UILD-825]:https://folio-org.atlassian.net/browse/UILD-825
+[UILD-838]:https://folio-org.atlassian.net/browse/UILD-838
 
 ## 2.0.4 (2026-06-03)
 * Fix default profile type persistence across edit form and profile settings. Fixes [UILD-820].

--- a/src/common/services/recordGenerator/profileSchemaManager.ts
+++ b/src/common/services/recordGenerator/profileSchemaManager.ts
@@ -30,7 +30,7 @@ export class ProfileSchemaManager implements IProfileSchemaManager {
 
     if (parentPath && parentPath.length > 0) {
       return entries.filter(entry => {
-        if (entry.path.length < parentPath.length) return false;
+        if (entry.path.length !== parentPath.length + 1) return false;
 
         for (let i = 0; i < parentPath.length; i++) {
           if (entry.path[i] !== parentPath[i]) return false;

--- a/src/test/__tests__/common/services/recordGenerator/profileSchemaManager.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/profileSchemaManager.test.ts
@@ -87,6 +87,22 @@ describe('ProfileSchemaManager', () => {
 
       expect(result).toEqual([]);
     });
+
+    it('does not return deeply nested entries that share a URI with a direct child', () => {
+      const deepEntry = {
+        uuid: 'uuid_deep',
+        uriBFLite: 'uri_1',
+        path: ['parent_1', 'child_1', 'grandchild_1'],
+      } as SchemaEntry;
+      const schemaWithDeepEntry = new Map([...mockSchema, ['uuid_deep', deepEntry]]);
+
+      manager.init(schemaWithDeepEntry);
+
+      const result = manager.findSchemaEntriesByUriBFLite('uri_1', ['parent_1']);
+
+      expect(result).toEqual([mockEntry_1]);
+      expect(result).not.toContain(deepEntry);
+    });
   });
 
   describe('getSchemaEntry', () => {


### PR DESCRIPTION
Fixes a bug where saving an authority record with only the LCCN identifier name filled would incorrectly also populate the top-level name field with the same value.

[https://folio-org.atlassian.net/browse/UILD-838](https://folio-org.atlassian.net/browse/UILD-838)

**Technical details:**
- `ProfileSchemaManager.findSchemaEntriesByUriBFLite` filtered candidates by checking that `entry.path` starts with the given parentPath, which matched descendants at any depth - not just direct children. When multiple schema fields share the same URI (e.g. `http://bibfra.me/vocab/lite/name` at the top level and nested inside map > LCCN), the nested entry's value leaked into the top-level field.
- Fixed by tightening the filter: `entry.path.length !== parentPath.length + 1` ensures only direct children (path exactly one level deeper than the parent) are returned.
- Added a regression test to `profileSchemaManager.test.ts` covering the scenario where a deeply nested entry shares a URI with a direct child.
