### PR TITLE
UILD-838: Language not processed

### DIFF
--- a/src/common/services/recordGenerator/profileSchemaManager.ts
+++ b/src/common/services/recordGenerator/profileSchemaManager.ts
@@ -30,7 +30,13 @@ export class ProfileSchemaManager implements IProfileSchemaManager {
 
     if (parentPath && parentPath.length > 0) {
       return entries.filter(entry => {
-        if (entry.path.length !== parentPath.length + 1) return false;
+        // Only filter for direct or direct + 1 children of the parent path.
+        // Anything beyond is more likely to be associated to a sub-resource
+        // and should not leak into a root resource property sharing the same URI.
+        const entryPathLength = entry.path.length;
+        const childMinPathLength = parentPath.length + 1;
+        const childMaxPathLength = parentPath.length + 2;
+        if (entryPathLength < childMinPathLength || entryPathLength > childMaxPathLength) return false;
 
         for (let i = 0; i < parentPath.length; i++) {
           if (entry.path[i] !== parentPath[i]) return false;

--- a/src/test/__tests__/common/services/recordGenerator/profileSchemaManager.test.ts
+++ b/src/test/__tests__/common/services/recordGenerator/profileSchemaManager.test.ts
@@ -92,7 +92,7 @@ describe('ProfileSchemaManager', () => {
       const deepEntry = {
         uuid: 'uuid_deep',
         uriBFLite: 'uri_1',
-        path: ['parent_1', 'child_1', 'grandchild_1'],
+        path: ['parent_1', 'child_1', 'grandchild_1', 'greatgrandchild_1'],
       } as SchemaEntry;
       const schemaWithDeepEntry = new Map([...mockSchema, ['uuid_deep', deepEntry]]);
 
@@ -102,6 +102,21 @@ describe('ProfileSchemaManager', () => {
 
       expect(result).toEqual([mockEntry_1]);
       expect(result).not.toContain(deepEntry);
+    });
+
+    it('does return grandchild entries that share a URI with a direct child', () => {
+      const deepEntry = {
+        uuid: 'uuid_deep',
+        uriBFLite: 'uri_1',
+        path: ['parent_1', 'child_1', 'grandchild_1'],
+      } as SchemaEntry;
+      const schemaWithDeepEntry = new Map([...mockSchema, ['uuid_deep', deepEntry]]);
+
+      manager.init(schemaWithDeepEntry);
+
+      const result = manager.findSchemaEntriesByUriBFLite('uri_1', ['parent_1']);
+
+      expect(result).toEqual([mockEntry_1, deepEntry]);
     });
   });
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-838

The fix in https://github.com/folio-org/ui-linked-data/pull/420 filtered out processing the language field due to its added restriction. Relaxing it slightly to include descendants one more level away allows the language field back in without reaching the deeply nested values it was intended to avoid.