### PR TITLE
UILD-780: Update profile settings workflow for improved user experience

### DIFF
--- a/src/common/constants/profileSettings.constants.ts
+++ b/src/common/constants/profileSettings.constants.ts
@@ -12,3 +12,9 @@ export const BASE_SETTINGS_OPTIONS = [
     value: '',
   },
 ];
+
+export enum ProfileSettingsMode {
+  Landing = 'landing',
+  Creating = 'creating',
+  Editing = 'editing',
+}

--- a/src/features/edit/components/EditSection/ProfileSettingsSelector.tsx
+++ b/src/features/edit/components/EditSection/ProfileSettingsSelector.tsx
@@ -39,8 +39,8 @@ export const ProfileSettingsSelector = () => {
     return profileSettings ? basicOption.concat(profileSettings) : basicOption;
   }, [basicOption, profileSettings]);
 
-  const hasOptions = useMemo(() => {
-    return (profileSettings?.length ?? 0) > 0;
+  const hasNoOptions = useMemo(() => {
+    return (profileSettings?.length ?? 0) === 0;
   }, [profileSettings]);
 
   const { isOpen: isMenuEnabled, setIsOpen: setIsMenuEnabled, toggle: toggleIsMenuEnabled } = useDismissMenu(ref);
@@ -83,7 +83,9 @@ export const ProfileSettingsSelector = () => {
     );
   };
 
-  return hasOptions ? (
+  if (hasNoOptions) return <></>;
+
+  return (
     <div className="profile-settings-selector" ref={ref}>
       <Button
         data-testid="profile-settings-selector-button"
@@ -122,7 +124,5 @@ export const ProfileSettingsSelector = () => {
         </ul>
       )}
     </div>
-  ) : (
-    <></>
   );
 };

