### PR TITLE
UILD-780: Correct lack of view reset, load authority profiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@trivago/prettier-plugin-sort-imports": "^6.0.2",
         "@types/jest": "^30.0.0",
         "@types/lodash": "^4.17.14",
-        "@types/node": "^25.5.2",
+        "@types/node": "^26.1.1",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
         "@types/react-router-dom": "^5.3.3",
@@ -835,29 +835,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3246,13 +3223,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -11665,9 +11642,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/jest": "^30.0.0",
     "@types/lodash": "^4.17.14",
-    "@types/node": "^25.5.2",
+    "@types/node": "^26.1.1",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "@types/react-router-dom": "^5.3.3",

--- a/src/common/helpers/record.helper.ts
+++ b/src/common/helpers/record.helper.ts
@@ -170,3 +170,22 @@ export const getRecordProfileId = (record?: RecordEntry<RecursiveRecordSchema> |
 
   return selectedProfileId;
 };
+
+export const preserveReferenceData = (
+  generated: RecordEntry | null | undefined,
+  source: RecordEntry | null | undefined,
+  blocks?: SelectedRecordBlocks,
+) => {
+  // Skip merging if generated is effectively empty.
+  if (generated && Object.keys(generated.resource).length === 0) return source;
+
+  const block = blocks?.block;
+  const refKey = blocks?.reference?.key;
+  const refData = block && refKey ? source?.resource?.[block]?.[refKey] : undefined;
+
+  if (!generated || !refData || !generated.resource?.[block!]) return generated;
+
+  const merged = cloneDeep(generated);
+  merged.resource[block!][refKey!] = refData;
+  return merged;
+};

