### PR TITLE
UILD-780: Incorporate preferred profile settings

### DIFF
--- a/src/common/api/profiles.api.ts
+++ b/src/common/api/profiles.api.ts
@@ -1,4 +1,5 @@
 import {
+  PREFERRED_PROFILE_SETTINGS_PATH,
   PROFILE_API_ENDPOINT,
   PROFILE_METADATA_API_ENDPOINT,
   PROFILE_PREFERRED_API_ENDPOINT,
@@ -96,6 +97,38 @@ export const saveProfileSettings = (
       headers: {
         'content-type': 'application/json',
       },
+    },
+  });
+};
+
+export const fetchPreferredProfileSettings = (profileId: string | number) =>
+  baseApi.getJson({
+    url: `${PROFILE_API_ENDPOINT}/${profileId}/${PREFERRED_PROFILE_SETTINGS_PATH}`,
+  }) as Promise<ProfileSettingsMetaList>;
+
+export const savePreferredProfileSettings = (profileId: string | number, profileSettingsId: number) => {
+  const url = `${PROFILE_API_ENDPOINT}/${profileId}/${PREFERRED_PROFILE_SETTINGS_PATH}`;
+  const body = JSON.stringify({ profileSettingsId });
+
+  return baseApi.request({
+    url,
+    requestParams: {
+      method: 'POST',
+      body,
+      headers: {
+        'content-type': 'application/json',
+      },
+    },
+  });
+};
+
+export const deletePreferredProfileSettings = (profileId: string | number) => {
+  const url = `${PROFILE_API_ENDPOINT}/${profileId}/${PREFERRED_PROFILE_SETTINGS_PATH}`;
+
+  return baseApi.request({
+    url,
+    requestParams: {
+      method: 'DELETE',
     },
   });
 };

--- a/src/common/constants/api.constants.ts
+++ b/src/common/constants/api.constants.ts
@@ -10,6 +10,7 @@ export const PROFILE_API_ENDPOINT = '/linked-data/profile';
 export const PROFILE_METADATA_API_ENDPOINT = '/linked-data/profile/metadata';
 export const PROFILE_PREFERRED_API_ENDPOINT = '/linked-data/profile/preferred';
 export const PROFILE_SETTINGS_PATH = 'settings';
+export const PREFERRED_PROFILE_SETTINGS_PATH = `preferred`;
 export const AUTHORITY_ASSIGNMENT_CHECK_API_ENDPOINT = '/linked-data/authority-assignment-check';
 export const IMPORT_JSON_FILE_API_ENDPOINT = '/linked-data/import/file';
 export const IMPORT_JSON_URL_API_ENDPOINT = '/linked-data/import/url';