--- a/src/features/manageProfileSettings/components/DefaultProfileOption/DefaultProfileOption.tsx
+++ b/src/features/manageProfileSettings/components/DefaultProfileOption/DefaultProfileOption.tsx
@@ -42,7 +42,7 @@ export const DefaultProfileOption: FC<DefaultProfileOptionProps> = ({ selectedPr
       const preferredProfiles = await loadPreferredProfiles();
       if (preferredProfiles?.length) {
         const preferred = preferredProfileForType(selectedProfile.resourceType, preferredProfiles);
-        setIsTypeDefaultProfile(!!preferred && preferred.id === String(selectedProfile.id));
+        setIsTypeDefaultProfile(!!preferred && preferred.id.toString() === selectedProfile.id.toString());
       } else {
         setIsTypeDefaultProfile(false);
       }

--- a/src/features/manageProfileSettings/components/ModalCloseProfileSettings/ModalCloseProfileSettings.test.tsx
+++ b/src/features/manageProfileSettings/components/ModalCloseProfileSettings/ModalCloseProfileSettings.test.tsx
@@ -6,6 +6,8 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+import { ProfileSettingsMode } from '@/common/constants/profileSettings.constants';
+
 import { useManageProfileSettingsState, useUIState } from '@/store';
 
 import { ModalCloseProfileSettings } from './ModalCloseProfileSettings';
@@ -30,7 +32,7 @@ jest.mock('../../hooks/useSaveProfileSettings', () => ({
 
 describe('ModalCloseProfileSettings', () => {
   const mockSetSelectedProfile = jest.fn();
-  const mockSetIsCreating = jest.fn();
+  const mockSetMode = jest.fn();
   const mockSetSelectedProfileSettingsMeta = jest.fn();
   const mockSetIsPreferredProfileSettings = jest.fn();
   const mockSetSettingsName = jest.fn();
@@ -59,6 +61,38 @@ describe('ModalCloseProfileSettings', () => {
     renderComponent();
 
     expect(screen.getByTestId('modal-close-profile-settings')).toBeInTheDocument();
+  });
+
+  it('renders modal component with component warning when not in landing mode', () => {
+    setInitialGlobalState([
+      {
+        store: useManageProfileSettingsState,
+        state: {
+          mode: ProfileSettingsMode.Editing,
+        },
+      },
+    ]);
+
+    renderComponent();
+
+    expect(screen.getByTestId('modal-close-profile-settings')).toBeInTheDocument();
+    expect(screen.getByText('ld.unsavedProfileNote')).toBeInTheDocument();
+  });
+
+  it('renders modal component without component warning when in landing mode', () => {
+    setInitialGlobalState([
+      {
+        store: useManageProfileSettingsState,
+        state: {
+          mode: ProfileSettingsMode.Landing,
+        },
+      },
+    ]);
+
+    renderComponent();
+
+    expect(screen.getByTestId('modal-close-profile-settings')).toBeInTheDocument();
+    expect(screen.queryByText('ld.unsavedProfileNote')).not.toBeInTheDocument();
   });
 
   it('when closing modal, do not save or navigate', async () => {
@@ -125,6 +159,7 @@ describe('ModalCloseProfileSettings', () => {
             resourceTypeURL: 'test-resource',
           },
           setSelectedProfile: mockSetSelectedProfile,
+          setMode: mockSetMode,
         },
       },
       {
@@ -144,6 +179,7 @@ describe('ModalCloseProfileSettings', () => {
       expect(mockSetSelectedProfile).toHaveBeenCalled();
       expect(mockSetIsManageProfileSettingsShowEditor).toHaveBeenCalledWith(true);
       expect(mockSetIsManageProfileSettingsShowProfiles).toHaveBeenCalledWith(false);
+      expect(mockSetMode).toHaveBeenCalledWith(ProfileSettingsMode.Landing);
     });
   });
 
@@ -190,7 +226,7 @@ describe('ModalCloseProfileSettings', () => {
           isClosingNext: false,
           nextSelectedProfile: null,
           isCreatingSettingsNext: true,
-          setIsCreating: mockSetIsCreating,
+          setMode: mockSetMode,
           setSelectedProfileSettingsMeta: mockSetSelectedProfileSettingsMeta,
           setIsPreferredProfileSettings: mockSetIsPreferredProfileSettings,
         },
@@ -202,7 +238,7 @@ describe('ModalCloseProfileSettings', () => {
     fireEvent.click(screen.getByTestId('modal-button-submit'));
 
     await waitFor(() => {
-      expect(mockSetIsCreating).toHaveBeenCalledWith(true);
+      expect(mockSetMode).toHaveBeenCalledWith(ProfileSettingsMode.Creating);
       expect(mockSetSelectedProfileSettingsMeta).toHaveBeenCalledWith(null);
       expect(mockSetIsPreferredProfileSettings).toHaveBeenCalledWith(false);
     });
@@ -219,7 +255,7 @@ describe('ModalCloseProfileSettings', () => {
           isCreatingSettingsNext: false,
           isEditingSettingsNext: true,
           nextSelectedSettingsMeta: settingsMeta,
-          setIsCreating: mockSetIsCreating,
+          setMode: mockSetMode,
           setSelectedProfileSettingsMeta: mockSetSelectedProfileSettingsMeta,
           setSettingsName: mockSetSettingsName,
         },
@@ -231,7 +267,7 @@ describe('ModalCloseProfileSettings', () => {
     fireEvent.click(screen.getByTestId('modal-button-submit'));
 
     await waitFor(() => {
-      expect(mockSetIsCreating).toHaveBeenCalledWith(false);
+      expect(mockSetMode).toHaveBeenCalledWith(ProfileSettingsMode.Editing);
       expect(mockSetSelectedProfileSettingsMeta).toHaveBeenCalledWith(settingsMeta);
       expect(mockSetSettingsName).toHaveBeenCalledWith('edit-name');
     });

--- a/src/features/manageProfileSettings/components/ModalCloseProfileSettings/ModalCloseProfileSettings.tsx
+++ b/src/features/manageProfileSettings/components/ModalCloseProfileSettings/ModalCloseProfileSettings.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 
+import { ProfileSettingsMode } from '@/common/constants/profileSettings.constants';
 import { useBackToSearchUri } from '@/common/hooks/useBackToSearchUri';
 import { Modal } from '@/components/Modal';
 
@@ -21,13 +22,14 @@ export const ModalCloseProfileSettings: FC<ModalCloseProfileSettingsProps> = ({ 
   const navigate = useNavigate();
   const searchResultsUri = useBackToSearchUri();
   const {
+    mode,
     isClosingNext,
     setIsClosingNext,
     nextSelectedProfile,
     setNextSelectedProfile,
     setSelectedProfile,
     setIsModified,
-    setIsCreating,
+    setMode,
     isCreatingSettingsNext,
     setIsCreatingSettingsNext,
     isEditingSettingsNext,
@@ -38,6 +40,7 @@ export const ModalCloseProfileSettings: FC<ModalCloseProfileSettingsProps> = ({ 
     setSettingsName,
     setIsPreferredProfileSettings,
   } = useManageProfileSettingsState([
+    'mode',
     'isClosingNext',
     'setIsClosingNext',
     'nextSelectedProfile',
@@ -45,7 +48,7 @@ export const ModalCloseProfileSettings: FC<ModalCloseProfileSettingsProps> = ({ 
     'setSelectedProfile',
     'resetSelectedProfileSettingsMeta',
     'setIsModified',
-    'setIsCreating',
+    'setMode',
     'isCreatingSettingsNext',
     'setIsCreatingSettingsNext',
     'isEditingSettingsNext',
@@ -73,17 +76,19 @@ export const ModalCloseProfileSettings: FC<ModalCloseProfileSettingsProps> = ({ 
       resetSettings();
       setIsManageProfileSettingsShowProfiles(false);
       setIsManageProfileSettingsShowEditor(true);
+      setMode(ProfileSettingsMode.Landing);
     } else if (isCreatingSettingsNext) {
-      setIsCreating(true);
+      setMode(ProfileSettingsMode.Creating);
       setSelectedProfileSettingsMeta(null);
       setSettingsName('');
       setIsPreferredProfileSettings(false);
       setIsCreatingSettingsNext(false);
     } else if (isEditingSettingsNext) {
-      setIsCreating(false);
+      setMode(ProfileSettingsMode.Editing);
       resetSettings();
       setSelectedProfileSettingsMeta(nextSelectedSettingsMeta);
       setSettingsName(nextSelectedSettingsMeta?.name ?? '');
+      setIsPreferredProfileSettings(false);
       setIsEditingSettingsNext(false);
       setNextSelectedSettingsMeta(null);
     }
@@ -124,9 +129,11 @@ export const ModalCloseProfileSettings: FC<ModalCloseProfileSettingsProps> = ({ 
       <p>
         <FormattedMessage id="ld.unsavedProfilePrompt" />
       </p>
-      <p>
-        <FormattedMessage id="ld.unsavedProfileNote" />
-      </p>
+      {mode !== ProfileSettingsMode.Landing && (
+        <p>
+          <FormattedMessage id="ld.unsavedProfileNote" />
+        </p>
+      )}
     </Modal>
   );
 };

--- a/src/features/manageProfileSettings/components/ProfileSettings/ProfileSettings.test.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettings/ProfileSettings.test.tsx
@@ -1,9 +1,9 @@
-import { setInitialGlobalState } from '@/test/__mocks__/store';
+import { setInitialGlobalState, setUpdatedGlobalState } from '@/test/__mocks__/store';
 
 import { MemoryRouter } from 'react-router-dom';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 
 import { fetchProfile } from '@/common/api/profiles.api';
 import { StatusType } from '@/common/constants/status.constants';
@@ -13,6 +13,20 @@ import { useLoadProfileSettings } from '@/features/profiles';
 import { useLoadingState, useManageProfileSettingsState, useStatusStore } from '@/store';
 
 import { ProfileSettings } from './ProfileSettings';
+
+// Settle promise chains of any depth before asserting.
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+};
 
 jest.mock('@/common/api/profiles.api', () => ({
   fetchPreferredProfiles: jest.fn(),
@@ -163,6 +177,174 @@ describe('ProfileSettings', () => {
 
     await waitFor(() => {
       expect(mockResetProfileSettings).toHaveBeenCalled();
+    });
+  });
+
+  describe('cancellation of stale async work', () => {
+    it('applies the profile and settings load when nothing changes before it resolves', async () => {
+      const profile = [{ id: 'node' }] as unknown as Profile;
+      const settings = { active: true, children: [], missingFromSettings: [] };
+      (fetchProfile as jest.Mock).mockResolvedValue(profile);
+      mockLoadProfileSettings.mockResolvedValue(settings);
+
+      renderComponent(true, false);
+
+      await waitFor(() => {
+        expect(useManageProfileSettingsState.getState().fullProfile).toEqual(profile);
+        expect(useManageProfileSettingsState.getState().profileSettings).toEqual(settings);
+      });
+      expect(mockSetIsLoading).toHaveBeenLastCalledWith(false);
+    });
+
+    it('ignores a stale profile load that resolves after the selected profile changes again', async () => {
+      const deferredOne = createDeferred<Profile>();
+      const deferredTwo = createDeferred<Profile>();
+      const profileOne = [{ id: 'stale-profile' }] as unknown as Profile;
+      const profileTwo = [{ id: 'fresh-profile' }] as unknown as Profile;
+
+      (fetchProfile as jest.Mock).mockImplementation((id: string) =>
+        id === 'one' ? deferredOne.promise : deferredTwo.promise,
+      );
+
+      renderComponent(true, false);
+
+      await waitFor(() => {
+        expect(fetchProfile).toHaveBeenCalledWith('one');
+      });
+
+      // the user selects a different profile before the first request resolves
+      act(() => {
+        setUpdatedGlobalState([
+          {
+            store: useManageProfileSettingsState,
+            updatedState: {
+              selectedProfile: { id: 'two', name: 'Two', resourceType: mockWorkResourceTypeUrl },
+            },
+          },
+        ]);
+      });
+
+      await waitFor(() => {
+        expect(fetchProfile).toHaveBeenCalledWith('two');
+      });
+
+      // the current request resolves first
+      await act(async () => {
+        deferredTwo.resolve(profileTwo);
+        await flushPromises();
+      });
+      expect(useManageProfileSettingsState.getState().fullProfile).toEqual(profileTwo);
+
+      // the stale request resolves afterwards and must not overwrite the current profile
+      await act(async () => {
+        deferredOne.resolve(profileOne);
+        await flushPromises();
+      });
+      expect(useManageProfileSettingsState.getState().fullProfile).toEqual(profileTwo);
+    });
+
+    it('ignores a stale profile settings load that resolves after the settings selection changes again', async () => {
+      (fetchProfile as jest.Mock).mockResolvedValue([]);
+
+      const deferredMetaOne = createDeferred<ProfileSettingsWithDrift>();
+      const deferredMetaTwo = createDeferred<ProfileSettingsWithDrift>();
+      const settingsOne = {
+        active: true,
+        children: [{ id: 'stale', visible: true, order: 1 }],
+        missingFromSettings: [],
+      };
+      const settingsTwo = {
+        active: true,
+        children: [{ id: 'fresh', visible: true, order: 1 }],
+        missingFromSettings: [],
+      };
+
+      mockLoadProfileSettings.mockImplementation((metaId: string) =>
+        metaId === 'meta-one' ? deferredMetaOne.promise : deferredMetaTwo.promise,
+      );
+
+      renderComponent(true, false);
+
+      await waitFor(() => {
+        expect(mockLoadProfileSettings).toHaveBeenCalledWith('meta-one', 'one', [], mockWorkResourceTypeUrl);
+      });
+
+      // the user selects a different settings option before the first request resolves
+      act(() => {
+        setUpdatedGlobalState([
+          {
+            store: useManageProfileSettingsState,
+            updatedState: { selectedProfileSettingsMeta: { id: 'meta-two', profileId: 'one', name: 'meta-two' } },
+          },
+        ]);
+      });
+
+      await waitFor(() => {
+        expect(mockLoadProfileSettings).toHaveBeenCalledWith('meta-two', 'one', [], mockWorkResourceTypeUrl);
+      });
+
+      // the current request resolves first
+      await act(async () => {
+        deferredMetaTwo.resolve(settingsTwo);
+        await flushPromises();
+      });
+      expect(useManageProfileSettingsState.getState().profileSettings).toEqual(settingsTwo);
+
+      // the stale request resolves afterwards and must not overwrite the current settings
+      await act(async () => {
+        deferredMetaOne.resolve(settingsOne);
+        await flushPromises();
+      });
+      expect(useManageProfileSettingsState.getState().profileSettings).toEqual(settingsTwo);
+    });
+
+    it('does not update the store or show an error for a stale, failed profile load', async () => {
+      const deferredOne = createDeferred<Profile>();
+      const deferredTwo = createDeferred<Profile>();
+      const profileTwo = [{ id: 'fresh-profile' }] as unknown as Profile;
+
+      (fetchProfile as jest.Mock).mockImplementation((id: string) =>
+        id === 'one' ? deferredOne.promise : deferredTwo.promise,
+      );
+
+      renderComponent(true, false);
+
+      await waitFor(() => {
+        expect(fetchProfile).toHaveBeenCalledWith('one');
+      });
+
+      act(() => {
+        setUpdatedGlobalState([
+          {
+            store: useManageProfileSettingsState,
+            updatedState: {
+              selectedProfile: { id: 'two', name: 'Two', resourceType: mockWorkResourceTypeUrl },
+            },
+          },
+        ]);
+      });
+
+      await waitFor(() => {
+        expect(fetchProfile).toHaveBeenCalledWith('two');
+      });
+
+      await act(async () => {
+        deferredTwo.resolve(profileTwo);
+        await flushPromises();
+      });
+      expect(useManageProfileSettingsState.getState().fullProfile).toEqual(profileTwo);
+
+      // the stale request fails after being superseded; it must not surface an error or clear loading state
+      mockAddStatusMessagesItem.mockClear();
+      mockSetIsLoading.mockClear();
+      await act(async () => {
+        deferredOne.reject(new Error('stale profile load failed'));
+        await flushPromises();
+      });
+
+      expect(mockAddStatusMessagesItem).not.toHaveBeenCalled();
+      expect(mockSetIsLoading).not.toHaveBeenCalled();
+      expect(useManageProfileSettingsState.getState().fullProfile).toEqual(profileTwo);
     });
   });
 });

--- a/src/features/manageProfileSettings/components/ProfileSettings/ProfileSettings.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettings/ProfileSettings.tsx
@@ -52,37 +52,50 @@ export const ProfileSettings = () => {
   };
 
   useEffect(() => {
-    if (selectedProfile) {
-      const initialize = async () => {
-        try {
-          setIsLoading(true);
-          const profile = await loadProfile(selectedProfile.id);
-          setFullProfile(profile);
-          if (selectedProfileSettingsMeta) {
-            if (selectedProfileSettingsMeta.id === PROFILE_SETTINGS_DEFAULT_OPTION) {
-              resetProfileSettings();
-            } else {
-              setProfileSettings(
-                await loadProfileSettings(
-                  selectedProfileSettingsMeta.id,
-                  String(selectedProfile.id),
-                  profile,
-                  selectedProfile.resourceType,
-                ),
-              );
-            }
+    if (!selectedProfile) return;
+
+    let cancelled = false;
+
+    const initialize = async () => {
+      try {
+        setIsLoading(true);
+        const profile = await loadProfile(selectedProfile.id);
+
+        if (cancelled) return;
+
+        setFullProfile(profile);
+        if (selectedProfileSettingsMeta) {
+          if (selectedProfileSettingsMeta.id === PROFILE_SETTINGS_DEFAULT_OPTION) {
+            resetProfileSettings();
+          } else {
+            const settings = await loadProfileSettings(
+              selectedProfileSettingsMeta.id,
+              String(selectedProfile.id),
+              profile,
+              selectedProfile.resourceType,
+            );
+
+            if (cancelled) return;
+
+            setProfileSettings(settings);
           }
-        } catch {
+        }
+      } catch {
+        if (!cancelled) {
           addStatusMessagesItem?.(
             UserNotificationFactory.createMessage(StatusType.error, 'ld.errorLoadingProfileSettings'),
           );
-        } finally {
-          setIsLoading(false);
         }
-      };
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
 
-      initialize();
-    }
+    initialize();
+
+    return () => {
+      cancelled = true;
+    };
   }, [selectedProfile, selectedProfileSettingsMeta]);
 
   const showView =

--- a/src/features/manageProfileSettings/components/ProfileSettingsEditor/BaseComponent.test.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsEditor/BaseComponent.test.tsx
@@ -182,4 +182,15 @@ describe('BaseComponent', () => {
       expect(screen.queryByTestId('move-menu')).not.toBeInTheDocument();
     });
   });
+
+  it('focuses the menu container when the only menu item is disabled (mandatory component)', async () => {
+    const mockComponent = makeComponent(true);
+    renderComponent(<SelectedComponent component={mockComponent} size={2} index={1} />, mockComponent);
+
+    fireEvent.click(screen.getByTestId('activate-menu'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('move-menu')).toHaveFocus();
+    });
+  });
 });

--- a/src/features/manageProfileSettings/components/ProfileSettingsEditor/BaseComponent.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsEditor/BaseComponent.tsx
@@ -31,6 +31,7 @@ type BaseComponentProps = {
 export const BaseComponent: FC<BaseComponentProps> = ({ size, index, component, type, upFn, downFn, moveFn }) => {
   const ref = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLButtonElement>(null);
+  const menuContainerRef = useRef<HTMLUListElement>(null);
   const dataRef = useRef<HTMLDivElement>(null);
   const { formatMessage } = useIntl();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -50,11 +51,11 @@ export const BaseComponent: FC<BaseComponentProps> = ({ size, index, component, 
     transition,
   };
 
-  const { isOpen: isMenuEnabled, toggle: toggleIsMenuEnabled } = useDismissMenu(menuRef);
+  const { isOpen: isMenuEnabled, toggle: toggleIsMenuEnabled } = useDismissMenu(menuContainerRef);
 
   useEffect(() => {
-    if (isMenuEnabled && menuRef.current) {
-      menuRef.current.focus();
+    if (isMenuEnabled) {
+      (menuRef.current ?? menuContainerRef.current)?.focus();
     }
   }, [isMenuEnabled]);
 
@@ -85,6 +86,8 @@ export const BaseComponent: FC<BaseComponentProps> = ({ size, index, component, 
               className="move-menu"
               role="menu" // NOSONAR
               aria-label={formatMessage({ id: 'ld.aria.moveComponentOptions' })}
+              ref={menuContainerRef}
+              tabIndex={-1}
             >
               <li className="move-menu-content" role="none">
                 {component.mandatory ? (

--- a/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.scss
+++ b/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.scss
@@ -1,5 +1,12 @@
 @use '@/common/styles/common.scss' as *;
 
+.profile-settings-editor-landing {
+  padding: 25px 20%;
+  text-align: center;
+  font-size: 120%;
+  max-width: 460px;
+}
+
 .components-editor-wrapper {
   container-type: inline-size;
 

--- a/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.test.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
+import { ProfileSettingsMode } from '@/common/constants/profileSettings.constants';
 import { AdvancedFieldType } from '@/common/constants/uiControls.constants';
 
 import { useManageProfileSettingsStore } from '@/store';
@@ -35,7 +36,71 @@ describe('ProfileSettingsEditor', () => {
   it('renders with no state', async () => {
     renderComponent();
 
-    expect(screen.getByTestId('profile-settings-editor')).toBeInTheDocument();
+    expect(screen.getByTestId('profile-settings-editor-landing')).toBeInTheDocument();
+  });
+
+  it('renders in creating mode', () => {
+    setInitialGlobalState([
+      {
+        store: useManageProfileSettingsStore,
+        state: {
+          fullProfile: [
+            {
+              id: 'profile',
+              type: AdvancedFieldType.block,
+              displayName: 'Profile',
+              children: ['child'],
+            },
+            {
+              id: 'child',
+              type: AdvancedFieldType.simple,
+              displayName: 'Child',
+            },
+          ],
+          profileSettings: {
+            active: false,
+            children: [],
+          },
+          mode: ProfileSettingsMode.Creating,
+        },
+      },
+    ]);
+
+    renderComponent();
+
+    expect(screen.getByText('ld.profileSettings.creatingSettingsName')).toBeInTheDocument();
+  });
+
+  it('renders in editing mode', () => {
+    setInitialGlobalState([
+      {
+        store: useManageProfileSettingsStore,
+        state: {
+          fullProfile: [
+            {
+              id: 'profile',
+              type: AdvancedFieldType.block,
+              displayName: 'Profile',
+              children: ['child'],
+            },
+            {
+              id: 'child',
+              type: AdvancedFieldType.simple,
+              displayName: 'Child',
+            },
+          ],
+          profileSettings: {
+            active: false,
+            children: [],
+          },
+          mode: ProfileSettingsMode.Editing,
+        },
+      },
+    ]);
+
+    renderComponent();
+
+    expect(screen.getByText('ld.profileSettings.editingSettingsName')).toBeInTheDocument();
   });
 
   it('renders with inactive settings', () => {
@@ -60,6 +125,7 @@ describe('ProfileSettingsEditor', () => {
             active: false,
             children: [],
           },
+          mode: ProfileSettingsMode.Creating,
         },
       },
     ]);
@@ -98,6 +164,7 @@ describe('ProfileSettingsEditor', () => {
               },
             ],
           },
+          mode: ProfileSettingsMode.Creating,
         },
       },
     ]);
@@ -147,6 +214,7 @@ describe('ProfileSettingsEditor', () => {
               },
             ],
           },
+          mode: ProfileSettingsMode.Creating,
         },
       },
     ]);
@@ -169,6 +237,7 @@ describe('ProfileSettingsEditor', () => {
         state: {
           settingsName: initialName,
           setSettingsName: mockSetSettingsName,
+          mode: ProfileSettingsMode.Creating,
         },
       },
     ]);

--- a/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.tsx
@@ -5,6 +5,7 @@ import { DndContext, DragOverlay, MeasuringStrategy, useSensor, useSensors } fro
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import classNames from 'classnames';
 
+import { ProfileSettingsMode } from '@/common/constants/profileSettings.constants';
 import { Input } from '@/components/Input';
 
 import { useManageProfileSettingsState } from '@/store';
@@ -54,7 +55,7 @@ export const ProfileSettingsEditor = () => {
     selectedComponents,
     isSettingsActive,
     settingsName,
-    isCreating,
+    mode,
     setIsSettingsActive,
     setUnusedComponents,
     setSelectedComponents,
@@ -68,13 +69,12 @@ export const ProfileSettingsEditor = () => {
     'selectedComponents',
     'isSettingsActive',
     'settingsName',
-    'isCreating',
+    'mode',
     'setIsSettingsActive',
     'setUnusedComponents',
     'setSelectedComponents',
     'setSettingsName',
     'setIsModified',
-    'setIsCreating',
   ]);
 
   const updateState = ({
@@ -168,12 +168,24 @@ export const ProfileSettingsEditor = () => {
     };
   });
 
+  if (mode === ProfileSettingsMode.Landing) {
+    return (
+      <div data-testid="profile-settings-editor-landing" className="profile-settings-editor-landing">
+        <FormattedMessage id="ld.profileSettings.editorLanding" />
+      </div>
+    );
+  }
+
   return (
     <div data-testid="profile-settings-editor" className="components-editor-wrapper">
       <div className="settings-name-edit">
         <label>
           <FormattedMessage
-            id={isCreating ? 'ld.profileSettings.creatingSettingsName' : 'ld.profileSettings.editingSettingsName'}
+            id={
+              mode === ProfileSettingsMode.Creating
+                ? 'ld.profileSettings.creatingSettingsName'
+                : 'ld.profileSettings.editingSettingsName'
+            }
           />
           <Input value={settingsName} onChange={handleNameChange} data-testid="settings-name" />
         </label>

--- a/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.scss
+++ b/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.scss
@@ -11,4 +11,8 @@
   label {
     white-space: nowrap;
   }
+
+  button {
+    flex-shrink: 0;
+  }
 }

--- a/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.test.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.test.tsx
@@ -3,13 +3,15 @@ import { setInitialGlobalState } from '@/test/__mocks__/store';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+import { ProfileSettingsMode } from '@/common/constants/profileSettings.constants';
+
 import { useManageProfileSettingsStore, useUIStore } from '@/store';
 
 import { ProfileSettingsList } from './ProfileSettingsList';
 
 describe('ProfileSettingsList', () => {
   const mockSetIsManageProfileSettingsUnsavedModalOpen = jest.fn();
-  const mockSetIsCreating = jest.fn();
+  const mockSetMode = jest.fn();
   const mockSetIsPreferredProfileSettings = jest.fn();
   const renderComponent = (modified: boolean) => {
     const queryClient = new QueryClient({
@@ -50,7 +52,7 @@ describe('ProfileSettingsList', () => {
             id: 3,
           },
           isModified: modified,
-          setIsCreating: mockSetIsCreating,
+          setMode: mockSetMode,
           setIsPreferredProfileSettings: mockSetIsPreferredProfileSettings,
         },
       },
@@ -92,7 +94,7 @@ describe('ProfileSettingsList', () => {
 
     waitFor(() => {
       expect(mockSetIsManageProfileSettingsUnsavedModalOpen).toHaveBeenCalledWith(true);
-      expect(mockSetIsCreating).not.toHaveBeenCalled();
+      expect(mockSetMode).not.toHaveBeenCalled();
       expect(mockSetIsPreferredProfileSettings).not.toHaveBeenCalled();
     });
   });
@@ -104,7 +106,7 @@ describe('ProfileSettingsList', () => {
 
     waitFor(() => {
       expect(mockSetIsManageProfileSettingsUnsavedModalOpen).not.toHaveBeenCalled();
-      expect(mockSetIsCreating).toHaveBeenCalledWith(true);
+      expect(mockSetMode).toHaveBeenCalledWith(ProfileSettingsMode.Creating);
       expect(mockSetIsPreferredProfileSettings).toHaveBeenCalledWith(false);
     });
   });
@@ -117,7 +119,7 @@ describe('ProfileSettingsList', () => {
 
     waitFor(() => {
       expect(mockSetIsManageProfileSettingsUnsavedModalOpen).not.toHaveBeenCalled();
-      expect(mockSetIsCreating).not.toHaveBeenCalled();
+      expect(mockSetMode).not.toHaveBeenCalled();
       expect(mockSetIsPreferredProfileSettings).not.toHaveBeenCalled();
     });
   });
@@ -129,7 +131,7 @@ describe('ProfileSettingsList', () => {
 
     waitFor(() => {
       expect(mockSetIsManageProfileSettingsUnsavedModalOpen).toHaveBeenCalledWith(true);
-      expect(mockSetIsCreating).not.toHaveBeenCalled();
+      expect(mockSetMode).not.toHaveBeenCalled();
       expect(mockSetIsPreferredProfileSettings).not.toHaveBeenCalled();
     });
   });
@@ -141,7 +143,7 @@ describe('ProfileSettingsList', () => {
 
     waitFor(() => {
       expect(mockSetIsManageProfileSettingsUnsavedModalOpen).not.toHaveBeenCalled();
-      expect(mockSetIsCreating).toHaveBeenCalledWith(false);
+      expect(mockSetMode).toHaveBeenCalledWith(ProfileSettingsMode.Editing);
       expect(mockSetIsPreferredProfileSettings).not.toHaveBeenCalled();
     });
   });

--- a/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.tsx
+++ b/src/features/manageProfileSettings/components/ProfileSettingsList/ProfileSettingsList.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { BASE_SETTINGS_OPTIONS } from '@/common/constants/profileSettings.constants';
+import { BASE_SETTINGS_OPTIONS, ProfileSettingsMode } from '@/common/constants/profileSettings.constants';
 import { Button, ButtonType } from '@/components/Button';
 import { Select, SelectValue } from '@/components/Select';
 
@@ -27,7 +27,7 @@ export const ProfileSettingsList = () => {
     selectedProfileSettingsMeta,
     setSelectedProfileSettingsMeta,
     setSettingsName,
-    setIsCreating,
+    setMode,
     setIsCreatingSettingsNext,
     setIsEditingSettingsNext,
     setIsPreferredProfileSettings,
@@ -38,7 +38,7 @@ export const ProfileSettingsList = () => {
     'selectedProfileSettingsMeta',
     'setSelectedProfileSettingsMeta',
     'setSettingsName',
-    'setIsCreating',
+    'setMode',
     'setIsCreatingSettingsNext',
     'setIsEditingSettingsNext',
     'setIsPreferredProfileSettings',
@@ -75,7 +75,7 @@ export const ProfileSettingsList = () => {
         setNextSelectedSettingsMeta(settingMeta ?? null);
         setIsManageProfileSettingsUnsavedModalOpen(true);
       } else {
-        setIsCreating(false);
+        setMode(ProfileSettingsMode.Editing);
         resetSettings();
 
         setSelectedProfileSettingsMeta(settingMeta ?? null);
@@ -89,7 +89,7 @@ export const ProfileSettingsList = () => {
       setIsCreatingSettingsNext(true);
       setIsManageProfileSettingsUnsavedModalOpen(true);
     } else {
-      setIsCreating(true);
+      setMode(ProfileSettingsMode.Creating);
       setSelectedProfileSettingsMeta(null);
       setSettingsName('');
       setIsPreferredProfileSettings(false);
@@ -98,12 +98,9 @@ export const ProfileSettingsList = () => {
 
   return (
     <div data-testid="profile-settings-select-section" className="profile-settings-select">
-      <Button
-        type={ButtonType.Highlighted}
-        label={<FormattedMessage id="ld.create.base" />}
-        onClick={handleCreate}
-        data-testid="profile-settings-select-create"
-      />
+      <Button type={ButtonType.Primary} onClick={handleCreate} data-testid="profile-settings-select-create">
+        <FormattedMessage id="ld.profileSettings.createNewSettings" />
+      </Button>
 
       <label id="profile-settings-select-label" htmlFor="profile-settings-select">
         <FormattedMessage id="ld.profileSettings.savedSettings" />

--- a/src/features/manageProfileSettings/components/ProfilesList/ResourceProfile.tsx
+++ b/src/features/manageProfileSettings/components/ProfilesList/ResourceProfile.tsx
@@ -14,9 +14,9 @@ type ResourceProfileProps = {
 };
 
 export const ResourceProfile: FC<ResourceProfileProps> = ({ profile, selected }) => {
-  const { isModified, resetIsCreating, setNextSelectedProfile, setSelectedProfile } = useManageProfileSettingsState([
+  const { isModified, resetMode, setNextSelectedProfile, setSelectedProfile } = useManageProfileSettingsState([
     'isModified',
-    'resetIsCreating',
+    'resetMode',
     'setNextSelectedProfile',
     'setSelectedProfile',
   ]);
@@ -41,7 +41,7 @@ export const ResourceProfile: FC<ResourceProfileProps> = ({ profile, selected })
     } else {
       setSelectedProfile(profile);
       resetSettings();
-      resetIsCreating();
+      resetMode();
       setIsManageProfileSettingsShowProfiles(false);
       setIsManageProfileSettingsShowEditor(true);
     }

--- a/src/features/manageProfileSettings/hooks/useSaveProfileSettings.test.tsx
+++ b/src/features/manageProfileSettings/hooks/useSaveProfileSettings.test.tsx
@@ -11,6 +11,7 @@ import {
   savePreferredProfileSettings,
   saveProfileSettings,
 } from '@/common/api/profiles.api';
+import { ProfileSettingsMode } from '@/common/constants/profileSettings.constants';
 import { StatusType } from '@/common/constants/status.constants';
 import { UserNotificationFactory } from '@/common/services/userNotification';
 
@@ -55,6 +56,45 @@ describe('useSaveProfileSettings', () => {
 
     afterEach(() => {
       jest.resetAllMocks();
+    });
+
+    it('only saves preferred profile when in settings editor is in landing mode', async () => {
+      setInitialGlobalState([
+        {
+          store: useProfileState,
+          state: {
+            preferredProfiles: [],
+          },
+        },
+        {
+          store: useManageProfileSettingsState,
+          state: {
+            selectedProfile: {
+              id: 'another',
+              name: 'another',
+              resourceType: 'for-type',
+            },
+            isTypeDefaultProfile: true,
+            mode: ProfileSettingsMode.Landing,
+          },
+        },
+        {
+          store: useStatusState,
+          state: {
+            addStatusMessagesItem: mockAddStatusMessagesItem,
+          },
+        },
+      ]);
+
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useSaveProfileSettings(), { wrapper });
+      await act(async () => {
+        await result.current.saveSettings();
+      });
+
+      expect(savePreferredProfile).toHaveBeenCalled();
+      expect(saveProfileSettings).not.toHaveBeenCalled();
+      expect(createProfileSettings).not.toHaveBeenCalled();
     });
 
     it('shows an error when saving preferred profile fails', async () => {
@@ -117,6 +157,7 @@ describe('useSaveProfileSettings', () => {
               resourceType: 'for-type',
             },
             isTypeDefaultProfile: true,
+            mode: ProfileSettingsMode.Editing,
           },
         },
         {
@@ -156,6 +197,7 @@ describe('useSaveProfileSettings', () => {
               resourceType: 'for-type',
             },
             isTypeDefaultProfile: true,
+            mode: ProfileSettingsMode.Creating,
           },
         },
         {
@@ -199,6 +241,7 @@ describe('useSaveProfileSettings', () => {
               resourceType: 'for-type',
             },
             isTypeDefaultProfile: true,
+            mode: ProfileSettingsMode.Creating,
           },
         },
         {
@@ -239,7 +282,7 @@ describe('useSaveProfileSettings', () => {
               resourceType: 'for-type',
             },
             isTypeDefaultProfile: true,
-            isCreating: false,
+            mode: ProfileSettingsMode.Editing,
             selectedProfileSettingsMeta: {
               id: 'thing',
               name: 'settings-thing',
@@ -280,7 +323,7 @@ describe('useSaveProfileSettings', () => {
               resourceType: 'for-type',
             },
             isTypeDefaultProfile: true,
-            isCreating: false,
+            mode: ProfileSettingsMode.Editing,
             isPreferredProfileSettings: true,
             selectedProfileSettingsMeta: {
               id: 44,

--- a/src/features/manageProfileSettings/hooks/useSaveProfileSettings.ts
+++ b/src/features/manageProfileSettings/hooks/useSaveProfileSettings.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import { createProfileSettings, saveProfileSettings } from '@/common/api/profiles.api';
 import { ApiErrorCodes } from '@/common/constants/api.constants';
+import { ProfileSettingsMode } from '@/common/constants/profileSettings.constants';
 import { StatusType } from '@/common/constants/status.constants';
 import { checkHasErrorOfCodeType } from '@/common/helpers/api.helper';
 import { logger } from '@/common/services/logger';
@@ -19,7 +20,7 @@ export const useSaveProfileSettings = () => {
   const { setIsLoading } = useLoadingState(['setIsLoading']);
   const { addStatusMessagesItem } = useStatusState(['addStatusMessagesItem']);
   const {
-    isCreating,
+    mode,
     isPreferredProfileSettings,
     isSettingsActive,
     isTypeDefaultProfile,
@@ -28,12 +29,12 @@ export const useSaveProfileSettings = () => {
     unusedComponents,
     selectedComponents,
     settingsName,
-    setIsCreating,
+    setMode,
     setIsModified,
     setProfileSettings,
     setSelectedProfileSettingsMeta,
   } = useManageProfileSettingsState([
-    'isCreating',
+    'mode',
     'isPreferredProfileSettings',
     'isSettingsActive',
     'isTypeDefaultProfile',
@@ -42,7 +43,7 @@ export const useSaveProfileSettings = () => {
     'unusedComponents',
     'selectedComponents',
     'settingsName',
-    'setIsCreating',
+    'setMode',
     'setIsModified',
     'setProfileSettings',
     'setSelectedProfileSettingsMeta',
@@ -76,12 +77,12 @@ export const useSaveProfileSettings = () => {
     let settingsMeta: ProfileSettingsMeta;
 
     try {
-      if (!isCreating && selectedProfileSettingsMeta) {
+      if (mode === ProfileSettingsMode.Editing && selectedProfileSettingsMeta) {
         settingsMeta = selectedProfileSettingsMeta;
         await saveProfileSettings(selectedProfile.id, settingsMeta.id, settingsToSave);
       } else {
         settingsMeta = await createProfileSettings(selectedProfile.id, settingsToSave);
-        setIsCreating(false);
+        setMode(ProfileSettingsMode.Editing);
       }
       setProfileSettings({ ...settingsToSave, missingFromSettings: [], id: settingsMeta.id });
       queryClient.refetchQueries({ queryKey: ['profileSettingsMeta', String(selectedProfile.id)] });
@@ -122,8 +123,10 @@ export const useSaveProfileSettings = () => {
     try {
       setIsLoading(true);
       await saveAndSetPreferred();
-      const settingsMeta = await saveAndSetSettings();
-      await saveAndSetPreferredProfileSetting(settingsMeta);
+      if (mode === ProfileSettingsMode.Creating || mode === ProfileSettingsMode.Editing) {
+        const settingsMeta = await saveAndSetSettings();
+        await saveAndSetPreferredProfileSetting(settingsMeta);
+      }
       setIsModified(false);
     } finally {
       setIsLoading(false);

--- a/src/store/stores/manageProfileSettings.ts
+++ b/src/store/stores/manageProfileSettings.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_INACTIVE_SETTINGS } from '@/common/constants/profileSettings.constants';
+import { DEFAULT_INACTIVE_SETTINGS, ProfileSettingsMode } from '@/common/constants/profileSettings.constants';
 
 import { type SliceConfigs, createStoreFactory } from '../utils/createStoreFactory';
 import { type SliceState } from '../utils/slice';
@@ -23,7 +23,7 @@ export type ManageProfileSettingsState = SliceState<'selectedProfile', ProfileDT
   SliceState<'isPreferredProfileSettings', boolean> &
   SliceState<'isModified', boolean> &
   SliceState<'settingsName', string> &
-  SliceState<'isCreating', boolean>;
+  SliceState<'mode', ProfileSettingsMode>;
 
 const STORE_NAME = 'ProfileSettings';
 
@@ -76,8 +76,8 @@ const sliceConfigs: SliceConfigs = {
   settingsName: {
     initialValue: '',
   },
-  isCreating: {
-    initialValue: true,
+  mode: {
+    initialValue: ProfileSettingsMode.Landing,
   },
 };
 

--- a/src/views/ManageProfileSettings/ManageProfileSettings.test.tsx
+++ b/src/views/ManageProfileSettings/ManageProfileSettings.test.tsx
@@ -121,6 +121,12 @@ describe('ManageProfileSettings', () => {
         expect(screen.getByTestId('profile-settings')).toBeInTheDocument();
       });
 
+      fireEvent.click(screen.getByTestId('profile-settings-select-create'));
+
+      waitFor(() => {
+        expect(screen.getByTestId('component-test:childC')).toBeInTheDocument();
+      });
+
       const component = screen.getByTestId('component-test:childC');
       const nudgeUpButton = within(component).getByTestId('nudge-up');
 
@@ -141,6 +147,12 @@ describe('ManageProfileSettings', () => {
 
       waitFor(() => {
         expect(screen.getByTestId('profile-settings')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('profile-settings-select-create'));
+
+      waitFor(() => {
+        expect(screen.getByTestId('component-test:childA')).toBeInTheDocument();
       });
 
       const component = screen.getByTestId('component-test:childA');
@@ -167,6 +179,12 @@ describe('ManageProfileSettings', () => {
 
       waitFor(() => {
         expect(screen.getByTestId('profile-settings')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('profile-settings-select-create'));
+
+      waitFor(() => {
+        expect(screen.getByTestId('component-test:childB')).toBeInTheDocument();
       });
 
       const component = screen.getByTestId('component-test:childB');
@@ -197,6 +215,12 @@ describe('ManageProfileSettings', () => {
         expect(screen.getByTestId('profile-settings')).toBeInTheDocument();
       });
 
+      fireEvent.click(screen.getByTestId('profile-settings-select-create'));
+
+      waitFor(() => {
+        expect(screen.getByTestId('component-test:childC')).toBeInTheDocument();
+      });
+
       const component = screen.getByTestId('component-test:childC');
       const menuButton = within(component).getByTestId('activate-menu');
 
@@ -219,6 +243,12 @@ describe('ManageProfileSettings', () => {
 
       waitFor(() => {
         expect(screen.getByTestId('profile-settings')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('profile-settings-select-create'));
+
+      waitFor(() => {
+        expect(screen.getByTestId('component-test:childC')).toBeInTheDocument();
       });
 
       // nudge
@@ -253,11 +283,15 @@ describe('ManageProfileSettings', () => {
 
   describe('modals', () => {
     it('shows a modal when changing profiles with unsaved changes', () => {
-      // deselect a component
       fireEvent.click(screen.getAllByTestId('resource-profile-item')[0]);
 
       waitFor(() => {
         expect(screen.getByTestId('profile-settings')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('profile-settings-select-create'));
+
+      waitFor(() => {
         expect(screen.getByTestId('component-test:childB')).toBeInTheDocument();
       });
 

--- a/translations/ui-linked-data/en.json
+++ b/translations/ui-linked-data/en.json
@@ -371,6 +371,8 @@
   "ld.profileSettings.creatingSettingsName": "Creating new profile settings with name",
   "ld.profileSettings.editingSettingsName": "Editing profile settings with name",
   "ld.profileSettings.resetComponents": "Reset components",
+  "ld.profileSettings.createNewSettings": "Create new settings",
+  "ld.profileSettings.editorLanding": "Create new profile settings with 'Create new settings,' or select saved profile settings from the list to edit.",
   "ld.importHub.header.title": "Import hub - {title}",
   "ld.importHub.fetchingFromUri": "Fetching hub from {uri}...",
   "ld.profileSettings.announce.instructions": "To pick up a component, press space or enter.  While dragging, use the arrow keys to move the component either up and down within each list or left and right to the other list. Press space or enter again to drop the component in its new position, or press escape to cancel.",


### PR DESCRIPTION
## Purpose

The previously implemented user experience proved to be too confusing during basic QA, so an explanatory screen was added to better explain the available options.

## Approach

- A modified, enumerated mechanism for determining which mode is in use replaces a basic boolean used previously.
- Also address an issue with changes to the global store occurring during other changes to the global store by adding cancellation to the appropriate `useEffect`.
- Also fix a context menu not being dismiss-able due to lack of a focusable element by providing a more reliable ref.

## Refs

https://folio-org.atlassian.net/browse/UILD-780

## Screenshots

<img width="1149" height="630" alt="Screenshot 2026-07-20 at 16 53 57" src="https://github.com/user-attachments/assets/889c5daa-37d1-47c6-9b23-332158e217aa" />