--- a/src/configs/resourceTypes/index.ts
+++ b/src/configs/resourceTypes/index.ts
@@ -19,6 +19,7 @@ export {
   hasReference,
   getReference,
   getUri,
+  getResourceTypeUri,
   getDefaultProfileId,
   getProfileBfid,
   getEditSectionPassiveClass,

--- a/src/configs/resourceTypes/utils/resourceType.accessors.ts
+++ b/src/configs/resourceTypes/utils/resourceType.accessors.ts
@@ -56,6 +56,10 @@ export const getUri = (type: ResourceTypeInput): string => {
   return getResourceTypeConfig(type).uri;
 };
 
+export const getResourceTypeUri = (type: ResourceTypeInput): string => {
+  return getResourceTypeConfig(type).resourceTypeUri ?? getResourceTypeConfig(type).uri;
+};
+
 export const getDefaultProfileId = (type: ResourceTypeInput): number => {
   return getResourceTypeConfig(type).defaultProfileId;
 };

--- a/src/features/edit/hooks/useEditPage.ts
+++ b/src/features/edit/hooks/useEditPage.ts
@@ -11,6 +11,7 @@ import { StatusType } from '@/common/constants/status.constants';
 import {
   getAdjustedRecordContents,
   getPrimaryEntitiesFromRecord,
+  preserveReferenceData,
   unwrapRecordValuesFromCommonContainer,
   wrapRecordValuesWithCommonContainer,
 } from '@/common/helpers/record.helper';
@@ -45,6 +46,10 @@ type ApplyToStoresProps = {
   withReference?: boolean;
 };
 
+type ApplyToProfileAndInputStoresProps = {
+  result: ProcessedResource;
+};
+
 export const useEditPage = () => {
   const [searchParams] = useSearchParams();
   const typeParam = searchParams.get(QueryParams.Type);
@@ -61,12 +66,15 @@ export const useEditPage = () => {
     'setInitialSchemaKey',
     'setSchema',
   ]);
-  const { setUserValues, setSelectedRecordBlocks, setSelectedEntries, setRecord } = useInputsState([
-    'setUserValues',
-    'setSelectedRecordBlocks',
-    'setSelectedEntries',
-    'setRecord',
-  ]);
+  const { record, selectedRecordBlocks, setUserValues, setSelectedRecordBlocks, setSelectedEntries, setRecord } =
+    useInputsState([
+      'record',
+      'selectedRecordBlocks',
+      'setUserValues',
+      'setSelectedRecordBlocks',
+      'setSelectedEntries',
+      'setRecord',
+    ]);
   const { setIsRecordEdited: setIsEdited, addStatusMessagesItem } = useStatusState([
     'setIsRecordEdited',
     'addStatusMessagesItem',
@@ -99,8 +107,8 @@ export const useEditPage = () => {
     [resourceType, setCurrentlyEditedEntityBfid, setCurrentlyPreviewedEntityBfid],
   );
 
-  const applyToStores = useCallback(
-    ({ result, record, withReference }: ApplyToStoresProps) => {
+  const applyToProfileAndInputStores = useCallback(
+    ({ result }: ApplyToProfileAndInputStoresProps) => {
       setSelectedProfile(result.selectedProfile ?? null);
       setSchema(result.schema);
       setInitialSchemaKey(result.initKey);
@@ -108,21 +116,19 @@ export const useEditPage = () => {
       setSelectedEntries(result.selectedEntries);
       setSelectedRecordBlocks(result.selectedRecordBlocks);
       selectedEntriesService.set(result.selectedEntries);
+    },
+    [setSelectedProfile, setSchema, setInitialSchemaKey, setUserValues, setSelectedEntries, setSelectedRecordBlocks],
+  );
+
+  const applyToStores = useCallback(
+    ({ result, record, withReference }: ApplyToStoresProps) => {
+      applyToProfileAndInputStores({ result });
 
       if (record !== undefined) setRecord(record);
 
       applyEntityBfids(record, withReference);
     },
-    [
-      setSelectedProfile,
-      setSchema,
-      setInitialSchemaKey,
-      setUserValues,
-      setSelectedEntries,
-      setSelectedRecordBlocks,
-      setRecord,
-      applyEntityBfids,
-    ],
+    [applyToProfileAndInputStores, setRecord, applyEntityBfids],
   );
 
   const initNewResource = useCallback(
@@ -152,11 +158,13 @@ export const useEditPage = () => {
       try {
         setIsLoading(true);
 
-        // Pass along current user values, but do not save to store as a record
-        const record = generateRecord({});
-        const result = await processResource({ record: record ?? undefined, profileSettingsId });
+        // Build a record based on current input.
+        const generated = generateRecord({});
+        // Augment it with the reference data from the current record if needed.
+        const fullRecord = preserveReferenceData(generated, record, selectedRecordBlocks);
+        const result = await processResource({ record: fullRecord ?? undefined, profileSettingsId });
 
-        if (result) applyToStores({ result, record: null, withReference: true });
+        if (result) applyToProfileAndInputStores({ result });
       } catch (error) {
         logger.error('Error occurred while applying profile settings to a resource', error);
         addStatusMessagesItem?.(
@@ -166,7 +174,7 @@ export const useEditPage = () => {
         setIsLoading(false);
       }
     },
-    [generateRecord, processResource, applyToStores, setIsLoading],
+    [generateRecord, processResource, preserveReferenceData, applyToProfileAndInputStores, setIsLoading],
   );
 
   const fetchRefRecord = useCallback(

--- a/src/features/manageProfileSettings/components/ProfilesList/ProfilesList.tsx
+++ b/src/features/manageProfileSettings/components/ProfilesList/ProfilesList.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 import { StatusType } from '@/common/constants/status.constants';
 import { UserNotificationFactory } from '@/common/services/userNotification';
-import { RESOURCE_TYPE_REGISTRY, getProfileLabelId, getUri } from '@/configs/resourceTypes';
+import { RESOURCE_TYPE_REGISTRY, getProfileLabelId, getResourceTypeUri } from '@/configs/resourceTypes';
 
 import { useProfileList } from '@/features/profiles';
 
@@ -94,7 +94,7 @@ export const ProfilesList = () => {
             <ResourceProfiles
               key={type}
               labelId={getProfileLabelId(type)}
-              profiles={availableProfiles[getUri(type) as ResourceTypeURL]}
+              profiles={availableProfiles[getResourceTypeUri(type) as ResourceTypeURL]}
             />
           );
         })}

--- a/src/features/manageProfileSettings/components/ProfilesList/ResourceProfile.tsx
+++ b/src/features/manageProfileSettings/components/ProfilesList/ResourceProfile.tsx
@@ -6,19 +6,20 @@ import { Button, ButtonType } from '@/components/Button';
 
 import { useManageProfileSettingsState, useUIState } from '@/store';
 
+import { useResetSettings } from '../../hooks';
+
 type ResourceProfileProps = {
   profile: ProfileDTO;
   selected: boolean;
 };
 
 export const ResourceProfile: FC<ResourceProfileProps> = ({ profile, selected }) => {
-  const { setNextSelectedProfile, setSelectedProfile, resetSelectedProfileSettingsMeta, isModified } =
-    useManageProfileSettingsState([
-      'setNextSelectedProfile',
-      'setSelectedProfile',
-      'resetSelectedProfileSettingsMeta',
-      'isModified',
-    ]);
+  const { isModified, resetIsCreating, setNextSelectedProfile, setSelectedProfile } = useManageProfileSettingsState([
+    'isModified',
+    'resetIsCreating',
+    'setNextSelectedProfile',
+    'setSelectedProfile',
+  ]);
   const {
     setIsManageProfileSettingsUnsavedModalOpen,
     setIsManageProfileSettingsShowProfiles,
@@ -28,6 +29,7 @@ export const ResourceProfile: FC<ResourceProfileProps> = ({ profile, selected })
     'setIsManageProfileSettingsShowProfiles',
     'setIsManageProfileSettingsShowEditor',
   ]);
+  const { resetSettings } = useResetSettings();
 
   const handleClick = () => {
     if (selected) {
@@ -38,7 +40,8 @@ export const ResourceProfile: FC<ResourceProfileProps> = ({ profile, selected })
       setIsManageProfileSettingsUnsavedModalOpen(true);
     } else {
       setSelectedProfile(profile);
-      resetSelectedProfileSettingsMeta();
+      resetSettings();
+      resetIsCreating();
       setIsManageProfileSettingsShowProfiles(false);
       setIsManageProfileSettingsShowEditor(true);
     }

--- a/src/features/resources/hooks/useRecordNavigation.ts
+++ b/src/features/resources/hooks/useRecordNavigation.ts
@@ -23,7 +23,10 @@ export const useRecordNavigation = () => {
     'setRecord',
     'setSelectedRecordBlocks',
   ]);
-  const { setSelectedProfile } = useProfileState(['setSelectedProfile']);
+  const { setSelectedProfile, resetSelectedProfileSettingsId } = useProfileState([
+    'setSelectedProfile',
+    'resetSelectedProfileSettingsId',
+  ]);
   const { setRecordStatus, addStatusMessagesItem } = useStatusState(['setRecordStatus', 'addStatusMessagesItem']);
   const { setIsLoading } = useLoadingState(['setIsLoading']);
   const { dispatchUnblockEvent, dispatchNavigateToOriginEventWithFallback } = useContainerEvents();
@@ -46,6 +49,7 @@ export const useRecordNavigation = () => {
     setRecord(null);
     setSelectedRecordBlocks(undefined);
     setSelectedProfile(null);
+    resetSelectedProfileSettingsId();
     setRecordStatus({ type: RecordStatus.close });
     dispatchUnblockEvent();
   };

--- a/src/test/__tests__/common/helpers/record.helper.test.ts
+++ b/src/test/__tests__/common/helpers/record.helper.test.ts
@@ -413,4 +413,100 @@ describe('record.helper', () => {
       expect(result).toEqual(['lde:Profile:Instance']);
     });
   });
+
+  describe('preserveReferenceData', () => {
+    const mockGenerated = {
+      resource: {
+        work: {
+          exists: 'yes',
+        },
+      },
+    };
+    const mockSource = {
+      resource: {
+        work: {
+          _ref: [
+            {
+              title: [
+                {
+                  title: 'source',
+                },
+              ],
+              profileId: 1,
+            },
+          ],
+        },
+      },
+    } as unknown as RecordEntry;
+    const mockBlocks = {
+      block: 'work',
+      reference: {
+        key: '_ref',
+        name: 'instance',
+        uri: 'instance-uri',
+      },
+    };
+    const mockMerged = {
+      resource: {
+        work: {
+          exists: 'yes',
+          _ref: [
+            {
+              title: [
+                {
+                  title: 'source',
+                },
+              ],
+              profileId: 1,
+            },
+          ],
+        },
+      },
+    };
+
+    test('returns source if generated is effectively empty', () => {
+      const result = RecordHelper.preserveReferenceData({ resource: {} }, mockSource, mockBlocks);
+
+      expect(result).toBe(mockSource);
+    });
+
+    test('returns undefined if generated is undefined', () => {
+      const result = RecordHelper.preserveReferenceData(undefined, mockSource, mockBlocks);
+
+      expect(result).toBeUndefined();
+    });
+
+    test('returns generated if selected record blocks not provided', () => {
+      const result = RecordHelper.preserveReferenceData(mockGenerated, mockSource);
+
+      expect(result).toBe(mockGenerated);
+    });
+
+    test('returns generated if no block in selected record blocks', () => {
+      const result = RecordHelper.preserveReferenceData(mockGenerated, mockSource, {
+        reference: { key: 'any', uri: 'any' },
+      });
+
+      expect(result).toBe(mockGenerated);
+    });
+
+    test('returns generated if no key in selected record blocks', () => {
+      const result = RecordHelper.preserveReferenceData(mockGenerated, mockSource, { block: 'any' });
+
+      expect(result).toBe(mockGenerated);
+    });
+
+    test('returns generated if block not present in generated resource', () => {
+      const generated = { resource: { hub: {} } };
+      const result = RecordHelper.preserveReferenceData(generated, mockSource, mockBlocks);
+
+      expect(result).toBe(generated);
+    });
+
+    test('properly merges generated and source when conditions line up', () => {
+      const result = RecordHelper.preserveReferenceData(mockGenerated, mockSource, mockBlocks);
+
+      expect(result).toEqual(mockMerged);
+    });
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node", "jest", "jsdom"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-780

- Navigating between profiles under manage profile settings left stray values persisting between profile choices, adding the correct reset fixes this, and should also help prevent saving values from one profile under a different one
- Resetting the selected profile settings ID when leaving the edit view prevents unexpected view changes when returning
- Adding a new accessor for resource type URIs allows loading of authority profiles in the profiles list, previously empty due to using `_authority` as the URI
- Update profile settings selection to only update visually relevant stores, and add a method to merge a generated record with the current record in order to retain preview info
- Update tsconfig to reflect changes in `@types/node` package (due to changes in Typescript, tsconfig's `types` array will no longer be auto-populated in order to reduce build time; fill it in by hand)