### PR TITLE
UILD-780: Adjust landing message display width

### DIFF
--- a/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.scss
+++ b/src/features/manageProfileSettings/components/ProfileSettingsEditor/ProfileSettingsEditor.scss
@@ -4,7 +4,7 @@
   padding: 25px 20%;
   text-align: center;
   font-size: 120%;
-  max-width: 460px;
+  max-width: 915px;
 }
 
 .components-editor-wrapper {


### PR DESCRIPTION
## Purpose

Adjust message display width, too narrow when rendered in FOLIO.

## Approach

Modify CSS.

## Refs

https://folio-org.atlassian.net/browse/UILD-780