--- a/src/common/helpers/navigation.helper.ts
+++ b/src/common/helpers/navigation.helper.ts
@@ -41,12 +41,10 @@ export const generatePageURL = ({
   url,
   queryParams,
   profileId,
-  profileSettingsId,
 }: {
   url: string;
   queryParams: Record<QueryParams, string>;
   profileId: string | number;
-  profileSettingsId?: string | number;
 }) => {
   const urlParams = new URLSearchParams();
 
@@ -60,10 +58,6 @@ export const generatePageURL = ({
 
   if (profileId) {
     urlParams.set(QueryParams.ProfileId, profileId.toString());
-  }
-
-  if (profileSettingsId) {
-    urlParams.set(QueryParams.ProfileSettingsId, profileSettingsId.toString());
   }
 
   const paramString = urlParams.toString();

--- a/src/features/edit/components/EditSection/EditSection.scss
+++ b/src/features/edit/components/EditSection/EditSection.scss
@@ -98,6 +98,21 @@
       padding-bottom: 5px;
     }
 
+    .setting-current {
+      font-weight: 700;
+    }
+
+    .setting-default {
+      font-style: italic;
+    }
+
+    .setting-preferred {
+      span {
+        text-transform: uppercase;
+        font-size: 90%;
+      }
+    }
+
     &-menu {
       position: absolute;
       list-style: none;

--- a/src/features/edit/components/EditSection/ProfileSettingsSelector.test.tsx
+++ b/src/features/edit/components/EditSection/ProfileSettingsSelector.test.tsx
@@ -19,7 +19,11 @@ describe('ProfileSettingsSelector', () => {
   const mockProfileId = 'profile-id';
   const mockSetSelectedProfileSettingsId = jest.fn();
 
-  const renderComponent = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const renderComponent = (withOptions: boolean) => {
     setInitialGlobalState([
       {
         store: useProfileStore,
@@ -30,22 +34,23 @@ describe('ProfileSettingsSelector', () => {
       },
     ]);
 
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
     queryClient.setQueryData(
       ['profileSettingsMeta', mockProfileId],
-      [
-        {
-          id: 15,
-          name: 'fifteen',
-        },
-        {
-          id: 32,
-          name: 'thirty-two',
-        },
-      ],
+      withOptions
+        ? [
+            {
+              id: 15,
+              name: 'fifteen',
+            },
+            {
+              id: 32,
+              name: 'thirty-two',
+            },
+          ]
+        : [],
     );
+
+    queryClient.setQueryData(['preferredProfileSettings', mockProfileId], [{ profileId: mockProfileId, id: 15 }]);
 
     return render(
       <QueryClientProvider client={queryClient}>
@@ -56,14 +61,30 @@ describe('ProfileSettingsSelector', () => {
     );
   };
 
+  afterEach(() => {
+    queryClient?.clear();
+  });
+
   it('renders the component', () => {
-    renderComponent();
+    mockGetRecordProfileId.mockReturnValue(mockProfileId);
+
+    renderComponent(true);
 
     expect(screen.getByTestId('profile-settings-selector-button')).toBeInTheDocument();
   });
 
+  it('does not render the component when no options', () => {
+    mockGetRecordProfileId.mockReturnValue(mockProfileId);
+
+    renderComponent(false);
+
+    expect(screen.queryByTestId('profile-settings-selector-button')).not.toBeInTheDocument();
+  });
+
   it('clicking button shows menu', () => {
-    renderComponent();
+    mockGetRecordProfileId.mockReturnValue(mockProfileId);
+
+    renderComponent(true);
 
     fireEvent.click(screen.getByTestId('profile-settings-selector-button'));
 
@@ -73,7 +94,7 @@ describe('ProfileSettingsSelector', () => {
   it('profile setting currently in use is disabled', async () => {
     mockGetRecordProfileId.mockReturnValue(mockProfileId);
 
-    renderComponent();
+    renderComponent(true);
 
     fireEvent.click(screen.getByTestId('profile-settings-selector-button'));
 
@@ -82,10 +103,22 @@ describe('ProfileSettingsSelector', () => {
     });
   });
 
+  it('preferred profile setting shows a label', async () => {
+    mockGetRecordProfileId.mockReturnValue(mockProfileId);
+
+    renderComponent(true);
+
+    fireEvent.click(screen.getByTestId('profile-settings-selector-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('ld.preferred')).toBeInTheDocument();
+    });
+  });
+
   it('clicking a setting selects it', async () => {
     mockGetRecordProfileId.mockReturnValue(mockProfileId);
 
-    renderComponent();
+    renderComponent(true);
 
     fireEvent.click(screen.getByTestId('profile-settings-selector-button'));
     fireEvent.click(screen.getByText('fifteen'));

--- a/src/features/edit/components/EditSection/ProfileSettingsSelector.tsx
+++ b/src/features/edit/components/EditSection/ProfileSettingsSelector.tsx
@@ -8,7 +8,7 @@ import { getRecordProfileId } from '@/common/helpers/record.helper';
 import { useDismissMenu } from '@/common/hooks/useDismissMenu';
 import { Button, ButtonType } from '@/components/Button';
 
-import { useLoadProfileSettingsMeta } from '@/features/profiles';
+import { useLoadProfileSettingsMeta, usePreferredProfileSettings } from '@/features/profiles';
 
 import { useInputsState, useProfileState } from '@/store';
 
@@ -33,9 +33,15 @@ export const ProfileSettingsSelector = () => {
     },
   ] as ProfileSettingsMetaList;
   const { data: profileSettings } = useLoadProfileSettingsMeta(selectedProfileId);
+  const { data: preferredProfileSettings } = usePreferredProfileSettings(selectedProfileId);
+
   const profileSettingsOptions = useMemo(() => {
     return profileSettings ? basicOption.concat(profileSettings) : basicOption;
   }, [basicOption, profileSettings]);
+
+  const hasOptions = useMemo(() => {
+    return (profileSettings?.length ?? 0) > 0;
+  }, [profileSettings]);
 
   const { isOpen: isMenuEnabled, setIsOpen: setIsMenuEnabled, toggle: toggleIsMenuEnabled } = useDismissMenu(ref);
 
@@ -44,7 +50,40 @@ export const ProfileSettingsSelector = () => {
     setSelectedProfileSettingsId(profileSettingsId.toString());
   };
 
-  return (
+  const isPreferred = (profileSetting: ProfileSettingsMeta) => {
+    return preferredProfileSettings?.some(p => p.id === profileSetting.id);
+  };
+
+  const getClassNames = (profileSetting: ProfileSettingsMeta) => {
+    const classNames = [];
+    if (profileSetting.id === PROFILE_SETTINGS_DEFAULT_OPTION) {
+      classNames.push('setting-default');
+    }
+    if (profileSetting.id === selectedProfileSettingsId) {
+      classNames.push('setting-current');
+    }
+    if (isPreferred(profileSetting)) {
+      classNames.push('setting-preferred');
+    }
+    return classNames.join(' ');
+  };
+
+  const getLabel = (profileSetting: ProfileSettingsMeta) => {
+    return (
+      <>
+        {profileSetting.name}
+        {isPreferred(profileSetting) ? (
+          <span>
+            <FormattedMessage id="ld.preferred" />
+          </span>
+        ) : (
+          ''
+        )}
+      </>
+    );
+  };
+
+  return hasOptions ? (
     <div className="profile-settings-selector" ref={ref}>
       <Button
         data-testid="profile-settings-selector-button"
@@ -69,17 +108,21 @@ export const ProfileSettingsSelector = () => {
               <li key={profileSetting.id} role="none">
                 <Button
                   type={ButtonType.Text}
-                  label={profileSetting.name}
                   role="menuitem"
                   disabled={profileSetting.id.toString() === selectedProfileSettingsId}
                   onClick={() => handleSettingClick(profileSetting.id)}
                   tabbable={isMenuEnabled}
-                />
+                  className={getClassNames(profileSetting)}
+                >
+                  {getLabel(profileSetting)}
+                </Button>
               </li>
             );
           })}
         </ul>
       )}
     </div>
+  ) : (
+    <></>
   );
 };

--- a/src/features/edit/hooks/useEditPage.test.ts
+++ b/src/features/edit/hooks/useEditPage.test.ts
@@ -65,6 +65,7 @@ jest.mock('@/common/hooks/useSchemaPipeline', () => ({
 
 const mockSetIsLoading = jest.fn();
 const mockSetSelectedProfile = jest.fn();
+const mockSetSelectedProfileSettingsId = jest.fn();
 const mockSetInitialSchemaKey = jest.fn();
 const mockSetSchema = jest.fn();
 const mockSetUserValues = jest.fn();
@@ -86,6 +87,7 @@ const setupStores = () => {
       store: useProfileStore,
       state: {
         setSelectedProfile: mockSetSelectedProfile,
+        setSelectedProfileSettingsId: mockSetSelectedProfileSettingsId,
         setInitialSchemaKey: mockSetInitialSchemaKey,
         setSchema: mockSetSchema,
       },

--- a/src/features/edit/hooks/useEditPage.ts
+++ b/src/features/edit/hooks/useEditPage.ts
@@ -61,8 +61,9 @@ export const useEditPage = () => {
   const { selectedEntriesService } = useSchemaPipeline();
 
   const { setIsLoading } = useLoadingState(['setIsLoading']);
-  const { setSelectedProfile, setInitialSchemaKey, setSchema } = useProfileState([
+  const { setSelectedProfile, setSelectedProfileSettingsId, setInitialSchemaKey, setSchema } = useProfileState([
     'setSelectedProfile',
+    'setSelectedProfileSettingsId',
     'setInitialSchemaKey',
     'setSchema',
   ]);
@@ -110,6 +111,7 @@ export const useEditPage = () => {
   const applyToProfileAndInputStores = useCallback(
     ({ result }: ApplyToProfileAndInputStoresProps) => {
       setSelectedProfile(result.selectedProfile ?? null);
+      setSelectedProfileSettingsId(result.selectedProfileSettingsId?.toString() ?? null);
       setSchema(result.schema);
       setInitialSchemaKey(result.initKey);
       setUserValues(result.userValues);

--- a/src/features/manageProfileSettings/components/DefaultProfileSettingsOption/DefaultProfileSettingsOption.scss
+++ b/src/features/manageProfileSettings/components/DefaultProfileSettingsOption/DefaultProfileSettingsOption.scss
@@ -1,0 +1,7 @@
+.default-profile-settings {
+  padding: 3px 15px 15px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.25rem;
+}

--- a/src/features/manageProfileSettings/components/DefaultProfileSettingsOption/DefaultProfileSettingsOption.test.tsx
+++ b/src/features/manageProfileSettings/components/DefaultProfileSettingsOption/DefaultProfileSettingsOption.test.tsx
@@ -1,0 +1,137 @@
+import { setInitialGlobalState } from '@/test/__mocks__/store';
+
+import { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { fetchPreferredProfileSettings } from '@/common/api/profiles.api';
+import { PROFILE_SETTINGS_DEFAULT_OPTION } from '@/common/constants/profileSettings.constants';
+
+import { useManageProfileSettingsState } from '@/store';
+
+import { DefaultProfileSettingsOption } from './DefaultProfileSettingsOption';
+
+jest.mock('@/common/api/profiles.api', () => ({
+  fetchPreferredProfileSettings: jest.fn(),
+}));
+
+describe('DefaultProfileSettingsOption', () => {
+  const mockSetIsModified = jest.fn();
+
+  let queryClient: QueryClient;
+
+  const createWrapper = () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    return Wrapper;
+  };
+
+  const mockProfileId = 3;
+  const mockProfileSettingsId = 24;
+  const mockPreferredProfileSettings = [
+    {
+      id: mockProfileSettingsId,
+      profileId: mockProfileId,
+      name: 'mock settings',
+    },
+  ];
+  const mockAlternatePreferredProfileSettings = [
+    {
+      id: 52,
+      profileId: mockProfileId,
+      name: 'alternate settings',
+    },
+  ];
+
+  const renderComponent = (profileId: string | number | null, profileSettingsId: string | number) => {
+    setInitialGlobalState([
+      {
+        store: useManageProfileSettingsState,
+        state: {
+          setIsModified: mockSetIsModified,
+        },
+      },
+    ]);
+
+    return render(
+      <MemoryRouter>
+        <DefaultProfileSettingsOption selectedProfileId={profileId} selectedProfileSettingsId={profileSettingsId} />
+      </MemoryRouter>,
+      { wrapper: createWrapper() },
+    );
+  };
+
+  afterEach(() => {
+    queryClient?.clear();
+    jest.clearAllMocks();
+  });
+
+  it('checked when current profile settings match preferred profile settings', async () => {
+    (fetchPreferredProfileSettings as jest.Mock).mockReturnValue(mockPreferredProfileSettings);
+
+    renderComponent(mockProfileId, mockProfileSettingsId);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('default-profile-settings-control')).toBeChecked();
+    });
+  });
+
+  it('disabled when profile is undefined', async () => {
+    (fetchPreferredProfileSettings as jest.Mock).mockReturnValue(mockPreferredProfileSettings);
+
+    renderComponent(null, PROFILE_SETTINGS_DEFAULT_OPTION);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('default-profile-settings-control')).toBeDisabled();
+    });
+  });
+
+  it('unchecked when selected profile settings is not preferred', async () => {
+    (fetchPreferredProfileSettings as jest.Mock).mockReturnValue(mockAlternatePreferredProfileSettings);
+
+    renderComponent(mockProfileId, mockProfileSettingsId);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('default-profile-settings-control')).not.toBeChecked();
+    });
+  });
+
+  it('unchecked when no preferred profle settings', async () => {
+    (fetchPreferredProfileSettings as jest.Mock).mockReturnValue([]);
+
+    renderComponent(mockProfileId, mockProfileSettingsId);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('default-profile-settings-control')).not.toBeChecked();
+    });
+  });
+
+  it('updates preferred value through interaction', async () => {
+    (fetchPreferredProfileSettings as jest.Mock).mockReturnValue(mockPreferredProfileSettings);
+
+    renderComponent(mockProfileId, mockProfileSettingsId);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('default-profile-settings-control')).toBeChecked();
+    });
+
+    fireEvent.click(screen.getByTestId('default-profile-settings-control'));
+
+    await waitFor(() => {
+      expect(mockSetIsModified).toHaveBeenCalledWith(true);
+      expect(screen.getByTestId('default-profile-settings-control')).not.toBeChecked();
+    });
+  });
+});

--- a/src/features/manageProfileSettings/components/DefaultProfileSettingsOption/DefaultProfileSettingsOption.tsx
+++ b/src/features/manageProfileSettings/components/DefaultProfileSettingsOption/DefaultProfileSettingsOption.tsx
@@ -1,0 +1,55 @@
+import { FC, useEffect } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import { usePreferredProfileSettings } from '@/features/profiles';
+
+import { useManageProfileSettingsState } from '@/store';
+
+import './DefaultProfileSettingsOption.scss';
+
+type DefaultProfileSettingsOptionProps = {
+  selectedProfileId: string | number | null;
+  selectedProfileSettingsId?: string | number;
+};
+
+export const DefaultProfileSettingsOption: FC<DefaultProfileSettingsOptionProps> = ({
+  selectedProfileId,
+  selectedProfileSettingsId,
+}) => {
+  const { data: defaultProfileSettings } = usePreferredProfileSettings(selectedProfileId);
+  const { isPreferredProfileSettings, setIsModified, setIsPreferredProfileSettings } = useManageProfileSettingsState([
+    'isPreferredProfileSettings',
+    'setIsModified',
+    'setIsPreferredProfileSettings',
+  ]);
+
+  useEffect(() => {
+    if (defaultProfileSettings) {
+      const exists = defaultProfileSettings.find(
+        pref => pref.id === selectedProfileSettingsId && pref.profileId === selectedProfileId,
+      );
+      setIsPreferredProfileSettings(!!exists);
+    }
+  }, [selectedProfileId, selectedProfileSettingsId, defaultProfileSettings, setIsPreferredProfileSettings]);
+
+  const handleChange = () => {
+    setIsModified(true);
+    setIsPreferredProfileSettings(prev => !prev);
+  };
+
+  return (
+    <div className="default-profile-settings">
+      <label htmlFor="default-profile-settings-control">
+        <input
+          type="checkbox"
+          checked={isPreferredProfileSettings}
+          onChange={handleChange}
+          id="default-profile-settings-control"
+          data-testid="default-profile-settings-control"
+          disabled={!selectedProfileId}
+        />
+        <FormattedMessage id="ld.setDefaultProfileSettings" />
+      </label>
+    </div>
+  );
+};

--- a/src/features/manageProfileSettings/components/DefaultProfileSettingsOption/DefaultProfileSettingsOption.tsx
+++ b/src/features/manageProfileSettings/components/DefaultProfileSettingsOption/DefaultProfileSettingsOption.tsx
@@ -25,10 +25,10 @@ export const DefaultProfileSettingsOption: FC<DefaultProfileSettingsOptionProps>
 
   useEffect(() => {
     if (defaultProfileSettings) {
-      const exists = defaultProfileSettings.find(
+      const exists = defaultProfileSettings.some(
         pref => pref.id === selectedProfileSettingsId && pref.profileId === selectedProfileId,
       );
-      setIsPreferredProfileSettings(!!exists);
+      setIsPreferredProfileSettings(exists);
     }
   }, [selectedProfileId, selectedProfileSettingsId, defaultProfileSettings, setIsPreferredProfileSettings]);
 

--- a/src/features/manageProfileSettings/components/DefaultProfileSettingsOption/index.ts
+++ b/src/features/manageProfileSettings/components/DefaultProfileSettingsOption/index.ts
@@ -1,0 +1,1 @@
+export { DefaultProfileSettingsOption } from './DefaultProfileSettingsOption';

--- a/src/features/manageProfileSettings/components/ModalCloseProfileSettings/ModalCloseProfileSettings.test.tsx
+++ b/src/features/manageProfileSettings/components/ModalCloseProfileSettings/ModalCloseProfileSettings.test.tsx
@@ -32,6 +32,8 @@ describe('ModalCloseProfileSettings', () => {
   const mockSetSelectedProfile = jest.fn();
   const mockSetIsCreating = jest.fn();
   const mockSetSelectedProfileSettingsMeta = jest.fn();
+  const mockSetIsPreferredProfileSettings = jest.fn();
+  const mockSetSettingsName = jest.fn();
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -190,6 +192,7 @@ describe('ModalCloseProfileSettings', () => {
           isCreatingSettingsNext: true,
           setIsCreating: mockSetIsCreating,
           setSelectedProfileSettingsMeta: mockSetSelectedProfileSettingsMeta,
+          setIsPreferredProfileSettings: mockSetIsPreferredProfileSettings,
         },
       },
     ]);
@@ -201,11 +204,12 @@ describe('ModalCloseProfileSettings', () => {
     await waitFor(() => {
       expect(mockSetIsCreating).toHaveBeenCalledWith(true);
       expect(mockSetSelectedProfileSettingsMeta).toHaveBeenCalledWith(null);
+      expect(mockSetIsPreferredProfileSettings).toHaveBeenCalledWith(false);
     });
   });
 
   it('when editing existing settings next, move to editing mode with next settings meta selected ', async () => {
-    const settingsMeta = { id: 'meta' };
+    const settingsMeta = { id: 'meta', name: 'edit-name' };
     setInitialGlobalState([
       {
         store: useManageProfileSettingsState,
@@ -217,6 +221,7 @@ describe('ModalCloseProfileSettings', () => {
           nextSelectedSettingsMeta: settingsMeta,
           setIsCreating: mockSetIsCreating,
           setSelectedProfileSettingsMeta: mockSetSelectedProfileSettingsMeta,
+          setSettingsName: mockSetSettingsName,
         },
       },
     ]);
@@ -228,6 +233,7 @@ describe('ModalCloseProfileSettings', () => {
     await waitFor(() => {
       expect(mockSetIsCreating).toHaveBeenCalledWith(false);
       expect(mockSetSelectedProfileSettingsMeta).toHaveBeenCalledWith(settingsMeta);
+      expect(mockSetSettingsName).toHaveBeenCalledWith('edit-name');
     });
   });
 });

--- a/src/features/manageProfileSettings/components/ModalCloseProfileSettings/ModalCloseProfileSettings.tsx
+++ b/src/features/manageProfileSettings/components/ModalCloseProfileSettings/ModalCloseProfileSettings.tsx
@@ -36,6 +36,7 @@ export const ModalCloseProfileSettings: FC<ModalCloseProfileSettingsProps> = ({ 
     setNextSelectedSettingsMeta,
     setSelectedProfileSettingsMeta,
     setSettingsName,
+    setIsPreferredProfileSettings,
   } = useManageProfileSettingsState([
     'isClosingNext',
     'setIsClosingNext',
@@ -53,6 +54,7 @@ export const ModalCloseProfileSettings: FC<ModalCloseProfileSettingsProps> = ({ 
     'setNextSelectedSettingsMeta',
     'setSelectedProfileSettingsMeta',
     'setSettingsName',
+    'setIsPreferredProfileSettings',
   ]);
   const { resetSettings } = useResetSettings();
   const { setIsManageProfileSettingsShowProfiles, setIsManageProfileSettingsShowEditor } = useUIState([
@@ -75,11 +77,13 @@ export const ModalCloseProfileSettings: FC<ModalCloseProfileSettingsProps> = ({ 
       setIsCreating(true);
       setSelectedProfileSettingsMeta(null);
       setSettingsName('');
+      setIsPreferredProfileSettings(false);
       setIsCreatingSettingsNext(false);
     } else if (isEditingSettingsNext) {
       setIsCreating(false);
       resetSettings();
       setSelectedProfileSettingsMeta(nextSelectedSettingsMeta);
+      setSettingsName(nextSelectedSettingsMeta?.name ?? '');
       setIsEditingSettingsNext(false);
       setNextSelectedSettingsMeta(null);
     }

--- a/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.test.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.test.tsx
@@ -2,6 +2,7 @@ import { setInitialGlobalState } from '@/test/__mocks__/store';
 
 import { MemoryRouter } from 'react-router-dom';
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import { AdvancedFieldType } from '@/common/constants/uiControls.constants';
@@ -13,12 +14,26 @@ import { ProfileSettingsEditor } from './ProfileSettingsEditor';
 describe('ProfileSettingsEditor', () => {
   const mockSetSettingsName = jest.fn();
 
-  it('renders with no state', async () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const renderComponent = () => {
     render(
       <MemoryRouter>
-        <ProfileSettingsEditor />
+        <QueryClientProvider client={queryClient}>
+          <ProfileSettingsEditor />
+        </QueryClientProvider>
       </MemoryRouter>,
     );
+  };
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it('renders with no state', async () => {
+    renderComponent();
 
     expect(screen.getByTestId('profile-settings-editor')).toBeInTheDocument();
   });
@@ -49,11 +64,7 @@ describe('ProfileSettingsEditor', () => {
       },
     ]);
 
-    render(
-      <MemoryRouter>
-        <ProfileSettingsEditor />
-      </MemoryRouter>,
-    );
+    renderComponent();
 
     const section = screen.getByTestId('selected-component-list');
     expect(within(section).getByText('1. Child')).toBeInTheDocument();
@@ -91,11 +102,7 @@ describe('ProfileSettingsEditor', () => {
       },
     ]);
 
-    render(
-      <MemoryRouter>
-        <ProfileSettingsEditor />
-      </MemoryRouter>,
-    );
+    renderComponent();
 
     const section = screen.getByTestId('unused-component-list');
     expect(within(section).getByText('Child')).toBeInTheDocument();
@@ -144,11 +151,7 @@ describe('ProfileSettingsEditor', () => {
       },
     ]);
 
-    render(
-      <MemoryRouter>
-        <ProfileSettingsEditor />
-      </MemoryRouter>,
-    );
+    renderComponent();
 
     const unused = screen.getByTestId('unused-component-list');
     const selected = screen.getByTestId('selected-component-list');
@@ -170,11 +173,7 @@ describe('ProfileSettingsEditor', () => {
       },
     ]);
 
-    render(
-      <MemoryRouter>
-        <ProfileSettingsEditor />
-      </MemoryRouter>,
-    );
+    renderComponent();
 
     const nameInput = screen.getByTestId('settings-name');
     expect(nameInput).toHaveValue(initialName);

--- a/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.tsx
@@ -27,6 +27,7 @@ import {
   getProfileChildren,
   getSettingsChildren,
 } from '../../utils';
+import { DefaultProfileSettingsOption } from '../DefaultProfileSettingsOption';
 import { ComponentType } from './BaseComponent';
 import { ComponentList } from './ComponentList';
 import { DraggingComponent } from './DraggingComponent';
@@ -47,6 +48,7 @@ export const ProfileSettingsEditor = () => {
 
   const {
     fullProfile,
+    selectedProfile,
     profileSettings,
     unusedComponents,
     selectedComponents,
@@ -60,6 +62,7 @@ export const ProfileSettingsEditor = () => {
     setIsModified,
   } = useManageProfileSettingsState([
     'fullProfile',
+    'selectedProfile',
     'profileSettings',
     'unusedComponents',
     'selectedComponents',
@@ -175,6 +178,11 @@ export const ProfileSettingsEditor = () => {
           <Input value={settingsName} onChange={handleNameChange} data-testid="settings-name" />
         </label>
       </div>
+
+      <DefaultProfileSettingsOption
+        selectedProfileId={selectedProfile.id}
+        selectedProfileSettingsId={profileSettings.id}
+      />
 
       <ResetComponents />
 

--- a/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.tsx
@@ -180,8 +180,8 @@ export const ProfileSettingsEditor = () => {
       </div>
 
       <DefaultProfileSettingsOption
-        selectedProfileId={selectedProfile.id}
-        selectedProfileSettingsId={profileSettings.id}
+        selectedProfileId={selectedProfile?.id}
+        selectedProfileSettingsId={profileSettings?.id}
       />
 
       <ResetComponents />

--- a/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.test.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.test.tsx
@@ -10,6 +10,7 @@ import { ProfileSettingsList } from './ProfileSettingsList';
 describe('ProfileSettingsList', () => {
   const mockSetIsManageProfileSettingsUnsavedModalOpen = jest.fn();
   const mockSetIsCreating = jest.fn();
+  const mockSetIsPreferredProfileSettings = jest.fn();
   const renderComponent = (modified: boolean) => {
     const queryClient = new QueryClient({
       defaultOptions: {
@@ -40,6 +41,7 @@ describe('ProfileSettingsList', () => {
           },
           isModified: modified,
           setIsCreating: mockSetIsCreating,
+          setIsPreferredProfileSettings: mockSetIsPreferredProfileSettings,
         },
       },
       {
@@ -71,6 +73,7 @@ describe('ProfileSettingsList', () => {
     waitFor(() => {
       expect(mockSetIsManageProfileSettingsUnsavedModalOpen).toHaveBeenCalledWith(true);
       expect(mockSetIsCreating).not.toHaveBeenCalled();
+      expect(mockSetIsPreferredProfileSettings).not.toHaveBeenCalled();
     });
   });
 
@@ -82,6 +85,7 @@ describe('ProfileSettingsList', () => {
     waitFor(() => {
       expect(mockSetIsManageProfileSettingsUnsavedModalOpen).not.toHaveBeenCalled();
       expect(mockSetIsCreating).toHaveBeenCalledWith(true);
+      expect(mockSetIsPreferredProfileSettings).toHaveBeenCalledWith(false);
     });
   });
 
@@ -94,6 +98,7 @@ describe('ProfileSettingsList', () => {
     waitFor(() => {
       expect(mockSetIsManageProfileSettingsUnsavedModalOpen).not.toHaveBeenCalled();
       expect(mockSetIsCreating).not.toHaveBeenCalled();
+      expect(mockSetIsPreferredProfileSettings).not.toHaveBeenCalled();
     });
   });
 
@@ -105,6 +110,7 @@ describe('ProfileSettingsList', () => {
     waitFor(() => {
       expect(mockSetIsManageProfileSettingsUnsavedModalOpen).toHaveBeenCalledWith(true);
       expect(mockSetIsCreating).not.toHaveBeenCalled();
+      expect(mockSetIsPreferredProfileSettings).not.toHaveBeenCalled();
     });
   });
 
@@ -116,6 +122,7 @@ describe('ProfileSettingsList', () => {
     waitFor(() => {
       expect(mockSetIsManageProfileSettingsUnsavedModalOpen).not.toHaveBeenCalled();
       expect(mockSetIsCreating).toHaveBeenCalledWith(false);
+      expect(mockSetIsPreferredProfileSettings).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.test.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.test.tsx
@@ -32,6 +32,16 @@ describe('ProfileSettingsList', () => {
         },
       ],
     );
+    queryClient.setQueryData(
+      ['preferredProfileSettings', '3'],
+      [
+        {
+          id: 18,
+          profileId: 3,
+          name: 'eighteen',
+        },
+      ],
+    );
     setInitialGlobalState([
       {
         store: useManageProfileSettingsStore,
@@ -63,6 +73,16 @@ describe('ProfileSettingsList', () => {
     renderComponent(false);
 
     expect(screen.getByTestId('profile-settings-select-section')).toBeInTheDocument();
+  });
+
+  it('labels the preferred setting in the options list', async () => {
+    renderComponent(false);
+
+    const selectInput = screen.getByTestId('profile-settings-select');
+
+    await fireEvent.change(selectInput, { target: { value: '18' } });
+
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent(/ld\.preferred/);
   });
 
   it('opens a confirmation modal when attempting to create while modified', async () => {

--- a/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.tsx
@@ -58,12 +58,12 @@ export const ProfileSettingsList = () => {
     const settingsWithDefault = settingsMeta
       ? BASE_SETTINGS_OPTIONS.concat(settingsMeta.map(metaToOption))
       : BASE_SETTINGS_OPTIONS;
-    settingsWithDefault.map(option => {
+    return settingsWithDefault.map(option => {
       if (option.value === preferredProfileSettings?.find(p => p.profileId === selectedProfile.id)?.id.toString()) {
         option.label += ' (' + formatMessage({ id: 'ld.preferred' }) + ')';
       }
+      return option;
     });
-    return settingsWithDefault;
   }, [settingsMeta, preferredProfileSettings, selectedProfile]);
 
   const handleChange = (selected: SelectValue) => {

--- a/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { BASE_SETTINGS_OPTIONS } from '@/common/constants/profileSettings.constants';
 import { Button, ButtonType } from '@/components/Button';
 import { Select, SelectValue } from '@/components/Select';
 
-import { useLoadProfileSettingsMeta } from '@/features/profiles';
+import { useLoadProfileSettingsMeta, usePreferredProfileSettings } from '@/features/profiles';
 
 import { useManageProfileSettingsState, useUIState } from '@/store';
 
@@ -49,11 +49,22 @@ export const ProfileSettingsList = () => {
 
   const { setIsManageProfileSettingsUnsavedModalOpen } = useUIState(['setIsManageProfileSettingsUnsavedModalOpen']);
 
+  const { formatMessage } = useIntl();
+
   const { data: settingsMeta } = useLoadProfileSettingsMeta(selectedProfile.id);
+  const { data: preferredProfileSettings } = usePreferredProfileSettings(selectedProfile.id);
 
   const settingsMetaOptions = useMemo(() => {
-    return settingsMeta ? BASE_SETTINGS_OPTIONS.concat(settingsMeta.map(metaToOption)) : BASE_SETTINGS_OPTIONS;
-  }, [settingsMeta]);
+    const settingsWithDefault = settingsMeta
+      ? BASE_SETTINGS_OPTIONS.concat(settingsMeta.map(metaToOption))
+      : BASE_SETTINGS_OPTIONS;
+    settingsWithDefault.map(option => {
+      if (option.value === preferredProfileSettings?.find(p => p.profileId === selectedProfile.id)?.id.toString()) {
+        option.label += ' (' + formatMessage({ id: 'ld.preferred' }) + ')';
+      }
+    });
+    return settingsWithDefault;
+  }, [settingsMeta, preferredProfileSettings, selectedProfile]);
 
   const handleChange = (selected: SelectValue) => {
     if (selected.value !== '') {

--- a/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.tsx
@@ -30,6 +30,7 @@ export const ProfileSettingsList = () => {
     setIsCreating,
     setIsCreatingSettingsNext,
     setIsEditingSettingsNext,
+    setIsPreferredProfileSettings,
     setNextSelectedSettingsMeta,
   } = useManageProfileSettingsState([
     'isModified',
@@ -40,6 +41,7 @@ export const ProfileSettingsList = () => {
     'setIsCreating',
     'setIsCreatingSettingsNext',
     'setIsEditingSettingsNext',
+    'setIsPreferredProfileSettings',
     'setNextSelectedSettingsMeta',
   ]);
 
@@ -79,6 +81,7 @@ export const ProfileSettingsList = () => {
       setIsCreating(true);
       setSelectedProfileSettingsMeta(null);
       setSettingsName('');
+      setIsPreferredProfileSettings(false);
     }
   };
 

--- a/src/features/manageProfileSettings/hooks/useResetSettings.ts
+++ b/src/features/manageProfileSettings/hooks/useResetSettings.ts
@@ -8,6 +8,7 @@ export const useResetSettings = () => {
     resetProfileSettings,
     resetSettingsName,
     resetNextSelectedProfile,
+    resetIsPreferredProfileSettings,
   } = useManageProfileSettingsState();
 
   const resetSettings = () => {
@@ -17,6 +18,7 @@ export const useResetSettings = () => {
 
   const resetSettingsExceptModified = () => {
     resetIsSettingsActive();
+    resetIsPreferredProfileSettings();
     resetSettingsName();
     resetSelectedProfileSettingsMeta();
     resetProfileSettings();

--- a/src/features/manageProfileSettings/hooks/useSaveProfileSettings.test.tsx
+++ b/src/features/manageProfileSettings/hooks/useSaveProfileSettings.test.tsx
@@ -5,7 +5,12 @@ import { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react';
 
-import { createProfileSettings, savePreferredProfile, saveProfileSettings } from '@/common/api/profiles.api';
+import {
+  createProfileSettings,
+  savePreferredProfile,
+  savePreferredProfileSettings,
+  saveProfileSettings,
+} from '@/common/api/profiles.api';
 import { StatusType } from '@/common/constants/status.constants';
 import { UserNotificationFactory } from '@/common/services/userNotification';
 
@@ -18,6 +23,7 @@ jest.mock('@/common/api/profiles.api', () => ({
   savePreferredProfile: jest.fn(),
   saveProfileSettings: jest.fn(),
   createProfileSettings: jest.fn(),
+  savePreferredProfileSettings: jest.fn(),
 }));
 jest.mock('@/common/services/userNotification', () => ({
   UserNotificationFactory: {
@@ -34,9 +40,12 @@ const createWrapper = () => {
     },
   });
 
-  return ({ children }: { children: ReactNode }) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  );
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  };
 };
 
 describe('useSaveProfileSettings', () => {
@@ -79,7 +88,8 @@ describe('useSaveProfileSettings', () => {
         },
       ]);
 
-      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper: createWrapper() });
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper });
       await act(async () => {
         await result.current.saveSettings();
       });
@@ -117,7 +127,8 @@ describe('useSaveProfileSettings', () => {
         },
       ]);
 
-      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper: createWrapper() });
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper });
       await act(async () => {
         await result.current.saveSettings();
       });
@@ -155,7 +166,8 @@ describe('useSaveProfileSettings', () => {
         },
       ]);
 
-      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper: createWrapper() });
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper });
       await act(async () => {
         await result.current.saveSettings();
       });
@@ -197,7 +209,8 @@ describe('useSaveProfileSettings', () => {
         },
       ]);
 
-      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper: createWrapper() });
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper });
       await act(async () => {
         await result.current.saveSettings();
       });
@@ -236,7 +249,8 @@ describe('useSaveProfileSettings', () => {
         },
       ]);
 
-      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper: createWrapper() });
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper });
       await act(async () => {
         await result.current.saveSettings();
       });
@@ -245,7 +259,48 @@ describe('useSaveProfileSettings', () => {
         active: false,
         children: [],
         name: 'settings-thing',
+        profileId: 'another',
       });
+    });
+
+    it('updates preferred profile setting', async () => {
+      setInitialGlobalState([
+        {
+          store: useProfileState,
+          state: {
+            preferredProfiles: [],
+          },
+        },
+        {
+          store: useManageProfileSettingsState,
+          state: {
+            selectedProfile: {
+              id: 'another',
+              name: 'another',
+              resourceType: 'for-type',
+            },
+            isTypeDefaultProfile: true,
+            isCreating: false,
+            isPreferredProfileSettings: true,
+            selectedProfileSettingsMeta: {
+              id: 44,
+              profileId: 'another',
+              name: 'settings-thing',
+            },
+            settingsName: 'settings-thing',
+          },
+        },
+      ]);
+
+      const { queryClient, wrapper } = createWrapper();
+      queryClient.setQueryData(['preferredProfileSettings', 'another'], []);
+
+      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper });
+      await act(async () => {
+        await result.current.saveSettings();
+      });
+
+      expect(savePreferredProfileSettings).toHaveBeenCalledWith('another', 44);
     });
 
     it('shows loading at start and removes it at end', async () => {
@@ -276,7 +331,8 @@ describe('useSaveProfileSettings', () => {
       ]);
       (createProfileSettings as jest.Mock).mockResolvedValue({ id: 'meta-one' });
 
-      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper: createWrapper() });
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper });
       await act(async () => {
         await result.current.saveSettings();
       });

--- a/src/features/manageProfileSettings/hooks/useSaveProfileSettings.ts
+++ b/src/features/manageProfileSettings/hooks/useSaveProfileSettings.ts
@@ -100,7 +100,6 @@ export const useSaveProfileSettings = () => {
       }
       addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, errKey));
     }
-    return;
   };
 
   const saveAndSetPreferredProfileSetting = async (settingsMeta: ProfileSettingsMeta | undefined) => {

--- a/src/features/manageProfileSettings/hooks/useSaveProfileSettings.ts
+++ b/src/features/manageProfileSettings/hooks/useSaveProfileSettings.ts
@@ -7,9 +7,11 @@ import { checkHasErrorOfCodeType } from '@/common/helpers/api.helper';
 import { logger } from '@/common/services/logger';
 import { UserNotificationFactory } from '@/common/services/userNotification';
 
+import { usePreferredProfileSettings, usePreferredProfileSettingsMutations } from '@/features/profiles';
+
 import { useLoadingState, useManageProfileSettingsState, useProfileState, useStatusState } from '@/store';
 
-import { determinePreferredAction, generateSettings } from '../utils';
+import { determinePreferredAction, determinePreferredSettingsAction, generateSettings } from '../utils';
 
 export const useSaveProfileSettings = () => {
   const queryClient = useQueryClient();
@@ -18,6 +20,7 @@ export const useSaveProfileSettings = () => {
   const { addStatusMessagesItem } = useStatusState(['addStatusMessagesItem']);
   const {
     isCreating,
+    isPreferredProfileSettings,
     isSettingsActive,
     isTypeDefaultProfile,
     selectedProfile,
@@ -31,6 +34,7 @@ export const useSaveProfileSettings = () => {
     setSelectedProfileSettingsMeta,
   } = useManageProfileSettingsState([
     'isCreating',
+    'isPreferredProfileSettings',
     'isSettingsActive',
     'isTypeDefaultProfile',
     'selectedProfile',
@@ -43,6 +47,8 @@ export const useSaveProfileSettings = () => {
     'setProfileSettings',
     'setSelectedProfileSettingsMeta',
   ]);
+  const { data: preferredProfileSettings } = usePreferredProfileSettings(selectedProfile?.id);
+  const { removePreferredProfileSettings, updatePreferredProfileSettings } = usePreferredProfileSettingsMutations();
 
   const saveAndSetPreferred = async () => {
     const preferredAction = determinePreferredAction(selectedProfile, preferredProfiles, isTypeDefaultProfile);
@@ -60,7 +66,13 @@ export const useSaveProfileSettings = () => {
   };
 
   const saveAndSetSettings = async () => {
-    const settingsToSave = generateSettings(selectedComponents, unusedComponents, isSettingsActive, settingsName);
+    const settingsToSave = generateSettings(
+      selectedProfile.id,
+      selectedComponents,
+      unusedComponents,
+      isSettingsActive,
+      settingsName,
+    );
     let settingsMeta: ProfileSettingsMeta;
 
     try {
@@ -71,10 +83,11 @@ export const useSaveProfileSettings = () => {
         settingsMeta = await createProfileSettings(selectedProfile.id, settingsToSave);
         setIsCreating(false);
       }
-      setProfileSettings({ ...settingsToSave, missingFromSettings: [] });
+      setProfileSettings({ ...settingsToSave, missingFromSettings: [], id: settingsMeta.id });
       queryClient.refetchQueries({ queryKey: ['profileSettingsMeta', String(selectedProfile.id)] });
       queryClient.refetchQueries({ queryKey: ['profileSettings', String(selectedProfile.id), settingsMeta.id] });
       setSelectedProfileSettingsMeta(settingsMeta);
+      return settingsMeta;
     } catch (error) {
       logger.error('Failed to set profile settings:', error);
       let errKey = 'ld.error.saveProfileSettings';
@@ -87,13 +100,31 @@ export const useSaveProfileSettings = () => {
       }
       addStatusMessagesItem?.(UserNotificationFactory.createMessage(StatusType.error, errKey));
     }
+    return;
+  };
+
+  const saveAndSetPreferredProfileSetting = async (settingsMeta: ProfileSettingsMeta | undefined) => {
+    if (settingsMeta) {
+      determinePreferredSettingsAction({
+        profileId: selectedProfile.id,
+        profileSettingsId: settingsMeta.id,
+        preferredProfileSettings,
+        isPreferredProfileSettings,
+        remove: removePreferredProfileSettings,
+        update: updatePreferredProfileSettings,
+      });
+    }
+    // If an undefined settingsMeta is being passed in, there was an error preceding it,
+    // so no additional error message should be shown. Do nothing, the user needs to
+    // fix something else before this will be tried again.
   };
 
   const saveSettings = async () => {
     try {
       setIsLoading(true);
       await saveAndSetPreferred();
-      await saveAndSetSettings();
+      const settingsMeta = await saveAndSetSettings();
+      await saveAndSetPreferredProfileSetting(settingsMeta);
       setIsModified(false);
     } finally {
       setIsLoading(false);

--- a/src/features/manageProfileSettings/utils/index.ts
+++ b/src/features/manageProfileSettings/utils/index.ts
@@ -1,4 +1,4 @@
 export { FilteredPointerSensor, FilteredKeyboardSensor } from './filteredSensors';
 export { componentFromId, getProfileChildren, getSettingsChildren, childrenDifference } from './children';
 export { chooseModifiers } from './modifiers';
-export { determinePreferredAction, generateSettings } from './profileSave';
+export { determinePreferredAction, determinePreferredSettingsAction, generateSettings } from './profileSave';

--- a/src/features/manageProfileSettings/utils/profileSave.test.ts
+++ b/src/features/manageProfileSettings/utils/profileSave.test.ts
@@ -1,6 +1,7 @@
 import { deletePreferredProfile, savePreferredProfile } from '@/common/api/profiles.api';
+import { PROFILE_SETTINGS_DEFAULT_OPTION } from '@/common/constants/profileSettings.constants';
 
-import { determinePreferredAction, generateSettings } from './profileSave';
+import { determinePreferredAction, determinePreferredSettingsAction, generateSettings } from './profileSave';
 
 jest.mock('@/common/api/profiles.api', () => ({
   deletePreferredProfile: jest.fn(),
@@ -163,6 +164,108 @@ describe('profileSave', () => {
     });
   });
 
+  describe('determinePreferredSettingsAction', () => {
+    const mockUpdate = jest.fn();
+    const mockRemove = jest.fn();
+    const mockProfileId = 100;
+    const mockProfileSettingsId = 24;
+    const mockPreferredProfileSettings = [
+      {
+        id: mockProfileSettingsId,
+        profileId: mockProfileId,
+        name: 'preferred',
+      },
+    ];
+
+    it('skips any action when preferred profile settings remains the same', async () => {
+      determinePreferredSettingsAction({
+        profileId: mockProfileId,
+        profileSettingsId: mockProfileSettingsId,
+        preferredProfileSettings: mockPreferredProfileSettings,
+        isPreferredProfileSettings: true,
+        remove: mockRemove,
+        update: mockUpdate,
+      });
+
+      expect(mockRemove).not.toHaveBeenCalled();
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('skips any action when no preferred profile settings and none set', async () => {
+      determinePreferredSettingsAction({
+        profileId: mockProfileId,
+        profileSettingsId: mockProfileSettingsId,
+        preferredProfileSettings: [],
+        isPreferredProfileSettings: false,
+        remove: mockRemove,
+        update: mockUpdate,
+      });
+
+      expect(mockRemove).not.toHaveBeenCalled();
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('removes preferred profile setting when previously set but now unset', async () => {
+      determinePreferredSettingsAction({
+        profileId: mockProfileId,
+        profileSettingsId: mockProfileSettingsId,
+        preferredProfileSettings: mockPreferredProfileSettings,
+        isPreferredProfileSettings: false,
+        remove: mockRemove,
+        update: mockUpdate,
+      });
+
+      expect(mockRemove).toHaveBeenCalledWith({ profileId: mockProfileId });
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('removes preferred profile setting when trying to set to default', async () => {
+      determinePreferredSettingsAction({
+        profileId: mockProfileId,
+        profileSettingsId: PROFILE_SETTINGS_DEFAULT_OPTION,
+        preferredProfileSettings: mockPreferredProfileSettings,
+        isPreferredProfileSettings: true,
+        remove: mockRemove,
+        update: mockUpdate,
+      });
+
+      expect(mockRemove).toHaveBeenCalledWith({ profileId: mockProfileId });
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('updates preferred profile setting when given a new profile setting', async () => {
+      const alternateProfileSettingsId = 846;
+      determinePreferredSettingsAction({
+        profileId: mockProfileId,
+        profileSettingsId: alternateProfileSettingsId,
+        preferredProfileSettings: mockPreferredProfileSettings,
+        isPreferredProfileSettings: true,
+        remove: mockRemove,
+        update: mockUpdate,
+      });
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        profileId: mockProfileId,
+        profileSettingsId: alternateProfileSettingsId,
+      });
+      expect(mockRemove).not.toHaveBeenCalled();
+    });
+
+    it('updates preferred profile setting when none previously set', async () => {
+      determinePreferredSettingsAction({
+        profileId: mockProfileId,
+        profileSettingsId: mockProfileSettingsId,
+        preferredProfileSettings: [],
+        isPreferredProfileSettings: true,
+        remove: mockRemove,
+        update: mockUpdate,
+      });
+
+      expect(mockUpdate).toHaveBeenCalledWith({ profileId: mockProfileId, profileSettingsId: mockProfileSettingsId });
+      expect(mockRemove).not.toHaveBeenCalled();
+    });
+  });
+
   describe('generateSettings', () => {
     it('generates expected settings from selected and unused components', async () => {
       const unusedComponents = [
@@ -185,9 +288,10 @@ describe('profileSave', () => {
         },
       ];
 
-      const result = generateSettings(selectedComponents, unusedComponents, true, 'some-name');
+      const result = generateSettings(22, selectedComponents, unusedComponents, true, 'some-name');
 
       expect(result).toEqual({
+        profileId: 22,
         active: true,
         name: 'some-name',
         children: [

--- a/src/features/manageProfileSettings/utils/profileSave.ts
+++ b/src/features/manageProfileSettings/utils/profileSave.ts
@@ -1,7 +1,18 @@
 import { deletePreferredProfile, savePreferredProfile } from '@/common/api/profiles.api';
 import { createUpdatedPreferredProfiles } from '@/common/helpers/profileActions.helper';
 
+import type { DeletePreferredProfileSettingsParams, SavePreferredProfileSettingsParams } from '@/features/profiles';
+
 import { type PreferredProfiles } from '@/store';
+
+interface DeterminePreferredSettingsParams {
+  profileId: string | number;
+  profileSettingsId: string | number;
+  preferredProfileSettings: ProfileSettingsMetaList | undefined;
+  isPreferredProfileSettings: boolean;
+  remove: (params: DeletePreferredProfileSettingsParams) => void;
+  update: (params: SavePreferredProfileSettingsParams) => void;
+}
 
 const saveAndUpdatePreferredProfiles = async (
   selectedProfile: ProfileDTO,
@@ -54,7 +65,40 @@ export const determinePreferredAction = (
   return null;
 };
 
+export const determinePreferredSettingsAction = ({
+  profileId,
+  profileSettingsId,
+  preferredProfileSettings,
+  isPreferredProfileSettings,
+  remove,
+  update,
+}: DeterminePreferredSettingsParams) => {
+  const preferred = preferredProfileSettings?.find(p => p.profileId === profileId);
+
+  if (preferred) {
+    if (preferred.id === profileSettingsId) {
+      if (!isPreferredProfileSettings) {
+        // This was preferred but is now not; delete the preferred settings for this profile.
+        remove({ profileId });
+      }
+    } else if (isPreferredProfileSettings) {
+      // This was not preferred but now is; update to set it as the preferred settings.
+      if (typeof profileSettingsId === 'number') {
+        update({ profileId, profileSettingsId });
+      } else {
+        // Unless profileSettingsId is PROFILE_SETTINGS_DEFAULT_OPTION (a string),
+        // in which case remove preferred settings for this profile.
+        remove({ profileId });
+      }
+    }
+  } else if (isPreferredProfileSettings) {
+    // There was no preferred settings, but now this is; update to set it as the preferred settings.
+    if (typeof profileSettingsId === 'number') update({ profileId, profileSettingsId });
+  }
+};
+
 export const generateSettings = (
+  profileId: string | number,
   selectedComponents: ProfileSettingComponent[],
   unusedComponents: ProfileSettingComponent[],
   isSettingsActive: boolean,
@@ -79,7 +123,8 @@ export const generateSettings = (
   });
 
   return {
-    name: name,
+    profileId,
+    name,
     active: isSettingsActive,
     children: settingsChildren,
   } as ProfileSettings;

--- a/src/features/profiles/components/ModalChooseProfile/ModalChooseProfile.test.tsx
+++ b/src/features/profiles/components/ModalChooseProfile/ModalChooseProfile.test.tsx
@@ -1,6 +1,5 @@
 import { createModalContainer } from '@/test/__mocks__/common/misc/createModalContainer.mock';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import { ModalChooseProfile } from './ModalChooseProfile';
@@ -14,33 +13,6 @@ const mockProfileSelectionType = {
   action: 'set',
   resourceTypeURL: 'http://bibfra.me/vocab/lite/Work' as ResourceTypeURL,
 } as ProfileSelectionType;
-
-const createWrapper = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  });
-
-  queryClient.setQueryData(
-    ['profileSettingsMeta', 'profile_1'],
-    [
-      {
-        id: 1,
-        name: 'one',
-      },
-      {
-        id: 2,
-        name: 'two',
-      },
-    ],
-  );
-
-  return ({ children }: { children: React.ReactNode }) => {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
-  };
-};
 
 describe('ModalChooseProfile', () => {
   const onCancel = jest.fn();
@@ -65,7 +37,6 @@ describe('ModalChooseProfile', () => {
         onClose={onClose}
         profiles={mockProfiles}
       />,
-      { wrapper: createWrapper() },
     );
 
     // Check that modal content is rendered
@@ -93,7 +64,6 @@ describe('ModalChooseProfile', () => {
         onClose={onClose}
         profiles={mockProfiles}
       />,
-      { wrapper: createWrapper() },
     );
 
     expect(screen.getByTestId('select-profile')).toHaveValue('profile_1');
@@ -109,7 +79,6 @@ describe('ModalChooseProfile', () => {
         onClose={onClose}
         profiles={mockProfiles}
       />,
-      { wrapper: createWrapper() },
     );
 
     const selectElement = screen.getByTestId('select-profile');
@@ -128,7 +97,6 @@ describe('ModalChooseProfile', () => {
         onClose={onClose}
         profiles={mockProfiles}
       />,
-      { wrapper: createWrapper() },
     );
 
     const checkbox = screen.getByRole('checkbox');
@@ -155,7 +123,6 @@ describe('ModalChooseProfile', () => {
         onClose={onClose}
         profiles={mockProfiles}
       />,
-      { wrapper: createWrapper() },
     );
 
     const selectElement = screen.getByTestId('select-profile');
@@ -163,7 +130,7 @@ describe('ModalChooseProfile', () => {
     fireEvent.click(screen.getByTestId('modal-button-submit'));
 
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith('profile_2', 'default', false);
+      expect(onSubmit).toHaveBeenCalledWith('profile_2', false);
     });
   });
 
@@ -177,7 +144,6 @@ describe('ModalChooseProfile', () => {
         onClose={onClose}
         profiles={mockProfiles}
       />,
-      { wrapper: createWrapper() },
     );
 
     fireEvent.click(screen.getByTestId('modal-button-cancel'));
@@ -194,7 +160,6 @@ describe('ModalChooseProfile', () => {
         onClose={onClose}
         profiles={mockProfiles}
       />,
-      { wrapper: createWrapper() },
     );
 
     fireEvent.click(screen.getByTestId('modal-overlay'));
@@ -211,7 +176,6 @@ describe('ModalChooseProfile', () => {
         onClose={onClose}
         profiles={mockProfiles}
       />,
-      { wrapper: createWrapper() },
     );
 
     expect(container.firstChild).toBeNull();
@@ -227,7 +191,6 @@ describe('ModalChooseProfile', () => {
         onClose={onClose}
         profiles={[]}
       />,
-      { wrapper: createWrapper() },
     );
 
     rerender(
@@ -244,7 +207,7 @@ describe('ModalChooseProfile', () => {
     fireEvent.click(screen.getByTestId('modal-button-submit'));
 
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith('profile_1', 'default', false);
+      expect(onSubmit).toHaveBeenCalledWith('profile_1', false);
       expect(onSubmit).not.toHaveBeenCalledWith('0');
       expect(onSubmit).not.toHaveBeenCalledWith(undefined);
     });
@@ -267,7 +230,6 @@ describe('ModalChooseProfile', () => {
         preferredProfiles={preferredProfiles}
         resourceTypeURL="http://bibfra.me/vocab/lite/Work"
       />,
-      { wrapper: createWrapper() },
     );
 
     const checkbox = screen.getByRole('checkbox');
@@ -291,7 +253,6 @@ describe('ModalChooseProfile', () => {
         preferredProfiles={preferredProfiles}
         resourceTypeURL="http://bibfra.me/vocab/lite/Work"
       />,
-      { wrapper: createWrapper() },
     );
 
     const checkbox = screen.getByRole('checkbox');
@@ -314,7 +275,6 @@ describe('ModalChooseProfile', () => {
         preferredProfiles={preferredProfiles}
         resourceTypeURL="http://bibfra.me/vocab/lite/Work"
       />,
-      { wrapper: createWrapper() },
     );
 
     const selectElement = screen.getByTestId('select-profile');
@@ -346,7 +306,6 @@ describe('ModalChooseProfile', () => {
         profiles={mockProfiles}
         selectedProfileId="profile_1"
       />,
-      { wrapper: createWrapper() },
     );
 
     const checkbox = screen.getByRole('checkbox');
@@ -369,33 +328,9 @@ describe('ModalChooseProfile', () => {
         selectedProfileId="profile_1"
         preferredProfiles={preferredProfiles}
       />,
-      { wrapper: createWrapper() },
     );
 
     const checkbox = screen.getByRole('checkbox');
     expect(checkbox).not.toBeChecked();
-  });
-
-  test('changing the selected settings changes the submitted settings ID', async () => {
-    render(
-      <ModalChooseProfile
-        isOpen={true}
-        profileSelectionType={mockProfileSelectionType}
-        onCancel={onCancel}
-        onSubmit={onSubmit}
-        onClose={onClose}
-        profiles={mockProfiles}
-        selectedProfileId="profile_1"
-      />,
-      { wrapper: createWrapper() },
-    );
-
-    fireEvent.change(screen.getByTestId('select-profile-settings'), { target: { value: '2' } });
-
-    fireEvent.click(screen.getByTestId('modal-button-submit'));
-
-    await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith('profile_1', '2', false);
-    });
   });
 });

--- a/src/features/profiles/components/ModalChooseProfile/ModalChooseProfile.tsx
+++ b/src/features/profiles/components/ModalChooseProfile/ModalChooseProfile.tsx
@@ -1,7 +1,6 @@
-import { FC, memo, useEffect, useMemo, useState } from 'react';
+import { FC, memo, useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { PROFILE_SETTINGS_DEFAULT_OPTION } from '@/common/constants/profileSettings.constants';
 import {
   PROFILE_SELECTION_LABEL_IDS,
   getProfileSelectionMessageIds,
@@ -11,23 +10,15 @@ import {
 import { Modal } from '@/components/Modal';
 import { Select, SelectValue } from '@/components/Select';
 
-import { useLoadProfileSettingsMeta } from '../../hooks';
 import { WarningMessages } from './WarningMessages';
 
 import './ModalChooseProfile.scss';
-
-const metaToOption = (meta: ProfileSettingsMeta) => {
-  return {
-    label: meta.name,
-    value: String(meta.id),
-  };
-};
 
 interface ModalChooseProfileProps {
   isOpen: boolean;
   profileSelectionType: ProfileSelectionType;
   onCancel: VoidFunction;
-  onSubmit: (profileId: string | number, profileSettingsId: string | number, isDefault?: boolean) => void;
+  onSubmit: (profileId: string | number, isDefault?: boolean) => void;
   onClose: VoidFunction;
   profiles: ProfileDTO[];
   selectedProfileId?: string | number | null;
@@ -49,24 +40,10 @@ export const ModalChooseProfile: FC<ModalChooseProfileProps> = memo(
   }) => {
     const { formatMessage } = useIntl();
     const [selectedValue, setSelectedValue] = useState<string | number>(selectedProfileId ?? profiles?.[0]?.id);
-    const [selectedSettingsValue, setSelectedSettingsValue] = useState<string | number>(
-      PROFILE_SETTINGS_DEFAULT_OPTION,
-    );
 
     const [isDefault, setIsDefault] = useState(() =>
       isProfilePreferred({ profileId: selectedProfileId ?? profiles?.[0]?.id, preferredProfiles, resourceTypeURL }),
     );
-
-    const SETTINGS_OPTION_DEFAULT = [
-      {
-        label: formatMessage({ id: 'ld.profileSettings.defaultSettings' }),
-        value: PROFILE_SETTINGS_DEFAULT_OPTION,
-      },
-    ];
-    const { data: settingsMeta } = useLoadProfileSettingsMeta(selectedValue);
-    const settingsMetaOptions = useMemo(() => {
-      return settingsMeta ? SETTINGS_OPTION_DEFAULT.concat(settingsMeta.map(metaToOption)) : SETTINGS_OPTION_DEFAULT;
-    }, [SETTINGS_OPTION_DEFAULT, settingsMeta]);
 
     useEffect(() => {
       if (profiles && profiles.length > 0 && !selectedValue) {
@@ -88,35 +65,18 @@ export const ModalChooseProfile: FC<ModalChooseProfileProps> = memo(
       setIsDefault(isProfilePreferred({ profileId: newValue, preferredProfiles, resourceTypeURL }));
     };
 
-    const onSettingsChange = (selected: SelectValue) => {
-      const newValue = selected.value;
-
-      setSelectedSettingsValue(newValue);
-    };
-
     const handleSubmit = () => {
-      onSubmit(selectedValue, selectedSettingsValue, isDefault);
+      onSubmit(selectedValue, isDefault);
     };
 
     const getProfileById = (id: string | number) => {
       return profiles.find(profile => profile.id === id);
     };
 
-    const getProfileSettingById = (id: string | number) => {
-      return settingsMeta?.find(settingMeta => settingMeta.id === id);
-    };
-
     const profileIdToSelectValue = (id: string | number) => {
       return {
         value: id,
         label: getProfileById(id)?.name,
-      } as SelectValue;
-    };
-
-    const profileSettingsIdToSelectValue = (id: string | number) => {
-      return {
-        value: id.toString(),
-        label: getProfileSettingById(id)?.name,
       } as SelectValue;
     };
 
@@ -136,7 +96,6 @@ export const ModalChooseProfile: FC<ModalChooseProfileProps> = memo(
     const labelSelect = formatMessage({ id: PROFILE_SELECTION_LABEL_IDS.select }, { type: typeLabel });
     const labelSetAsDefault = formatMessage({ id: PROFILE_SELECTION_LABEL_IDS.setAsDefault }, { type: typeLabel });
     const labelSubmit = formatMessage({ id: submitId });
-    const labelSettingsSelect = formatMessage({ id: 'ld.savedSettings' });
 
     return (
       <Modal
@@ -181,21 +140,6 @@ export const ModalChooseProfile: FC<ModalChooseProfileProps> = memo(
               <span>{labelSetAsDefault}</span>
             </label>
           </div>
-
-          {profileSelectionType.action === 'set' && (
-            <div className="modal-content-controls-block">
-              <h5>{labelSettingsSelect}</h5>
-              <Select
-                name={labelSettingsSelect}
-                id="select-profile-settings"
-                data-testid="select-profile-settings"
-                onChange={onSettingsChange}
-                value={profileSettingsIdToSelectValue(selectedSettingsValue)}
-                options={settingsMetaOptions}
-                disabled={settingsMetaOptions.length === 1}
-              ></Select>
-            </div>
-          )}
 
           {profileSelectionType.action === 'change' && (
             <WarningMessages

--- a/src/features/profiles/hooks/index.ts
+++ b/src/features/profiles/hooks/index.ts
@@ -3,6 +3,12 @@ export { useLoadProfileSettings } from './useLoadProfileSettings';
 export { useLoadProfileSettingsMeta } from './useLoadProfileSettingsMeta';
 export { useNavigateToCreatePage } from './useNavigateToCreatePage';
 export { usePreferredProfiles } from './usePreferredProfiles';
+export { preferredProfileSettingsOptions, usePreferredProfileSettings } from './usePreferredProfileSettings';
+export { usePreferredProfileSettingsMutations } from './usePreferredProfileSettingsMutations';
+export type {
+  DeletePreferredProfileSettingsParams,
+  SavePreferredProfileSettingsParams,
+} from './usePreferredProfileSettingsMutations';
 export { useProfileList } from './useProfileList';
 export { useProfileSelection } from './useProfileSelection';
 export { useProfileSelectionActions } from './useProfileSelectionActions';

--- a/src/features/profiles/hooks/usePreferredProfileSettings.test.tsx
+++ b/src/features/profiles/hooks/usePreferredProfileSettings.test.tsx
@@ -1,0 +1,72 @@
+import { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import * as profilesApi from '@/common/api/profiles.api';
+
+import { usePreferredProfileSettings } from './usePreferredProfileSettings';
+
+jest.mock('@/common/api/profiles.api');
+
+describe('usePreferredProfileSettings', () => {
+  let queryClient: QueryClient;
+
+  const createWrapper = () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    return Wrapper;
+  };
+
+  const mockFetchPreferredProfileSettings = profilesApi.fetchPreferredProfileSettings as jest.MockedFunction<
+    typeof profilesApi.fetchPreferredProfileSettings
+  >;
+
+  afterEach(() => {
+    queryClient?.clear();
+  });
+
+  describe('loadPreferredProfileSettings', () => {
+    it('returns the preferred profile settings for a given profile', async () => {
+      const mockProfileId = 3;
+      const mockResult = [
+        {
+          id: 25,
+          profileId: mockProfileId,
+          name: 'settings name',
+        },
+      ];
+      mockFetchPreferredProfileSettings.mockResolvedValue(mockResult);
+
+      const { result } = renderHook(() => usePreferredProfileSettings(mockProfileId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(mockFetchPreferredProfileSettings).toHaveBeenCalledWith(mockProfileId);
+        expect(result.current.data).toEqual(mockResult);
+      });
+    });
+
+    it('does not fetch when profile ID is null', async () => {
+      const { result } = renderHook(() => usePreferredProfileSettings(null), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(mockFetchPreferredProfileSettings).not.toHaveBeenCalled();
+        expect(result.current.data).toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/features/profiles/hooks/usePreferredProfileSettings.ts
+++ b/src/features/profiles/hooks/usePreferredProfileSettings.ts
@@ -1,0 +1,17 @@
+import { queryOptions, useQuery } from '@tanstack/react-query';
+
+import { fetchPreferredProfileSettings } from '@/common/api/profiles.api';
+
+export const preferredProfileSettingsOptions = (profileId: string | number | null) =>
+  queryOptions<ProfileSettingsMetaList>({
+    queryKey: ['preferredProfileSettings', String(profileId)],
+    queryFn: async () => {
+      return fetchPreferredProfileSettings(profileId!);
+    },
+    staleTime: Infinity,
+    enabled: !!profileId,
+  });
+
+export const usePreferredProfileSettings = (profileId: string | number | null) => {
+  return useQuery<ProfileSettingsMetaList>(preferredProfileSettingsOptions(profileId));
+};

--- a/src/features/profiles/hooks/usePreferredProfileSettingsMutations.test.tsx
+++ b/src/features/profiles/hooks/usePreferredProfileSettingsMutations.test.tsx
@@ -1,0 +1,94 @@
+import { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import * as profilesApi from '@/common/api/profiles.api';
+
+import { usePreferredProfileSettingsMutations } from './usePreferredProfileSettingsMutations';
+
+jest.mock('@/common/api/profiles.api');
+
+describe('usePreferredProfileSettings', () => {
+  let queryClient: QueryClient;
+
+  const createWrapper = () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    return Wrapper;
+  };
+
+  const mockSavePreferredProfileSettings = profilesApi.savePreferredProfileSettings as jest.MockedFunction<
+    typeof profilesApi.savePreferredProfileSettings
+  >;
+  const mockDeletePreferredProfileSettings = profilesApi.deletePreferredProfileSettings as jest.MockedFunction<
+    typeof profilesApi.deletePreferredProfileSettings
+  >;
+
+  afterEach(() => {
+    queryClient?.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('updatePreferredProfileSettings', () => {
+    it('calls the correct API method', async () => {
+      const mockProfileId = 993;
+      const mockProfileSettingsId = 21;
+      const mockResponse = new Response(JSON.stringify({ ok: true }), { status: 201 });
+      mockSavePreferredProfileSettings.mockResolvedValue(mockResponse);
+
+      const { result } = renderHook(() => usePreferredProfileSettingsMutations(), {
+        wrapper: createWrapper(),
+      });
+      const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+      result.current.updatePreferredProfileSettings({
+        profileId: mockProfileId,
+        profileSettingsId: mockProfileSettingsId,
+      });
+
+      await waitFor(() => {
+        expect(mockSavePreferredProfileSettings).toHaveBeenCalledWith(mockProfileId, mockProfileSettingsId);
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferredProfileSettings', String(mockProfileId)] });
+      });
+    });
+
+    it('handles errors with an error message', async () => {
+      // TODO
+    });
+  });
+
+  describe('removePreferredProfileSettings', () => {
+    it('calls the correct API method', async () => {
+      const mockProfileId = 744;
+      const mockResponse = new Response(JSON.stringify({ ok: true }), { status: 204 });
+      mockDeletePreferredProfileSettings.mockResolvedValue(mockResponse);
+
+      const { result } = renderHook(() => usePreferredProfileSettingsMutations(), {
+        wrapper: createWrapper(),
+      });
+      const setQueryDataSpy = jest.spyOn(queryClient, 'setQueryData');
+
+      result.current.removePreferredProfileSettings({ profileId: mockProfileId });
+
+      await waitFor(() => {
+        expect(mockDeletePreferredProfileSettings).toHaveBeenCalledWith(mockProfileId);
+        expect(setQueryDataSpy).toHaveBeenCalledWith(['preferredProfileSettings', String(mockProfileId)], []);
+      });
+    });
+
+    it('handles errors with an error message', async () => {
+      // TODO
+    });
+  });
+});

--- a/src/features/profiles/hooks/usePreferredProfileSettingsMutations.test.tsx
+++ b/src/features/profiles/hooks/usePreferredProfileSettingsMutations.test.tsx
@@ -1,3 +1,5 @@
+import { setInitialGlobalState } from '@/test/__mocks__/store';
+
 import { ReactNode } from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -5,11 +7,14 @@ import { renderHook, waitFor } from '@testing-library/react';
 
 import * as profilesApi from '@/common/api/profiles.api';
 
+import { useStatusStore } from '@/store';
+
 import { usePreferredProfileSettingsMutations } from './usePreferredProfileSettingsMutations';
 
 jest.mock('@/common/api/profiles.api');
 
 describe('usePreferredProfileSettings', () => {
+  const mockAddStatusMessagesItem = jest.fn();
   let queryClient: QueryClient;
 
   const createWrapper = () => {
@@ -41,9 +46,10 @@ describe('usePreferredProfileSettings', () => {
   });
 
   describe('updatePreferredProfileSettings', () => {
+    const mockProfileId = 993;
+    const mockProfileSettingsId = 21;
+
     it('calls the correct API method', async () => {
-      const mockProfileId = 993;
-      const mockProfileSettingsId = 21;
       const mockResponse = new Response(JSON.stringify({ ok: true }), { status: 201 });
       mockSavePreferredProfileSettings.mockResolvedValue(mockResponse);
 
@@ -64,13 +70,38 @@ describe('usePreferredProfileSettings', () => {
     });
 
     it('handles errors with an error message', async () => {
-      // TODO
+      const mockResponse = new Response(JSON.stringify({ ok: false }), { status: 400 });
+      mockSavePreferredProfileSettings.mockRejectedValue(mockResponse);
+
+      setInitialGlobalState([
+        {
+          store: useStatusStore,
+          state: {
+            addStatusMessagesItem: mockAddStatusMessagesItem,
+          },
+        },
+      ]);
+
+      const { result } = renderHook(() => usePreferredProfileSettingsMutations(), {
+        wrapper: createWrapper(),
+      });
+
+      result.current.updatePreferredProfileSettings({
+        profileId: mockProfileId,
+        profileSettingsId: mockProfileSettingsId,
+      });
+
+      await waitFor(() => {
+        expect(mockSavePreferredProfileSettings).toHaveBeenCalledWith(mockProfileId, mockProfileSettingsId);
+        expect(mockAddStatusMessagesItem).toHaveBeenCalled();
+      });
     });
   });
 
   describe('removePreferredProfileSettings', () => {
+    const mockProfileId = 744;
+
     it('calls the correct API method', async () => {
-      const mockProfileId = 744;
       const mockResponse = new Response(JSON.stringify({ ok: true }), { status: 204 });
       mockDeletePreferredProfileSettings.mockResolvedValue(mockResponse);
 
@@ -88,7 +119,28 @@ describe('usePreferredProfileSettings', () => {
     });
 
     it('handles errors with an error message', async () => {
-      // TODO
+      const mockResponse = new Response(JSON.stringify({ ok: false }), { status: 400 });
+      mockDeletePreferredProfileSettings.mockRejectedValue(mockResponse);
+
+      setInitialGlobalState([
+        {
+          store: useStatusStore,
+          state: {
+            addStatusMessagesItem: mockAddStatusMessagesItem,
+          },
+        },
+      ]);
+
+      const { result } = renderHook(() => usePreferredProfileSettingsMutations(), {
+        wrapper: createWrapper(),
+      });
+
+      result.current.removePreferredProfileSettings({ profileId: mockProfileId });
+
+      await waitFor(() => {
+        expect(mockDeletePreferredProfileSettings).toHaveBeenCalledWith(mockProfileId);
+        expect(mockAddStatusMessagesItem).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/features/profiles/hooks/usePreferredProfileSettingsMutations.ts
+++ b/src/features/profiles/hooks/usePreferredProfileSettingsMutations.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deletePreferredProfileSettings, savePreferredProfileSettings } from '@/common/api/profiles.api';
+
+export interface SavePreferredProfileSettingsParams {
+  profileId: string | number;
+  profileSettingsId: number;
+}
+
+export interface DeletePreferredProfileSettingsParams {
+  profileId: string | number;
+}
+
+export const usePreferredProfileSettingsMutations = () => {
+  const queryClient = useQueryClient();
+
+  const updateMutation = useMutation<Response, Error, SavePreferredProfileSettingsParams>({
+    mutationFn: async ({ profileId, profileSettingsId }) => {
+      return savePreferredProfileSettings(profileId, profileSettingsId);
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['preferredProfileSettings', String(variables.profileId)],
+      });
+    },
+    onError: () => {
+      // handle error
+    },
+  });
+
+  const deleteMutation = useMutation<Response, Error, DeletePreferredProfileSettingsParams>({
+    mutationFn: async ({ profileId }) => {
+      return deletePreferredProfileSettings(profileId);
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.setQueryData(['preferredProfileSettings', String(variables.profileId)], []);
+    },
+    onError: () => {
+      // TODO handle error
+    },
+  });
+
+  const updatePreferredProfileSettings = (params: SavePreferredProfileSettingsParams) => {
+    return updateMutation.mutate(params);
+  };
+
+  const removePreferredProfileSettings = (params: DeletePreferredProfileSettingsParams) => {
+    return deleteMutation.mutate(params);
+  };
+
+  return {
+    updatePreferredProfileSettings,
+    removePreferredProfileSettings,
+  };
+};

--- a/src/features/profiles/hooks/usePreferredProfileSettingsMutations.ts
+++ b/src/features/profiles/hooks/usePreferredProfileSettingsMutations.ts
@@ -1,6 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { deletePreferredProfileSettings, savePreferredProfileSettings } from '@/common/api/profiles.api';
+import { StatusType } from '@/common/constants/status.constants';
+import { logger } from '@/common/services/logger';
+import { UserNotificationFactory } from '@/common/services/userNotification';
+
+import { useStatusState } from '@/store';
 
 export interface SavePreferredProfileSettingsParams {
   profileId: string | number;
@@ -13,6 +18,7 @@ export interface DeletePreferredProfileSettingsParams {
 
 export const usePreferredProfileSettingsMutations = () => {
   const queryClient = useQueryClient();
+  const { addStatusMessagesItem } = useStatusState(['addStatusMessagesItem']);
 
   const updateMutation = useMutation<Response, Error, SavePreferredProfileSettingsParams>({
     mutationFn: async ({ profileId, profileSettingsId }) => {
@@ -23,8 +29,11 @@ export const usePreferredProfileSettingsMutations = () => {
         queryKey: ['preferredProfileSettings', String(variables.profileId)],
       });
     },
-    onError: () => {
-      // handle error
+    onError: error => {
+      logger.error('Failed to save preferred profile settings', error);
+      addStatusMessagesItem?.(
+        UserNotificationFactory.createMessage(StatusType.error, 'ld.error.updatePreferredProfileSettings'),
+      );
     },
   });
 
@@ -35,8 +44,11 @@ export const usePreferredProfileSettingsMutations = () => {
     onSuccess: (_data, variables) => {
       queryClient.setQueryData(['preferredProfileSettings', String(variables.profileId)], []);
     },
-    onError: () => {
-      // TODO handle error
+    onError: error => {
+      logger.error('Failed to delete preferred profile settings', error);
+      addStatusMessagesItem?.(
+        UserNotificationFactory.createMessage(StatusType.error, 'ld.error.updatePreferredProfileSettings'),
+      );
     },
   });
 

--- a/src/features/profiles/hooks/useProfileSelectionActions.test.ts
+++ b/src/features/profiles/hooks/useProfileSelectionActions.test.ts
@@ -53,7 +53,6 @@ describe('useProfileSelectionActions', () => {
   const mockSetPreferredProfiles = jest.fn();
   const mockQueryParams = { param: 'value' };
   const mockProfileId = 'profile-123';
-  const mockProfileSettingsId = 'settings-456';
   const mockResourceTypeURL = 'test-resource-type' as ResourceTypeURL;
   const mockGeneratedURL = '/generated-url';
   const mockProfileName = 'Test Profile';
@@ -132,7 +131,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, true);
+        await result.current.handleSubmit(mockProfileId, true);
       });
 
       expect(savePreferredProfile).toHaveBeenCalledWith(mockProfileId, mockResourceTypeURL);
@@ -150,7 +149,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, true);
+        await result.current.handleSubmit(mockProfileId, true);
       });
 
       expect(getProfileNameById).toHaveBeenCalledWith({
@@ -181,7 +180,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, true);
+        await result.current.handleSubmit(mockProfileId, true);
       });
 
       expect(mockSetIsLoading).toHaveBeenCalledWith(true);
@@ -197,7 +196,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, true);
+        await result.current.handleSubmit(mockProfileId, true);
       });
 
       expect(savePreferredProfile).not.toHaveBeenCalled();
@@ -219,7 +218,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, true);
+        await result.current.handleSubmit(mockProfileId, true);
       });
 
       expect(savePreferredProfile).toHaveBeenCalledWith(mockProfileId, mockResourceTypeURL);
@@ -242,14 +241,13 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, false);
+        await result.current.handleSubmit(mockProfileId, false);
       });
 
       expect(generatePageURL).toHaveBeenCalledWith({
         url: ROUTES.RESOURCE_CREATE.uri,
         queryParams: mockQueryParams,
         profileId: mockProfileId,
-        profileSettingsId: mockProfileSettingsId,
       });
       expect(mockNavigateToEditPage).toHaveBeenCalledWith(mockGeneratedURL);
       expect(mockResetModalState).toHaveBeenCalled();
@@ -267,7 +265,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, false);
+        await result.current.handleSubmit(mockProfileId, false);
       });
 
       expect(mockChangeRecordProfile).toHaveBeenCalledWith({ profileId: mockProfileId });
@@ -287,7 +285,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, false);
+        await result.current.handleSubmit(mockProfileId, false);
       });
 
       expect(mockChangeRecordProfile).toHaveBeenCalledWith({ profileId: mockProfileId });
@@ -307,7 +305,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, true);
+        await result.current.handleSubmit(mockProfileId, true);
       });
 
       expect(savePreferredProfile).toHaveBeenCalledWith(mockProfileId, mockResourceTypeURL);
@@ -327,7 +325,6 @@ describe('useProfileSelectionActions', () => {
         url: ROUTES.RESOURCE_CREATE.uri,
         queryParams: mockQueryParams,
         profileId: mockProfileId,
-        profileSettingsId: mockProfileSettingsId,
       });
       expect(mockNavigateToEditPage).toHaveBeenCalledWith(mockGeneratedURL);
       expect(mockResetModalState).toHaveBeenCalled();
@@ -346,7 +343,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, true);
+        await result.current.handleSubmit(mockProfileId, true);
       });
 
       expect(savePreferredProfile).toHaveBeenCalledWith(mockProfileId, mockResourceTypeURL);
@@ -380,7 +377,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, false);
+        await result.current.handleSubmit(mockProfileId, false);
       });
 
       expect(deletePreferredProfile).toHaveBeenCalledWith(mockResourceTypeURL);
@@ -400,7 +397,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, false);
+        await result.current.handleSubmit(mockProfileId, false);
       });
 
       expect(deletePreferredProfile).not.toHaveBeenCalled();
@@ -420,7 +417,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, false);
+        await result.current.handleSubmit(mockProfileId, false);
       });
 
       expect(mockSetIsLoading).toHaveBeenCalledWith(true);
@@ -441,7 +438,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, false);
+        await result.current.handleSubmit(mockProfileId, false);
       });
 
       expect(deletePreferredProfile).toHaveBeenCalledWith(mockResourceTypeURL);
@@ -470,7 +467,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, false);
+        await result.current.handleSubmit(mockProfileId, false);
       });
 
       expect(deletePreferredProfile).toHaveBeenCalledWith(mockResourceTypeURL);
@@ -481,7 +478,6 @@ describe('useProfileSelectionActions', () => {
         url: ROUTES.RESOURCE_CREATE.uri,
         queryParams: mockQueryParams,
         profileId: mockProfileId,
-        profileSettingsId: mockProfileSettingsId,
       });
       expect(mockNavigateToEditPage).toHaveBeenCalledWith(mockGeneratedURL);
       expect(mockResetModalState).toHaveBeenCalled();
@@ -502,7 +498,7 @@ describe('useProfileSelectionActions', () => {
       );
 
       await act(async () => {
-        await result.current.handleSubmit(mockProfileId, mockProfileSettingsId, false);
+        await result.current.handleSubmit(mockProfileId, false);
       });
 
       expect(deletePreferredProfile).toHaveBeenCalledWith(mockResourceTypeURL);

--- a/src/features/profiles/hooks/useProfileSelectionActions.ts
+++ b/src/features/profiles/hooks/useProfileSelectionActions.ts
@@ -84,12 +84,12 @@ export const useProfileSelectionActions = ({
     }
   };
 
-  const handleCreateResource = (profileId: string | number, profileSettingsId: string | number) => {
-    const url = generatePageURL({ url: ROUTES.RESOURCE_CREATE.uri, queryParams, profileId, profileSettingsId });
+  const handleCreateResource = (profileId: string | number) => {
+    const url = generatePageURL({ url: ROUTES.RESOURCE_CREATE.uri, queryParams, profileId });
     navigateToEditPage(url);
   };
 
-  const handleSubmit = async (profileId: string | number, profileSettingsId: string | number, isDefault?: boolean) => {
+  const handleSubmit = async (profileId: string | number, isDefault?: boolean) => {
     // If "set as default" is checked, save preferred profile
     if (isDefault) {
       await handleSetProfileAsDefault(profileId);
@@ -100,7 +100,7 @@ export const useProfileSelectionActions = ({
     resetModalState();
 
     if (action === 'set') {
-      handleCreateResource(profileId, profileSettingsId);
+      handleCreateResource(profileId);
     } else {
       try {
         await changeRecordProfile({ profileId });

--- a/src/features/resources/helpers/buildProcessedResource.ts
+++ b/src/features/resources/helpers/buildProcessedResource.ts
@@ -72,9 +72,11 @@ export const buildProcessedResource = async ({
   const preferredProfileSettings = profileSettingsId
     ? []
     : await queryClient?.ensureQueryData(preferredProfileSettingsOptions(selectedProfileId));
+  const selectedProfileSettingsId =
+    profileSettingsId ?? preferredProfileSettings?.[0]?.id ?? PROFILE_SETTINGS_DEFAULT_OPTION;
 
   const profileSettings = await loadProfileSettings(
-    profileSettingsId ?? preferredProfileSettings?.[0]?.id ?? PROFILE_SETTINGS_DEFAULT_OPTION,
+    selectedProfileSettingsId,
     selectedProfileId,
     selectedProfile,
     getUri(resourceType),
@@ -127,6 +129,7 @@ export const buildProcessedResource = async ({
     selectedEntries: pipeline.selectedEntriesService.get(),
     selectedRecordBlocks,
     selectedProfile,
+    selectedProfileSettingsId,
     title: getRecordTitle(recordData as RecordEntry),
     entities: record ? getPrimaryEntitiesFromRecord(record) : undefined,
     referenceIds: record ? getReferenceIdsRaw(record) : undefined,

--- a/src/features/resources/helpers/buildProcessedResource.ts
+++ b/src/features/resources/helpers/buildProcessedResource.ts
@@ -1,3 +1,4 @@
+import { QueryClient } from '@tanstack/react-query';
 import { v4 as uuidv4 } from 'uuid';
 
 import { PROFILE_SETTINGS_DEFAULT_OPTION } from '@/common/constants/profileSettings.constants';
@@ -11,6 +12,8 @@ import {
 import { getReferenceIdsRaw } from '@/common/helpers/recordFormatting.helper';
 import { getUri } from '@/configs/resourceTypes';
 
+import { preferredProfileSettingsOptions } from '@/features/profiles';
+
 import type { ProcessedResource } from '../types';
 import { extractProfileParams } from './resourceParams';
 
@@ -18,10 +21,11 @@ type BuildProcessedResourceParams = {
   pipeline: SchemaPipelineServices;
   record?: RecordEntry;
   profileIdParam?: string | null;
-  profileSettingsIdParam?: string | null;
+  profileSettingsId?: string | null;
   typeParam?: string | null;
   asClone?: boolean;
   templateMetadata?: ResourceTemplateMetadata[];
+  queryClient?: QueryClient | null;
   loadProfile: (id: string | number) => Promise<Profile>;
   loadProfileSettings: (
     id: string | number,
@@ -35,10 +39,11 @@ export const buildProcessedResource = async ({
   pipeline,
   record,
   profileIdParam = null,
-  profileSettingsIdParam = null,
+  profileSettingsId = null,
   typeParam = null,
   asClone = false,
   templateMetadata,
+  queryClient = null,
   loadProfile,
   loadProfileSettings,
 }: BuildProcessedResourceParams): Promise<ProcessedResource | null> => {
@@ -63,9 +68,14 @@ export const buildProcessedResource = async ({
 
   if (!selectedProfile) return null;
 
+  const selectedProfileId = String(profileConfig.ids?.[0]);
+  const preferredProfileSettings = profileSettingsId
+    ? []
+    : await queryClient?.ensureQueryData(preferredProfileSettingsOptions(selectedProfileId));
+
   const profileSettings = await loadProfileSettings(
-    profileSettingsIdParam ?? PROFILE_SETTINGS_DEFAULT_OPTION,
-    String(profileConfig.ids?.[0]),
+    profileSettingsId ?? preferredProfileSettings?.[0]?.id ?? PROFILE_SETTINGS_DEFAULT_OPTION,
+    selectedProfileId,
     selectedProfile,
     getUri(resourceType),
   );

--- a/src/features/resources/hooks/useResourceProcessing.test.tsx
+++ b/src/features/resources/hooks/useResourceProcessing.test.tsx
@@ -9,7 +9,7 @@ import * as buildProcessedResourceModule from '../helpers/buildProcessedResource
 import { useResourceProcessing } from './useResourceProcessing';
 
 jest.mock('react-router-dom', () => ({
-  useSearchParams: () => [new URLSearchParams('type=work&profileId=123&profileSettingsId=456'), jest.fn()],
+  useSearchParams: () => [new URLSearchParams('type=work&profileId=123'), jest.fn()],
 }));
 
 jest.mock('../helpers/buildProcessedResource', () => ({
@@ -66,7 +66,7 @@ describe('useResourceProcessing', () => {
     (getEditingRecordBlocks as jest.Mock).mockReturnValue(undefined);
   });
 
-  it('calls buildProcessedResource with typeParam, profileIdParam, and profileSettingsIdParam from URL', async () => {
+  it('calls buildProcessedResource with typeParam, profileIdParam from URL', async () => {
     const { result } = renderHook(() => useResourceProcessing(), { wrapper });
 
     await result.current.processResource({});
@@ -75,7 +75,6 @@ describe('useResourceProcessing', () => {
       expect.objectContaining({
         typeParam: 'work',
         profileIdParam: '123',
-        profileSettingsIdParam: '456',
       }),
     );
   });

--- a/src/features/resources/hooks/useResourceProcessing.ts
+++ b/src/features/resources/hooks/useResourceProcessing.ts
@@ -27,7 +27,6 @@ export const useResourceProcessing = () => {
   const [searchParams] = useSearchParams();
   const typeParam = searchParams.get(QueryParams.Type);
   const profileIdParam = searchParams.get(QueryParams.ProfileId);
-  const profileSettingsIdParam = searchParams.get(QueryParams.ProfileSettingsId);
 
   const sharedInfra = useContext(SharedInfraContext);
   const queryClient = useQueryClient();
@@ -59,24 +58,16 @@ export const useResourceProcessing = () => {
         pipeline,
         record,
         profileIdParam,
-        profileSettingsIdParam: profileSettingsId ?? profileSettingsIdParam,
+        profileSettingsId,
         typeParam,
         asClone,
         templateMetadata,
+        queryClient,
         loadProfile,
         loadProfileSettings,
       });
     },
-    [
-      typeParam,
-      profileIdParam,
-      profileSettingsIdParam,
-      sharedInfra,
-      queryClient,
-      loadProfile,
-      loadProfileSettings,
-      formatMessage,
-    ],
+    [typeParam, profileIdParam, sharedInfra, queryClient, loadProfile, loadProfileSettings, formatMessage],
   );
 
   return { processResource };

--- a/src/features/resources/types/resource.types.ts
+++ b/src/features/resources/types/resource.types.ts
@@ -5,6 +5,7 @@ export type ProcessedResource = {
   selectedEntries: string[];
   selectedRecordBlocks?: SelectedRecordBlocks;
   selectedProfile?: Profile;
+  selectedProfileSettingsId?: string | number;
   title?: string;
   entities?: string[];
   referenceIds?: { id: unknown }[];

--- a/src/store/stores/manageProfileSettings.ts
+++ b/src/store/stores/manageProfileSettings.ts
@@ -20,6 +20,7 @@ export type ManageProfileSettingsState = SliceState<'selectedProfile', ProfileDT
   SliceState<'isSettingsActive', boolean> &
   SliceState<'profileSettings', ProfileSettingsWithDrift> &
   SliceState<'isTypeDefaultProfile', boolean> &
+  SliceState<'isPreferredProfileSettings', boolean> &
   SliceState<'isModified', boolean> &
   SliceState<'settingsName', string> &
   SliceState<'isCreating', boolean>;
@@ -64,6 +65,9 @@ const sliceConfigs: SliceConfigs = {
     initialValue: DEFAULT_INACTIVE_SETTINGS,
   },
   isTypeDefaultProfile: {
+    initialValue: false,
+  },
+  isPreferredProfileSettings: {
     initialValue: false,
   },
   isModified: {

--- a/src/test/__tests__/common/api/profiles.api.test.ts
+++ b/src/test/__tests__/common/api/profiles.api.test.ts
@@ -2,11 +2,14 @@ import baseApi from '@/common/api/base.api';
 import {
   createProfileSettings,
   deletePreferredProfile,
+  deletePreferredProfileSettings,
   fetchAllSettingsForProfile,
+  fetchPreferredProfileSettings,
   fetchProfile,
   fetchProfileSettings,
   fetchProfiles,
   savePreferredProfile,
+  savePreferredProfileSettings,
   saveProfileSettings,
 } from '@/common/api/profiles.api';
 
@@ -256,6 +259,66 @@ describe('profiles.api', () => {
         headers: {
           'content-type': 'application/json',
         },
+      },
+    });
+    expect(result).toEqual(mockResponse);
+  });
+
+  test('fetchPreferredProfileSettings', async () => {
+    const profileId = 105;
+    const testResult = [
+      {
+        profileId,
+        profileSettingsId: 2003,
+        name: 'fetch-test-name',
+      },
+    ];
+
+    jest.spyOn(baseApi, 'getJson').mockResolvedValue(testResult);
+
+    const result = await fetchPreferredProfileSettings(profileId);
+
+    expect(baseApi.getJson).toHaveBeenCalledWith({
+      url: `/linked-data/profile/${profileId}/preferred`,
+    });
+
+    expect(result).toEqual(testResult);
+  });
+
+  test('savePreferredProfileSettings', async () => {
+    const profileId = 98;
+    const profileSettingsId = 22;
+    const mockResponse = new Response(JSON.stringify({ ok: true }), { status: 201 });
+
+    jest.spyOn(baseApi, 'request').mockResolvedValue(mockResponse);
+
+    const result = await savePreferredProfileSettings(profileId, profileSettingsId);
+
+    expect(baseApi.request).toHaveBeenCalledWith({
+      url: `/linked-data/profile/${profileId}/preferred`,
+      requestParams: {
+        method: 'POST',
+        body: JSON.stringify({ profileSettingsId }),
+        headers: {
+          'content-type': 'application/json',
+        },
+      },
+    });
+    expect(result).toEqual(mockResponse);
+  });
+
+  test('deletePreferredProfileSettings', async () => {
+    const profileId = '341';
+    const mockResponse = new Response(JSON.stringify({ ok: true }), { status: 204 });
+
+    jest.spyOn(baseApi, 'request').mockResolvedValue(mockResponse);
+
+    const result = await deletePreferredProfileSettings(profileId);
+
+    expect(baseApi.request).toHaveBeenCalledWith({
+      url: `/linked-data/profile/${profileId}/preferred`,
+      requestParams: {
+        method: 'DELETE',
       },
     });
     expect(result).toEqual(mockResponse);

--- a/translations/ui-linked-data/en.json
+++ b/translations/ui-linked-data/en.json
@@ -359,7 +359,7 @@
   "ld.selectedComponents": "Selected components",
   "ld.selectedComponents.description": "Drag or use move buttons to place components in the desired order.",
   "ld.setDefaultTypeProfile": "Set as my default {type} profile",
-  "ld.setDefaultProfileSettings": "Set as my default profile settings for this profile",
+  "ld.setDefaultProfileSettings": "Set as my preferred profile settings for this profile",
   "ld.aria.nudgeComponentUp": "Move component up",
   "ld.aria.nudgeComponentDown": "Move component down",
   "ld.aria.moveComponentOptions": "Move component options",

--- a/translations/ui-linked-data/en.json
+++ b/translations/ui-linked-data/en.json
@@ -359,6 +359,7 @@
   "ld.selectedComponents": "Selected components",
   "ld.selectedComponents.description": "Drag or use move buttons to place components in the desired order.",
   "ld.setDefaultTypeProfile": "Set as my default {type} profile",
+  "ld.setDefaultProfileSettings": "Set as my default profile settings for this profile",
   "ld.aria.nudgeComponentUp": "Move component up",
   "ld.aria.nudgeComponentDown": "Move component down",
   "ld.aria.moveComponentOptions": "Move component options",
@@ -385,6 +386,5 @@
   "ld.visibleByDrift": "This component is shown because it is missing from your settings. Manage profile settings for this profile and save your update to clear this message.",
   "ld.types.books": "Books",
   "ld.types.continuingResources": "Serials Work",
-  "ld.savedSettings": "Saved settings for this profile",
   "ld.profileDefaults": "Profile defaults"
 }

--- a/translations/ui-linked-data/en.json
+++ b/translations/ui-linked-data/en.json
@@ -381,6 +381,7 @@
   "ld.authorities": "Authorities",
   "ld.error.saveProfileSettings": "Error saving profile settings",
   "ld.error.profileSettingsNameNotBlank": "Profile settings name should not be blank, please provide a name",
+  "ld.error.updatePreferredProfileSettings": "Error updating preferred profile settings",
   "ld.profileComponentsDeselected": "Profile components deselected",
   "ld.removedProfileComponentsResult": "You have removed components from your selected list for this profile. Only the selected components will be visible for resources using this profile. Would you like to proceed?",
   "ld.visibleByDrift": "This component is shown because it is missing from your settings. Manage profile settings for this profile and save your update to clear this message.",

--- a/translations/ui-linked-data/en.json
+++ b/translations/ui-linked-data/en.json
@@ -386,5 +386,6 @@
   "ld.visibleByDrift": "This component is shown because it is missing from your settings. Manage profile settings for this profile and save your update to clear this message.",
   "ld.types.books": "Books",
   "ld.types.continuingResources": "Serials Work",
-  "ld.profileDefaults": "Profile defaults"
+  "ld.profileDefaults": "Profile Defaults",
+  "ld.preferred": "preferred"
 }


### PR DESCRIPTION
## Purpose


Update the UI to handle having a preferred profile setting now that there may be several associated with one profile.

## Approach

- Add backend API calls
- Use react-query to manage calling and caching results and handling mutations
- Update manage profile settings to include a new toggle component indicating a profile settings is the default for that profile
- Update editor to automatically use the preferred profile settings when editing with that profile
- Remove selecting profile settings from profile selection modal, too confusing; users should rely on the settings switcher to temporarily change and re-render which profile settings are in use

## Refs

https://folio-org.atlassian.net/browse/UILD-780
